### PR TITLE
fix(teardown): reap swarm server and processes when team config fails to parse

### DIFF
--- a/internal/teardown/discover.go
+++ b/internal/teardown/discover.go
@@ -296,6 +296,51 @@ func discoverTeammatePIDs(agentID string) []int {
 	return pids
 }
 
+// cmdlineTeamName returns the value following --team-name in argv, or "" if
+// absent. Matching on this explicit token (rather than splitting the
+// <name>@<team> agent id) is unambiguous: team and member names may contain '@'.
+func cmdlineTeamName(argv []string) string {
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] == "--team-name" {
+			return argv[i+1]
+		}
+	}
+	return ""
+}
+
+// discoverTeamAgentIDsFn is a test seam over discoverTeamAgentIDs so the
+// parse-fail teardown path can be exercised without faking the process table.
+var discoverTeamAgentIDsFn = discoverTeamAgentIDs
+
+// discoverTeamAgentIDs scans the process table for live teammate processes in
+// team, returning their distinct agent ids. The config-free counterpart to
+// discoverTeammatePIDs: used when a team's config can't be parsed, so ghosts
+// still get reaped by team name.
+func discoverTeamAgentIDs(team string) []string {
+	if team == "" {
+		return nil
+	}
+	procs, err := procintrospect.ProcessTable()
+	if err != nil {
+		return nil
+	}
+	self := os.Getpid()
+	seen := map[string]struct{}{}
+	var ids []string
+	for _, p := range procs {
+		if p.PID == self || !cmdlineLooksLikeTeammate(p.Argv) || cmdlineTeamName(p.Argv) != team {
+			continue
+		}
+		if id := cmdlineAgentID(p.Argv); id != "" {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
+}
+
 // parseTeammateCmdline extracts the structured Teammate fields from a /proc
 // cmdline argv slice. Missing fields are left empty rather than erroring —
 // ps's job is to display what's there.

--- a/internal/teardown/discover_test.go
+++ b/internal/teardown/discover_test.go
@@ -282,6 +282,40 @@ func TestCmdlineAgentID(t *testing.T) {
 	}
 }
 
+// TestCmdlineTeamName covers the unambiguous --team-name match used by the
+// parse-fail teardown reap: it must read the explicit token, not split the
+// <name>@<team> agent id (team names may contain '@'), and must not confuse
+// "alpha" with "beta-alpha".
+func TestCmdlineTeamName(t *testing.T) {
+	cases := []struct {
+		argv []string
+		want string
+	}{
+		{argvOf("/path/claude --agent-id alice@alpha --team-name alpha"), "alpha"},
+		{argvOf("/path/claude --agent-id w@alpha@prod --team-name alpha@prod"), "alpha@prod"},
+		{argvOf("/path/claude --agent-id x@beta-alpha --team-name beta-alpha"), "beta-alpha"},
+		{argvOf("/path/claude --agent-id solo"), ""}, // no --team-name
+		{argvOf("claude --team-name"), ""},           // flag present but no value
+		{nil, ""},
+	}
+	for _, tc := range cases {
+		if got := cmdlineTeamName(tc.argv); got != tc.want {
+			t.Errorf("cmdlineTeamName(%v) = %q, want %q", tc.argv, got, tc.want)
+		}
+	}
+}
+
+// TestDiscoverTeamAgentIDs_EmptySafe: an empty team matches nothing, and a real
+// (unfaked) /proc scan for a unique team returns no ids and never our own work.
+func TestDiscoverTeamAgentIDs_EmptySafe(t *testing.T) {
+	if got := discoverTeamAgentIDs(""); got != nil {
+		t.Fatalf("discoverTeamAgentIDs(\"\") = %v, want nil", got)
+	}
+	if got := discoverTeamAgentIDs("no-such-team-9999"); len(got) != 0 {
+		t.Fatalf("discoverTeamAgentIDs(unique) = %v, want empty", got)
+	}
+}
+
 // TestDiscoverTeammatePIDs_EmptyAndSelfSafe exercises the real /proc scan
 // (no fake) for safety properties only: an empty id matches nothing, a unique
 // fake id matches no live process, and the scan never panics nor returns our

--- a/internal/teardown/teardown.go
+++ b/internal/teardown/teardown.go
@@ -201,11 +201,18 @@ func TeardownTeam(team string) Result {
 				}
 			}
 		} else if loadErr != nil && !errors.Is(loadErr, spawn.ErrTeamNotFound) {
-			// A real load error (parse failure, permission) — record as a
-			// warning but proceed to RemoveAll: removing a broken team
-			// directory is usually exactly what the user wants.
+			// Config is unreadable, so we have no pane ids — but the swarm
+			// socket name is derivable from the team name and ghost processes
+			// carry <name>@<team>. Reap both before RemoveAll deletes the only
+			// record, or they leak with no way left to find them.
 			res.Warnings = append(res.Warnings,
 				fmt.Sprintf("load team config: %v", loadErr))
+			sock := spawn.SwarmSocketName(team)
+			if err := tmux.NewServer(sock).KillServer(); err != nil {
+				res.Warnings = append(res.Warnings,
+					fmt.Sprintf("kill swarm server %s: %v", sock, err))
+			}
+			reapIDs = append(reapIDs, discoverTeamAgentIDsFn(team)...)
 		}
 
 		// Remove the entire team dir. This is the failure path that matters:

