### PR TITLE
fix(subagent): validate job id in StatusFor to prevent jobs-dir path traversal

### DIFF
--- a/internal/ids/validate.go
+++ b/internal/ids/validate.go
@@ -19,6 +19,10 @@ var ErrInvalidTeamName = errors.New("invalid team name")
 // ErrInvalidMemberName is the member-name analogue of ErrInvalidTeamName.
 var ErrInvalidMemberName = errors.New("invalid member name")
 
+// ErrInvalidJobID is returned by ValidateJobID for a subagent job id that fails
+// the path-safety rules. Use errors.Is for dispatch.
+var ErrInvalidJobID = errors.New("invalid job id")
+
 // maxIDLen caps identifier length: a defense-in-depth guard against
 // pathologically long argv tokens / paths, not a tmux/fs limit.
 const maxIDLen = 128
@@ -53,6 +57,17 @@ func ValidateTeamName(s string) error {
 func ValidateMemberName(s string) error {
 	if err := validateID(s); err != nil {
 		return fmt.Errorf("%w %q: %s", ErrInvalidMemberName, s, err.Error())
+	}
+	return nil
+}
+
+// ValidateJobID is the same rule set as ValidateTeamName, used for subagent job
+// ids (always a uuid.NewString() in practice) that flow into the jobs-dir path
+// via filepath.Join. It guards the subagent-status entry point against reading
+// outside the jobs directory. Returns ErrInvalidJobID on failure.
+func ValidateJobID(s string) error {
+	if err := validateID(s); err != nil {
+		return fmt.Errorf("%w %q: %s", ErrInvalidJobID, s, err.Error())
 	}
 	return nil
 }

--- a/internal/ids/validate_test.go
+++ b/internal/ids/validate_test.go
@@ -150,3 +150,28 @@ func TestValidateID_RejectsWhitespace(t *testing.T) {
 		t.Errorf("ValidateTeamName(%q) = %v, want nil", "worker-1", err)
 	}
 }
+
+// TestValidateJobID_RejectsPathTraversal: a subagent job id flows into the
+// jobs-dir path via filepath.Join, so every traversal form must fail (wrapping
+// ErrInvalidJobID so the subagent-status entry point can dispatch on it).
+func TestValidateJobID_RejectsPathTraversal(t *testing.T) {
+	for _, in := range []string{"", ".", "..", "../..", "../../etc/passwd", "a/b", `c\d`, "/abs", "./x", "x/..", "a\x00b", strings.Repeat("x", maxIDLen+1)} {
+		err := ValidateJobID(in)
+		if err == nil {
+			t.Fatalf("ValidateJobID(%q): want error, got nil", in)
+		}
+		if !errors.Is(err, ErrInvalidJobID) {
+			t.Fatalf("ValidateJobID(%q): err=%v, want ErrInvalidJobID", in, err)
+		}
+	}
+}
+
+// TestValidateJobID_AcceptsUUID: the only job ids cc-fleet ever generates are
+// uuid.NewString() values, which must keep passing.
+func TestValidateJobID_AcceptsUUID(t *testing.T) {
+	for _, in := range []string{"550e8400-e29b-41d4-a716-446655440000", "00000000-0000-0000-0000-000000000000"} {
+		if err := ValidateJobID(in); err != nil {
+			t.Errorf("ValidateJobID(%q): unexpected error %v", in, err)
+		}
+	}
+}

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/procintrospect"
 )
 
@@ -272,6 +273,12 @@ var killProcessGroup = func(pid int) {
 // SAME classifier as the sync path, caches the terminal Result to
 // <id>.result.json, and returns done/failed.
 func StatusFor(jobID string) Result {
+	// jobID flows straight into filepath.Join below; validate it before any
+	// path is built so a "../" arg can't read outside the jobs dir.
+	if err := ids.ValidateJobID(jobID); err != nil {
+		return fail(ErrCodeBadArgs, fmt.Sprintf("invalid job id %q", jobID), "",
+			"Check the job_id printed by the --background launch")
+	}
 	dir, err := jobsDir()
 	if err != nil {
 		return fail(ErrCodeFailed, fmt.Sprintf("resolve jobs dir: %v", err), "", "")

--- a/internal/subagent/statusfor_validate_test.go
+++ b/internal/subagent/statusfor_validate_test.go
@@ -1,0 +1,54 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStatusFor_RejectsPathTraversal: a "../"-style job id must be rejected with
+// the SUBAGENT_BAD_ARGS envelope BEFORE any path is built, so subagent-status
+// can't be used to read a file outside the jobs directory.
+func TestStatusFor_RejectsPathTraversal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	// Plant a file one level above the jobs dir; a successful traversal would
+	// read it. The guard must make this unreachable.
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	secret := filepath.Join(xdg, "cc-fleet", "secret.json")
+	if err := os.MkdirAll(filepath.Dir(secret), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secret, []byte(`{"k":"v"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, in := range []string{"../secret", "../../etc/passwd", "a/b", "/abs", ".."} {
+		res := StatusFor(in)
+		if res.OK {
+			t.Fatalf("StatusFor(%q): OK=true, want rejection", in)
+		}
+		if res.ErrorCode != ErrCodeBadArgs {
+			t.Fatalf("StatusFor(%q): ErrorCode=%q, want %q", in, res.ErrorCode, ErrCodeBadArgs)
+		}
+	}
+}
+
+// TestStatusFor_AcceptsUUIDShape: a well-formed (but unknown) job id passes the
+// id guard and reaches the normal "unknown job" path — i.e. the guard doesn't
+// reject legitimate uuid.NewString() values.
+func TestStatusFor_AcceptsUUIDShape(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	res := StatusFor("550e8400-e29b-41d4-a716-446655440000")
+	if res.OK {
+		t.Fatalf("StatusFor(unknown uuid): OK=true, want not-found")
+	}
+	// It must fail as "unknown job" (bad args, post-validation), not be silently
+	// accepted; the point is the id-shape guard let it through to the lookup.
+	if res.ErrorCode != ErrCodeBadArgs {
+		t.Fatalf("StatusFor(unknown uuid): ErrorCode=%q, want %q", res.ErrorCode, ErrCodeBadArgs)
+	}
+}


### PR DESCRIPTION
## Problem

`cc-fleet subagent-status <job_id>` forwarded its argument verbatim into `filepath.Join(dir, jobID+".json")` (via `StatusFor` → `readMeta`) with no validation, so `subagent-status '../../../../etc/foo'` read files outside the jobs directory.

## Fix

Add `ids.ValidateJobID` (reusing the existing `validateID` rule body) and call it as the first statement in `StatusFor`, before any path is built — returning a `SUBAGENT_BAD_ARGS` envelope on failure. `StatusFor` is the chokepoint every reader goes through (CLI, TUI `ListJobs`, future callers), and real `uuid.NewString()` ids pass unchanged. Aligns `subagent-status` with the centralized path-safety boundary `internal/ids` already enforces elsewhere.

## Tests

`ValidateJobID` rejects every traversal form / accepts uuids; `StatusFor` returns `SUBAGENT_BAD_ARGS` for traversal args (with a planted file above the jobs dir proven unreachable). `go build`, `go vet`, `gofmt -l`, `go test -race ./...` pass.

Fixes #7.
