### PR TITLE
fix(teardown): reap swarm server and processes when the team dir is gone

### DIFF
--- a/internal/teardown/teardown.go
+++ b/internal/teardown/teardown.go
@@ -107,6 +107,20 @@ func reapTeammateProcess(agentID string) (killed []int, warnings []string) {
 	return killed, warnings
 }
 
+// configFreeReap kills team's deterministic swarm server and returns the agent
+// ids of any still-live teammate processes matched by --team-name — both
+// derivable from the team name alone, with no config. Shared by the two
+// config-less teardown paths (the dir is absent; or its config is unparseable),
+// so cleanup no longer depends on an on-disk record. The caller reaps the
+// returned ids after releasing the team lock.
+func configFreeReap(team string) (agentIDs []string, warnings []string) {
+	sock := spawn.SwarmSocketName(team)
+	if err := tmux.NewServer(sock).KillServer(); err != nil {
+		warnings = append(warnings, fmt.Sprintf("kill swarm server %s: %v", sock, err))
+	}
+	return discoverTeamAgentIDsFn(team), warnings
+}
+
 // TeardownTeam kills every tmux pane registered in team's config.json and
 // removes the entire ~/.claude/teams/<team>/ directory tree.
 //
@@ -114,8 +128,12 @@ func reapTeammateProcess(agentID string) (killed []int, warnings []string) {
 // OK with empty Panes/Members. tmux failures become warnings. Only a
 // filesystem failure on RemoveAll flips OK to false.
 //
-// The whole sequence runs under WithTeamLock so a concurrent spawn into
-// the same team waits for the kill+rm to finish before re-creating state.
+// Even when the team dir is already gone, a swarm server / vendor process can
+// still be alive under this team name (a prior teardown left it, or the dir was
+// deleted out of band). Both the swarm socket and the per-proc --team-name are
+// derivable from the team name alone, so recovery runs config-free — and under
+// WithTeamLock, so it serializes with a concurrent spawn into the same team
+// (the lock recreates the absent dir; RemoveAll cleans it back up).
 func TeardownTeam(team string) Result {
 	if team == "" {
 		return Result{
@@ -127,9 +145,6 @@ func TeardownTeam(team string) Result {
 
 	res := Result{OK: true, Target: team}
 
-	// First check: if the team dir doesn't even exist, this is a no-op and
-	// we should NOT acquire WithTeamLock (which would create the dir and
-	// lock file just to delete them again).
 	dir, dirErr := spawn.TeamDir(team)
 	if dirErr != nil {
 		res.OK = false
@@ -137,10 +152,15 @@ func TeardownTeam(team string) Result {
 		res.ErrorMsg = dirErr.Error()
 		return res
 	}
-	if _, statErr := os.Stat(dir); errors.Is(statErr, os.ErrNotExist) {
-		// Idempotent: nothing to clean. Caller's --json receives ok=true
-		// with empty slices.
-		return res
+	// Note whether a real team dir existed up front: a no-op teardown of a
+	// never-created team must not claim TeamRemoved (the lock below recreates
+	// then deletes the dir). We deliberately do NOT early-return on absence —
+	// leftovers can outlive a deleted dir, and recovery must run under the lock.
+	dirExisted := false
+	if _, statErr := os.Stat(dir); statErr == nil {
+		dirExisted = true
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("stat team dir: %v", statErr))
 	}
 
 	// Agent ids whose (possibly reparented) processes we reap after releasing
@@ -152,7 +172,8 @@ func TeardownTeam(team string) Result {
 		// rm -rf the team dir, which is the primary cleanup goal. We just
 		// won't know which pane ids to kill or member names to report.
 		tc, loadErr := spawn.LoadTeamConfig(team)
-		if loadErr == nil && tc != nil {
+		switch {
+		case loadErr == nil && tc != nil:
 			// Per-member socket — out-of-tmux teams keep their panes on a private
 			// swarm server (cc-fleet-swarm-<team>), and a team can mix in-tmux +
 			// swarm members. KillPane MUST target the right server, or a
@@ -200,28 +221,36 @@ func TeardownTeam(team string) Result {
 						fmt.Sprintf("kill swarm server %s: %v", sock, err))
 				}
 			}
-		} else if loadErr != nil && !errors.Is(loadErr, spawn.ErrTeamNotFound) {
-			// Config is unreadable, so we have no pane ids — but the swarm
-			// socket name is derivable from the team name and ghost processes
-			// carry <name>@<team>. Reap both before RemoveAll deletes the only
-			// record, or they leak with no way left to find them.
+		case loadErr != nil && !errors.Is(loadErr, spawn.ErrTeamNotFound):
+			// Config present but unparseable (parse error / permission): no pane
+			// ids to read, but the swarm socket + ghost --team-name are derivable
+			// from the team name. Recover before RemoveAll deletes the only record.
 			res.Warnings = append(res.Warnings,
 				fmt.Sprintf("load team config: %v", loadErr))
-			sock := spawn.SwarmSocketName(team)
-			if err := tmux.NewServer(sock).KillServer(); err != nil {
-				res.Warnings = append(res.Warnings,
-					fmt.Sprintf("kill swarm server %s: %v", sock, err))
-			}
-			reapIDs = append(reapIDs, discoverTeamAgentIDsFn(team)...)
+			ids, warns := configFreeReap(team)
+			res.Warnings = append(res.Warnings, warns...)
+			reapIDs = append(reapIDs, ids...)
+		default:
+			// ErrTeamNotFound: the dir was absent (recreated empty by the lock) or
+			// carries no config.json. A swarm server / vendor proc may still be
+			// alive under this team name with no record to find it — recover
+			// config-free, same as the parse-fail path but without a load warning.
+			ids, warns := configFreeReap(team)
+			res.Warnings = append(res.Warnings, warns...)
+			reapIDs = append(reapIDs, ids...)
 		}
 
 		// Remove the entire team dir. This is the failure path that matters:
 		// if we can't delete the directory, the user will see stale state on
-		// next spawn / ps.
+		// next spawn / ps. TeamRemoved reflects only a real team that existed
+		// before this call — a recovery sweep of an already-absent dir removes
+		// nothing the user can see.
 		if err := os.RemoveAll(dir); err != nil {
 			return fmt.Errorf("remove team dir: %w", err)
 		}
-		res.TeamRemoved = true
+		if dirExisted {
+			res.TeamRemoved = true
+		}
 		return nil
 	})
 

--- a/internal/teardown/teardown_recovery_test.go
+++ b/internal/teardown/teardown_recovery_test.go
@@ -1,0 +1,118 @@
+package teardown
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/spawn"
+)
+
+// TestTeardownTeam_DirGoneRecoversSwarmServer: when the team dir is already gone
+// but a swarm server / vendor process is still alive under the team name,
+// teardown must NOT bare-return — it kills the deterministic swarm server and
+// reaps the ghost (both derivable from the team name), leaving no orphan dir and
+// without claiming TeamRemoved (nothing the user could see was removed).
+func TestTeardownTeam_DirGoneRecoversSwarmServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	argsPath := installFakeTmux(t)
+	h := installReapHarness(t)
+
+	// Stand in for the /proc scan: one teammate of this team is still live.
+	const ghostID, ghostPID = "w1@gonet", 4242
+	orig := discoverTeamAgentIDsFn
+	t.Cleanup(func() { discoverTeamAgentIDsFn = orig })
+	discoverTeamAgentIDsFn = func(team string) []string {
+		if team == "gonet" {
+			return []string{ghostID}
+		}
+		return nil
+	}
+	h.pids[ghostID] = []int{ghostPID}
+
+	// Deliberately do NOT seed the team — the dir is absent.
+	res := TeardownTeam("gonet")
+	if !res.OK {
+		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
+	}
+	if res.TeamRemoved {
+		t.Fatal("TeamRemoved should be false when the dir never existed")
+	}
+
+	// The recovery sweep recreated the dir under the lock, then removed it: no orphan.
+	dir, _ := spawn.TeamDir("gonet")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("recovery left an orphan team dir: %v", err)
+	}
+
+	calls := readFakeTmuxCalls(t, argsPath)
+	if want := []string{"-L", "cc-fleet-swarm-gonet", "kill-server"}; !containsCall(calls, want) {
+		t.Fatalf("missing config-free kill-server on the deterministic swarm socket; calls=%v", calls)
+	}
+
+	var reaped bool
+	for _, p := range res.KilledPIDs {
+		if p == ghostPID {
+			reaped = true
+		}
+	}
+	if !reaped {
+		t.Fatalf("ghost pid %d not reaped; KilledPIDs=%v", ghostPID, res.KilledPIDs)
+	}
+	if sigs := h.sigs(ghostPID); len(sigs) == 0 || sigs[0] != syscall.SIGTERM {
+		t.Fatalf("ghost pid %d: signals=%v, want SIGTERM first", ghostPID, sigs)
+	}
+}
+
+// TestTeardownTeam_DirGoneIdempotentNoop: teardown of a team that never existed
+// (dir absent, nothing alive) is a clean idempotent OK — it still attempts the
+// config-free swarm-server kill (swallowed when no server is running) but reaps
+// nothing, claims no removal, and leaves no orphan dir.
+func TestTeardownTeam_DirGoneIdempotentNoop(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	argsPath := installFakeTmux(t)
+	installReapHarness(t)
+
+	// Simulate a dead swarm server: kill-server exits non-zero AND prints the
+	// "no server running" message KillServer keys on, so the recovery's
+	// best-effort kill is swallowed (no warning surfaced) — the realistic
+	// "leftovers already gone" recovery case, not just "the command was attempted".
+	outFile := filepath.Join(t.TempDir(), "tmux.out")
+	if err := os.WriteFile(outFile, []byte("no server running on cc-fleet-swarm-nobody\n"), 0o600); err != nil {
+		t.Fatalf("write mock output: %v", err)
+	}
+	t.Setenv("MOCK_OUTPUT_FILE", outFile)
+	t.Setenv("MOCK_EXIT_CODE", "1")
+
+	orig := discoverTeamAgentIDsFn
+	t.Cleanup(func() { discoverTeamAgentIDsFn = orig })
+	discoverTeamAgentIDsFn = func(string) []string { return nil }
+
+	res := TeardownTeam("nobody")
+	if !res.OK {
+		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
+	}
+	if res.TeamRemoved {
+		t.Fatal("TeamRemoved should be false for a never-existed team")
+	}
+	if len(res.KilledPIDs) != 0 {
+		t.Fatalf("expected no kills, got %v", res.KilledPIDs)
+	}
+	// The dead-server kill error must be SWALLOWED — no warning surfaced.
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "kill swarm server") {
+			t.Fatalf("dead-server kill error should be swallowed, got warning: %q", w)
+		}
+	}
+	dir, _ := spawn.TeamDir("nobody")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("idempotent no-op left an orphan team dir: %v", err)
+	}
+	// The recovery path still fired (deterministic socket kill attempted).
+	calls := readFakeTmuxCalls(t, argsPath)
+	if want := []string{"-L", "cc-fleet-swarm-nobody", "kill-server"}; !containsCall(calls, want) {
+		t.Fatalf("recovery kill-server not attempted; calls=%v", calls)
+	}
+}


### PR DESCRIPTION
## Problem

`TeardownTeam` returned early when the team directory was absent, treating it as a pure no-op. But a swarm tmux server or a vendor process can outlive a deleted directory — a prior teardown removed the dir but left something running, or the dir was deleted out of band — and nothing could reach them anymore, even though the swarm socket name (`SwarmSocketName(team)`) and the per-process `--team-name` are both derivable from the team name alone.

## Fix

Drop the early return and let the team-lock callback switch on the config load: a readable config takes the normal pane-kill and reap-by-agent-id path; a missing config (the dir was absent or empty) and an unparseable config both run a config-free recovery sweep that kills the deterministic swarm server and reaps processes matched by `--team-name`. Running the sweep under `WithTeamLock` serializes it against a concurrent spawn into the same team, and the parse-fail path now shares the same helper. `TeamRemoved` reflects only a directory that existed before the call.

## Tests

`go build`, `go vet`, `gofmt -l`, and `go test -race ./...` pass. New unit cases cover a dir-gone recovery (the swarm server is killed and a ghost reaped by team name, with no orphan directory) and an idempotent re-run against a dead server (the kill error is swallowed, result stays ok). A real run confirms it end to end: a live swarm server on a socket with no team directory is killed by `teardown <team>`.
