### PR TITLE
feat(tui): filter the model picker by typed keyword

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -93,10 +93,12 @@ type Model struct {
 
 	// Model picker: models fetched from the vendor's models_endpoint to fill the
 	// default_model field. While loading, modelList is nil and modelsErr is nil;
-	// the picker view branches on those.
+	// the picker view branches on those. modelFilter is the live type-to-narrow
+	// query; modelCursor indexes the FILTERED list, not modelList.
 	modelList   []models.Model
 	modelCursor int
 	modelsErr   error
+	modelFilter string
 
 	// Remove confirmation target.
 	removeName string
@@ -834,6 +836,7 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.modelList = nil
 		m.modelsErr = nil
 		m.modelCursor = 0
+		m.modelFilter = ""
 		return m, fetchModelsCmd(m.formMode, m.editName,
 			m.form.value("models_endpoint"), m.form.value("api_key"))
 	}
@@ -852,28 +855,59 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // updateModelPick drives the model picker. Enter accepts the highlighted model
 // id into the form's default_model field; esc (or an empty / failed fetch)
 // returns to the form so the user can type the id manually — the required
-// fallback when the vendor list is unavailable.
+// fallback when the vendor list is unavailable. Printable input narrows the
+// list (type-to-filter), so vim j/k no longer navigate — letters are filter
+// input and the arrow keys move the cursor.
 func (m Model) updateModelPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	filtered := m.filteredModels()
 	switch msg.String() {
 	case "esc":
 		m.screen = screenForm
 		return m, textinput.Blink
-	case "up", "k":
-		if m.modelCursor > 0 {
-			m.modelCursor--
-		}
-	case "down", "j":
-		if m.modelCursor < len(m.modelList)-1 {
-			m.modelCursor++
-		}
 	case "enter":
-		if len(m.modelList) > 0 {
-			m.form.setValue("default_model", m.modelList[m.modelCursor].ID)
+		if len(filtered) > 0 {
+			m.form.setValue("default_model", filtered[m.modelCursor].ID)
 		}
 		m.screen = screenForm
 		return m, textinput.Blink
+	case "up":
+		if m.modelCursor > 0 {
+			m.modelCursor--
+		}
+	case "down":
+		if m.modelCursor < len(filtered)-1 {
+			m.modelCursor++
+		}
+	case "backspace", "ctrl+h": // some terminals report Backspace as Ctrl-H
+		if m.modelFilter != "" {
+			r := []rune(m.modelFilter)
+			m.modelFilter = string(r[:len(r)-1])
+			m.modelCursor = 0
+		}
+	default:
+		if msg.Type == tea.KeyRunes && len(m.modelList) > 0 {
+			m.modelFilter += string(msg.Runes)
+			m.modelCursor = 0
+		}
 	}
 	return m, nil
+}
+
+// filteredModels returns the models whose id contains modelFilter
+// (case-insensitive substring — covers prefix, suffix, and infix). An empty
+// filter returns the full list. modelCursor indexes into this result.
+func (m Model) filteredModels() []models.Model {
+	if m.modelFilter == "" {
+		return m.modelList
+	}
+	q := strings.ToLower(m.modelFilter)
+	var out []models.Model
+	for _, mod := range m.modelList {
+		if strings.Contains(strings.ToLower(mod.ID), q) {
+			out = append(out, mod)
+		}
+	}
+	return out
 }
 
 func (m Model) updateRemoveConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -515,6 +515,92 @@ func TestModelPickerSkippedWhenNoEndpoint(t *testing.T) {
 	}
 }
 