--- a/internal/teardown/teardown_parsefail_test.go
+++ b/internal/teardown/teardown_parsefail_test.go
@@ -1,0 +1,101 @@
+package teardown
+
+import (
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/spawn"
+)
+
+// TestTeardownTeam_ParseFailureStillKillsSwarmServer: when a team's config can't
+// be parsed, teardown can't read pane ids — but it must still kill the swarm
+// server (derivable from the team name) before RemoveAll deletes the only
+// record, otherwise the panes/processes leak with nothing left to target them.
+func TestTeardownTeam_ParseFailureStillKillsSwarmServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	argsPath := installFakeTmux(t)
+	installReapHarness(t)
+
+	// Seed a real team dir, then corrupt config.json so LoadTeamConfig fails.
+	dir := seedTeam(t, "brokt", []spawn.Member{
+		{Name: "w1", AgentID: "w1@brokt", TmuxPaneID: "%0", AgentType: "general-purpose"},
+	})
+	cfgPath, _ := spawn.TeamConfigPath("brokt")
+	if err := os.WriteFile(cfgPath, []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("corrupt config: %v", err)
+	}
+
+	res := TeardownTeam("brokt")
+	if !res.OK {
+		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
+	}
+	if !res.TeamRemoved {
+		t.Fatal("TeamRemoved should be true even on a corrupt config")
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("team dir still exists: %v", err)
+	}
+
+	calls := readFakeTmuxCalls(t, argsPath)
+	want := []string{"-L", "cc-fleet-swarm-brokt", "kill-server"}
+	if !containsCall(calls, want) {
+		t.Fatalf("missing config-free kill-server on the deterministic swarm socket; calls=%v", calls)
+	}
+
+	var sawLoadWarning bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "load team config") {
+			sawLoadWarning = true
+		}
+	}
+	if !sawLoadWarning {
+		t.Fatalf("expected a load-team-config warning; warnings=%v", res.Warnings)
+	}
+}
+
+// TestTeardownTeam_ParseFailureReapsGhostProcess: on a corrupt config, a ghost
+// process discovered by team name (config-free) must be reaped before the dir
+// is removed, so it can't be orphaned with no record left to find it.
+func TestTeardownTeam_ParseFailureReapsGhostProcess(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	installFakeTmux(t)
+	h := installReapHarness(t)
+
+	// The discovery seam stands in for the /proc scan: pretend one teammate of
+	// this team is still live, with a known pid for the reap harness to "kill".
+	const ghostID, ghostPID = "w1@brokt", 4242
+	orig := discoverTeamAgentIDsFn
+	t.Cleanup(func() { discoverTeamAgentIDsFn = orig })
+	discoverTeamAgentIDsFn = func(team string) []string {
+		if team == "brokt" {
+			return []string{ghostID}
+		}
+		return nil
+	}
+	h.pids[ghostID] = []int{ghostPID}
+
+	seedTeam(t, "brokt", []spawn.Member{{Name: "w1", AgentID: ghostID, AgentType: "general-purpose"}})
+	cfgPath, _ := spawn.TeamConfigPath("brokt")
+	if err := os.WriteFile(cfgPath, []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("corrupt config: %v", err)
+	}
+
+	res := TeardownTeam("brokt")
+	if !res.OK {
+		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
+	}
+	var reaped bool
+	for _, p := range res.KilledPIDs {
+		if p == ghostPID {
+			reaped = true
+		}
+	}
+	if !reaped {
+		t.Fatalf("ghost pid %d not reaped; KilledPIDs=%v", ghostPID, res.KilledPIDs)
+	}
+	if sigs := h.sigs(ghostPID); len(sigs) == 0 || sigs[0] != syscall.SIGTERM {
+		t.Fatalf("ghost pid %d: signals=%v, want SIGTERM first", ghostPID, sigs)
+	}
+}


### PR DESCRIPTION
## Problem

When a team's `config.json` fails to parse, `TeardownTeam` skipped all pane-kill / process-reap work (those run only in the `loadErr == nil` branch) but still ran `os.RemoveAll(dir)` unconditionally. The live swarm tmux server and vendor processes were left running, and the directory — the only record of their ids — was deleted, so cc-fleet could no longer find or tear them down.

## Fix

On the parse-error path, before `RemoveAll`, do a config-free best-effort cleanup: kill the swarm server via the deterministic `spawn.SwarmSocketName(team)` (idempotent, no pane ids needed), and reap processes matched by the explicit `--team-name` token in their argv (new `discoverTeamAgentIDs`, reusing the existing `reapTeammateProcess` path outside the lock). Both the socket name and the team match are derivable from the team name alone, so cleanup no longer depends on the unreadable config.

Matching uses the `--team-name` token rather than splitting the `<name>@<team>` agent id, because team and member names may contain `@`.

Boundary: in-tmux members on the default tmux server can't be pane-killed here (no pane ids without the config, and the default server is never kill-served), but their vendor process is still reaped by team name, so no process is orphaned.

## Tests

`cmdlineTeamName` matching (including `@`-bearing teams and `alpha` vs `beta-alpha`); parse-failure teardown still kills the deterministic swarm server, removes the dir, and warns; a ghost process discovered by team name is reaped before removal. `go build`, `go vet`, `gofmt -l`, `go test -race ./...` pass.

Fixes #9.