+// pickerWith opens the model picker on the add form and loads the given models.
+func pickerWith(t *testing.T, ids ...string) Model {
+	t.Helper()
+	m := focusDefaultModel(t, addFormOnDeepseek(t))
+	m, _ = press(t, m, "enter") // open picker (loading)
+	list := make([]models.Model, len(ids))
+	for i, id := range ids {
+		list[i] = models.Model{ID: id, OwnedBy: "deepseek"}
+	}
+	m, _ = step(t, m, modelsMsg{models: list})
+	return m
+}
+
+func TestModelPickerFiltersByKeyword(t *testing.T) {
+	m := pickerWith(t, "deepseek-chat", "deepseek-reasoner", "deepseek-coder")
+	for _, r := range "reason" { // narrows to the single reasoner id
+		m, _ = press(t, m, string(r))
+	}
+	if got := m.filteredModels(); len(got) != 1 || got[0].ID != "deepseek-reasoner" {
+		t.Fatalf("filter %q → %+v, want [deepseek-reasoner]", m.modelFilter, got)
+	}
+	if m.modelCursor != 0 {
+		t.Fatalf("modelCursor = %d, want 0 (reset on filter)", m.modelCursor)
+	}
+	if out := m.View(); !strings.Contains(out, "deepseek-reasoner") || strings.Contains(out, "deepseek-coder") {
+		t.Fatalf("filtered view should show only the match, got %q", out)
+	}
+	m, _ = press(t, m, "enter")
+	if got := m.form.value("default_model"); got != "deepseek-reasoner" {
+		t.Fatalf("default_model = %q, want deepseek-reasoner", got)
+	}
+}
+
+func TestModelPickerFilterNoMatchDoesNotPick(t *testing.T) {
+	m := pickerWith(t, "deepseek-chat", "deepseek-reasoner")
+	for _, r := range "zzz" {
+		m, _ = press(t, m, string(r))
+	}
+	if got := m.filteredModels(); len(got) != 0 {
+		t.Fatalf("no-match filter → %+v, want empty", got)
+	}
+	if out := m.View(); !strings.Contains(out, "no model matches") {
+		t.Fatalf("no-match view should say so, got %q", out)
+	}
+	before := m.form.value("default_model")
+	m, _ = press(t, m, "enter") // must not silently pick the first item
+	if got := m.form.value("default_model"); got != before {
+		t.Fatalf("no-match enter changed default_model %q → %q", before, got)
+	}
+	if m.screen != screenForm {
+		t.Fatalf("enter returns to form; screen = %d, want screenForm", m.screen)
+	}
+}
+
+func TestModelPickerFilterBackspaceWidens(t *testing.T) {
+	m := pickerWith(t, "glm-4.5", "glm-4.5-air", "deepseek-chat")
+	for _, r := range "glm" {
+		m, _ = press(t, m, string(r))
+	}
+	if got := len(m.filteredModels()); got != 2 {
+		t.Fatalf("filter glm → %d, want 2", got)
+	}
+	m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlH}) // terminals that report Backspace as Ctrl-H
+	m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
+	m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.modelFilter != "" {
+		t.Fatalf("modelFilter = %q, want empty after backspacing past the start", m.modelFilter)
+	}
+	if got := len(m.filteredModels()); got != 3 {
+		t.Fatalf("empty filter → %d, want the full 3", got)
+	}
+}
+
+func TestModelPickerFilterResetsOnReopen(t *testing.T) {
+	m := pickerWith(t, "deepseek-chat")
+	m, _ = press(t, m, "c")
+	if m.modelFilter == "" {
+		t.Fatal("filter should be set after typing")
+	}
+	m, _ = press(t, m, "esc")   // back to the form (focus stays on default_model)
+	m, _ = press(t, m, "enter") // reopen the picker
+	if m.modelFilter != "" {
+		t.Fatalf("reopened picker: modelFilter = %q, want reset", m.modelFilter)
+	}
+}
+
 // boardModel enters the agent-status board with the given teammates + jobs
 // already loaded (screen=screenSpawn, boardEpoch=1, loading=false).
 func boardModel(t *testing.T, tms []teardown.Teammate, jobs []subagent.Result) Model {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -545,12 +545,24 @@ func (m Model) viewModelPick() string {
 		b.WriteString(faintStyle.Render("vendor returned no models") + "\n")
 		b.WriteString(faintStyle.Render("press esc to type the model id manually") + "\n")
 	default:
-		start, end := windowBounds(m.modelCursor, len(m.modelList), maxVisibleModels)
+		filtered := m.filteredModels()
+		total := len(m.modelList)
+		if m.modelFilter == "" {
+			b.WriteString(faintStyle.Render(fmt.Sprintf("filter: type to narrow %d models", total)) + "\n\n")
+		} else {
+			b.WriteString("filter: " + m.modelFilter +
+				faintStyle.Render(fmt.Sprintf("  (%d/%d)", len(filtered), total)) + "\n\n")
+		}
+		if len(filtered) == 0 {
+			b.WriteString(faintStyle.Render("no model matches — backspace to widen, esc to type manually") + "\n")
+			break
+		}
+		start, end := windowBounds(m.modelCursor, len(filtered), maxVisibleModels)
 		if start > 0 {
 			b.WriteString(faintStyle.Render(fmt.Sprintf("    ↑ %d more", start)) + "\n")
 		}
 		for i := start; i < end; i++ {
-			mod := m.modelList[i]
+			mod := filtered[i]
 			cursor := "  "
 			id := mod.ID
 			if i == m.modelCursor {
@@ -562,11 +574,11 @@ func (m Model) viewModelPick() string {
 				b.WriteString(faintStyle.Render("    "+mod.OwnedBy) + "\n")
 			}
 		}
-		if end < len(m.modelList) {
-			b.WriteString(faintStyle.Render(fmt.Sprintf("    ↓ %d more", len(m.modelList)-end)) + "\n")
+		if end < len(filtered) {
+			b.WriteString(faintStyle.Render(fmt.Sprintf("    ↓ %d more", len(filtered)-end)) + "\n")
 		}
 	}
-	b.WriteString("\n" + footer("↑/↓ move · enter pick · esc manual entry"))
+	b.WriteString("\n" + footer("type to filter · ↑/↓ move · enter pick · esc manual entry"))
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary

Type-to-filter the vendor default-model picker in the TUI — with many models returned from `models_endpoint`, scrolling a flat list to the target was slow.

## Type of change

- [x] New feature

## Related issue

Closes #12

## Screenshots / recording

<img width="860" height="248" alt="Image" src="https://github.com/user-attachments/assets/01d86648-5880-492b-af6b-1f1949b815dd" />

## Checklist

- [x] `go test -race ./...` passes
- [x] `gofmt -l .` prints nothing and `go vet ./...` is clean
- [x] `make build` compiles
- [ ] If plugin/skill touched: `claude plugin validate . --strict` is green — n/a, no plugin/skill change
- [x] Commits follow Conventional Commits; AI-assisted commits carry a `Co-Authored-By` trailer

Behavior: type to filter (case-insensitive substring on the model id) · arrows move · enter picks · backspace/ctrl+h widen · empty filter shows all · no match shows an explicit empty state instead of a silent first-item pick. Vim j/k now feeds the filter. Pure TUI change — no spawn / tmux / lock / network path touched.
