### PR TITLE
fix: bound external and child reads with byte budgets

### DIFF
--- a/internal/models/fetch.go
+++ b/internal/models/fetch.go
@@ -70,6 +70,12 @@ const fetchTimeout = 10 * time.Second
 // truncateBodyPreview to ensure callers never log unbounded vendor bytes.
 const bodySnippetMax = 200
 
+// maxModelsBody bounds how much of a /v1/models response we buffer in memory. A
+// model list is normally a few KB; the cap only stops a misconfigured or hostile
+// endpoint from OOMing add/refresh by streaming an unbounded body within
+// fetchTimeout (which caps time, not bytes). Package var so tests can shrink it.
+var maxModelsBody = 8 << 20 // 8 MiB
+
 // Fetch hits v.ModelsEndpoint and returns the parsed model list.
 //
 // It looks up the vendor's API key via the secrets package (so the caller
@@ -157,9 +163,13 @@ func FetchWithKey(ctx context.Context, endpoint string, key []byte) ([]Model, er
 	}
 	defer resp.Body.Close()
 
-	// Read body up-front so error paths can include a truncated snippet
-	// without burning the body before parsing.
-	body, readErr := io.ReadAll(resp.Body)
+	// Read body up-front so error paths can include a truncated snippet without
+	// burning the body before parsing — but BOUNDED: a misconfigured or hostile
+	// endpoint can stream gigabytes within fetchTimeout. LimitReader+1 lets us
+	// tell "exactly the cap" from "over the cap". Status classification below is
+	// unchanged (it doesn't need the whole body); only the 2xx parse path treats
+	// an overflow as an error, so an oversized 401/5xx still classifies normally.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, int64(maxModelsBody)+1))
 	if readErr != nil {
 		return nil, fmt.Errorf("models: read body from %s (status %d): %w",
 			endpoint, resp.StatusCode, readErr)
@@ -177,6 +187,13 @@ func FetchWithKey(ctx context.Context, endpoint string, key []byte) ([]Model, er
 			// bearer key into the body cannot leak it even via the preview surface.
 			body: truncateBodyPreview(redact.MaskKeyLike(body)),
 		}
+	}
+
+	// Success path needs the whole body to parse — so an oversized response is a
+	// hard error here (size only, never body bytes: key-safe), not a silent
+	// truncation that would mis-parse into a confusing "neither data nor array".
+	if len(body) > maxModelsBody {
+		return nil, fmt.Errorf("models: response from %s exceeds %d bytes", endpoint, maxModelsBody)
 	}
 
 	out, err := parseModelsBody(body)

--- a/internal/models/fetch_limit_test.go
+++ b/internal/models/fetch_limit_test.go
@@ -1,0 +1,75 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// shrinkModelsBody temporarily shrinks the response-body cap for a test so the
+// overflow path is exercised without streaming megabytes.
+func shrinkModelsBody(t *testing.T, n int) {
+	t.Helper()
+	orig := maxModelsBody
+	t.Cleanup(func() { maxModelsBody = orig })
+	maxModelsBody = n
+}
+
+// TestFetchWithKey_OversizedBody_Rejected: a 2xx body over the cap is a hard,
+// key-safe error (size only, no body bytes) — not a silent truncation that would
+// mis-parse, and not an unbounded read.
+func TestFetchWithKey_OversizedBody_Rejected(t *testing.T) {
+	shrinkModelsBody(t, 64)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("a", maxModelsBody+1)))
+	}))
+	defer srv.Close()
+
+	_, err := FetchWithKey(context.Background(), srv.URL, []byte("k"))
+	if err == nil {
+		t.Fatal("oversized 200 body: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("err = %v, want an 'exceeds' size error", err)
+	}
+	// Key-safety: the error names a size, never echoes body bytes.
+	if strings.Contains(err.Error(), "aaaa") {
+		t.Fatalf("error leaked body bytes: %v", err)
+	}
+}
+
+// TestFetchWithKey_Oversized401_StillKeyInvalid: bounding the read must NOT break
+// status classification — an oversized 401 stays ErrKeyInvalid, not too-large.
+func TestFetchWithKey_Oversized401_StillKeyInvalid(t *testing.T) {
+	shrinkModelsBody(t, 64)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(strings.Repeat("a", maxModelsBody+1)))
+	}))
+	defer srv.Close()
+
+	_, err := FetchWithKey(context.Background(), srv.URL, []byte("k"))
+	if !errors.Is(err, ErrKeyInvalid) {
+		t.Fatalf("err = %v, want ErrKeyInvalid (classification must survive the cap)", err)
+	}
+}
+
+// TestFetchWithKey_Oversized500_StillHTTPStatusError: an oversized 5xx stays a
+// *HTTPStatusError carrying the status — not reclassified as too-large.
+func TestFetchWithKey_Oversized500_StillHTTPStatusError(t *testing.T) {
+	shrinkModelsBody(t, 64)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(strings.Repeat("a", maxModelsBody+1)))
+	}))
+	defer srv.Close()
+
+	_, err := FetchWithKey(context.Background(), srv.URL, []byte("k"))
+	var hse *HTTPStatusError
+	if !errors.As(err, &hse) || hse.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("err = %v, want *HTTPStatusError(500)", err)
+	}
+}

--- a/internal/subagent/classify.go
+++ b/internal/subagent/classify.go
@@ -255,6 +255,8 @@ func suggestionFor(code string) string {
 		return "Retry once or switch vendor"
 	case ErrCodeFailed:
 		return "Inspect the error; retry or switch vendor"
+	case ErrCodeOutputTooLarge:
+		return "Narrow the task or cap it with --max-turns / --output-format json"
 	default:
 		return ""
 	}

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -31,6 +31,12 @@ const jobsDirName = "subagent-jobs"
 // defaultGCAge is the cutoff subagent-gc uses when --older-than is unset.
 const defaultGCAge = 24 * time.Hour
 
+// maxPromptBytes bounds a materialized --prompt-file / piped stdin. A task prompt
+// is far smaller; claude's own context window is the real ceiling. The cap only
+// stops an unbounded caller-supplied reader from OOMing the launch. Package var
+// so tests can shrink it.
+var maxPromptBytes = 10 << 20 // 10 MiB
+
 // jobMeta is the on-disk record written at --background launch (and a lighter
 // "running" record for a sync run, so the board can see it). It carries no
 // secret (prompt/answer are intentionally NOT persisted here) — just enough to
@@ -239,9 +245,15 @@ func materializePromptReader(r io.Reader, dst string) (f *os.File, err error) {
 		}
 	}()
 
-	data, err := io.ReadAll(r)
+	// Bounded read: a --prompt-file / piped stdin is caller-supplied and otherwise
+	// unbounded. LimitReader+1 distinguishes "exactly the cap" from "over"; an
+	// overflow fails here, BEFORE cmd.Start, so the child never gets a partial prompt.
+	data, err := io.ReadAll(io.LimitReader(r, int64(maxPromptBytes)+1))
 	if err != nil {
 		return nil, fmt.Errorf("read prompt: %w", err)
+	}
+	if len(data) > maxPromptBytes {
+		return nil, fmt.Errorf("prompt exceeds %d bytes", maxPromptBytes)
 	}
 	if err = os.WriteFile(dst, data, 0o600); err != nil {
 		return nil, fmt.Errorf("write prompt %s: %w", dst, err)

--- a/internal/subagent/job_prompt_cap_test.go
+++ b/internal/subagent/job_prompt_cap_test.go
@@ -1,0 +1,43 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// floodReader yields an endless stream of 'a' so the prompt cap can be exercised
+// without allocating a huge source buffer.
+type floodReader struct{}
+
+func (floodReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+// TestMaterializePromptReader_Oversized: a prompt past the cap fails BEFORE
+// cmd.Start (so the child never gets a partial prompt) and leaves no orphan
+// .prompt file behind.
+func TestMaterializePromptReader_Oversized(t *testing.T) {
+	orig := maxPromptBytes
+	maxPromptBytes = 1024
+	t.Cleanup(func() { maxPromptBytes = orig })
+
+	dst := filepath.Join(t.TempDir(), "p.prompt")
+	f, err := materializePromptReader(floodReader{}, dst)
+	if err == nil {
+		t.Fatal("oversized prompt: want error, got nil")
+	}
+	if f != nil {
+		t.Fatalf("returned non-nil file %p on error", f)
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("err = %v, want an 'exceeds' size error", err)
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Fatalf("oversized prompt left an orphan file at %s (stat err=%v)", dst, statErr)
+	}
+}

--- a/internal/subagent/runclaude_cap_test.go
+++ b/internal/subagent/runclaude_cap_test.go
@@ -1,0 +1,123 @@
+package subagent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRunClaude_OutputCapKillsGroup: a child that floods stdout past the cap is
+// SIGKILLed (the whole group), runClaude returns errOutputTooLarge promptly (not
+// at the generous ctx deadline), and the captured stdout stays bounded — never a
+// hang, never unbounded buffering.
+func TestRunClaude_OutputCapKillsGroup(t *testing.T) {
+	origCap, origGrace := maxChildOutput, waitGrace
+	maxChildOutput = 4096
+	waitGrace = 200 * time.Millisecond
+	t.Cleanup(func() { maxChildOutput, waitGrace = origCap, origGrace })
+
+	// Flood >cap to stdout, then hang: only the overflow-kill (not the 10s ctx
+	// deadline) can end this run quickly.
+	bin := writeFakeBin(t, "#!/bin/sh\nyes | head -c 100000\nsleep 30\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	stdout, _, _, err := runClaude(ctx, bin, []string{bin}, os.Environ(), nil)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, errOutputTooLarge) {
+		t.Fatalf("err = %v, want errOutputTooLarge", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("runClaude took %v — the overflow kill did not end the flood promptly", elapsed)
+	}
+	if len(stdout) > maxChildOutput {
+		t.Fatalf("captured stdout = %d bytes, want <= cap %d (must not buffer unbounded)", len(stdout), maxChildOutput)
+	}
+}
+
+// TestRunClaude_OutputCapBothStreams floods stdout AND stderr past the cap
+// concurrently, so the race detector exercises both copy goroutines driving the
+// shared kill-group / sync.Once path (the stdout-only test never does). Asserts a
+// clean OUTPUT_TOO_LARGE outcome with both captures bounded.
+func TestRunClaude_OutputCapBothStreams(t *testing.T) {
+	origCap, origGrace := maxChildOutput, waitGrace
+	maxChildOutput = 4096
+	waitGrace = 200 * time.Millisecond
+	t.Cleanup(func() { maxChildOutput, waitGrace = origCap, origGrace })
+
+	script := "#!/bin/sh\n" +
+		"{ yes | head -c 100000; } &\n" +
+		"{ yes | head -c 100000 1>&2; } &\n" +
+		"sleep 30\n"
+	bin := writeFakeBin(t, script)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	stdout, stderr, _, err := runClaude(ctx, bin, []string{bin}, os.Environ(), nil)
+	if !errors.Is(err, errOutputTooLarge) {
+		t.Fatalf("err = %v, want errOutputTooLarge", err)
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Fatal("both-stream flood not ended promptly by the overflow kill")
+	}
+	if len(stdout) > maxChildOutput || len(stderr) > maxChildOutput {
+		t.Fatalf("capture exceeded cap: stdout=%d stderr=%d cap=%d", len(stdout), len(stderr), maxChildOutput)
+	}
+}
+
+// TestRun_OutputTooLarge_Surfaces: end-to-end, a vendor child that floods stdout
+// past the cap surfaces as SUBAGENT_OUTPUT_TOO_LARGE — not a misclassified
+// SUBAGENT_FAILED from a truncated envelope.
+func TestRun_OutputTooLarge_Surfaces(t *testing.T) {
+	origCap, origGrace := maxChildOutput, waitGrace
+	maxChildOutput = 4096
+	waitGrace = 200 * time.Millisecond
+	t.Cleanup(func() { maxChildOutput, waitGrace = origCap, origGrace })
+
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	// Fake claude: answer --version for ResolveBinaryPath, else flood >cap then hang.
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in --version) echo \"2.1.150\"; exit 0;; esac\n" +
+		"yes | head -c 100000\nsleep 30\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dir := filepath.Join(xdg, "cc-fleet")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	toml := `version = 1
+
+[glm]
+base_url        = "https://example.invalid/anthropic"
+default_model   = "glm-4.6"
+models_endpoint = "https://example.invalid/v1/models"
+secret_backend  = "file"
+secret_ref      = "glm.key"
+enabled         = true
+added_at        = 2026-05-24T05:00:00Z
+`
+	if err := os.WriteFile(filepath.Join(dir, "vendors.toml"), []byte(toml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Run(Request{Vendor: "glm", Prompt: "hi", JSON: true, Timeout: 10 * time.Second})
+	if res.OK {
+		t.Fatal("OK should be false on output overflow")
+	}
+	if res.ErrorCode != ErrCodeOutputTooLarge {
+		t.Fatalf("ErrorCode = %s (msg=%s), want SUBAGENT_OUTPUT_TOO_LARGE", res.ErrorCode, res.ErrorMsg)
+	}
+}

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
@@ -27,6 +28,48 @@ const defaultTimeout = 300 * time.Second
 // waitGrace is how long Go waits after context cancel (SIGTERM via cmd.Cancel)
 // before SIGKILLing the child. Package var so tests can shrink it.
 var waitGrace = 5 * time.Second
+
+// maxChildOutput bounds each captured child stream (stdout, stderr) on the SYNC
+// path. A `claude -p --output-format json` result is KB; the cap only stops a
+// runaway child from OOMing the in-memory capture (the --background path streams
+// to disk instead). Package var so tests can shrink it.
+var maxChildOutput = 32 << 20 // 32 MiB per stream
+
+// errOutputTooLarge is runClaude's sentinel when a captured stream overflowed
+// maxChildOutput and the process group was killed. Run maps it to
+// SUBAGENT_OUTPUT_TOO_LARGE rather than classifying a truncated body.
+var errOutputTooLarge = errors.New("subagent: child output exceeded cap")
+
+// cappedWriter buffers up to limit bytes; the first write that would exceed it
+// trips overflow and calls onOverflow (kills the process group), then silently
+// discards the rest so the os/exec copy goroutine drains to EOF without an
+// EPIPE-driven reclassification. Each instance is written by a single os/exec
+// copy goroutine and its fields are read only after cmd.Run() joins that
+// goroutine, so it needs no mutex; the shared onOverflow guards itself.
+type cappedWriter struct {
+	limit      int
+	buf        bytes.Buffer
+	overflow   bool
+	onOverflow func()
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	if w.overflow {
+		return len(p), nil // already over: discard, report success
+	}
+	rem := w.limit - w.buf.Len()
+	if len(p) <= rem {
+		return w.buf.Write(p)
+	}
+	if rem > 0 {
+		w.buf.Write(p[:rem])
+	}
+	w.overflow = true
+	if w.onOverflow != nil {
+		w.onOverflow()
+	}
+	return len(p), nil // consume the tail into the void
+}
 
 // loadFP is a seam so tests can inject a fake fingerprint without a real cache.
 // Production = LoadOrBundled: the user's probed cache if present, else the
@@ -148,8 +191,20 @@ func Run(req Request) Result {
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	stdout, stderr, exitCode, _ := runClaude(ctx, fp.BinaryPath, argv, env, req.PromptReader)
+	stdout, stderr, exitCode, runErr := runClaude(ctx, fp.BinaryPath, argv, env, req.PromptReader)
 	timedOut := errors.Is(ctx.Err(), context.DeadlineExceeded)
+
+	// A genuine deadline wins over an overflow that fired during the kill (the
+	// task ran too long is the dominant cause). Otherwise an over-cap child
+	// surfaces as SUBAGENT_OUTPUT_TOO_LARGE — never a misclassified truncation.
+	if !timedOut && errors.Is(runErr, errOutputTooLarge) {
+		res = fail(ErrCodeOutputTooLarge,
+			fmt.Sprintf("vendor %s child output exceeded %d bytes", req.Vendor, maxChildOutput),
+			req.Vendor, suggestionFor(ErrCodeOutputTooLarge))
+		res.LeadSessionID = req.LeadSessionID
+		res.ExitCode = exitCode
+		return res
+	}
 
 	// 8. Classify into the outer envelope, plus stash the raw passthrough.
 	innerJSON := req.JSON || req.OutputFormat == "json"
@@ -203,7 +258,8 @@ func buildArgv(binaryPath, profilePath, model string, req Request) []string {
 // runClaude execs the headless child with a process-group kill model so a
 // timeout reaps the WHOLE tree (claude forks Bash-tool grandchildren). It is a
 // standalone func so tests can drive it with a fake binary. It never streams to
-// the parent's stdio: stdout/stderr are captured to buffers.
+// the parent's stdio: stdout/stderr are captured to byte-capped buffers, and a
+// stream that overflows maxChildOutput kills the group and returns errOutputTooLarge.
 func runClaude(ctx context.Context, binaryPath string, argv, env []string, stdin io.Reader) (stdout, stderr []byte, exitCode int, err error) {
 	cmd := exec.CommandContext(ctx, binaryPath)
 	cmd.Args = argv // argv[0] == binaryPath by construction
@@ -211,9 +267,22 @@ func runClaude(ctx context.Context, binaryPath string, argv, env []string, stdin
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}
-	var outBuf, errBuf bytes.Buffer
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
+	// Capture each stream through a byte cap so a runaway child can't OOM the
+	// parent. On overflow we SIGKILL the whole group (the over-cap output is
+	// already useless) and surface errOutputTooLarge — never a silent truncation,
+	// which would mis-parse into SUBAGENT_FAILED or echo a truncated answer.
+	var killOnce sync.Once
+	killGroup := func() {
+		killOnce.Do(func() {
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+		})
+	}
+	outW := &cappedWriter{limit: maxChildOutput, onOverflow: killGroup}
+	errW := &cappedWriter{limit: maxChildOutput, onOverflow: killGroup}
+	cmd.Stdout = outW
+	cmd.Stderr = errW
 
 	// Setpgid makes the child its own group leader, so -Pid == the whole group.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -249,5 +318,8 @@ func runClaude(ctx context.Context, binaryPath string, argv, env []string, stdin
 			exitCode = -1
 		}
 	}
-	return outBuf.Bytes(), errBuf.Bytes(), exitCode, err
+	if outW.overflow || errW.overflow {
+		return outW.buf.Bytes(), errW.buf.Bytes(), exitCode, errOutputTooLarge
+	}
+	return outW.buf.Bytes(), errW.buf.Bytes(), exitCode, err
 }

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -118,8 +118,9 @@ const (
 	ErrCodeVendorAPIError      = "VENDOR_API_ERROR"     // other is_error / 5xx / overloaded
 
 	// cc-fleet layer.
-	ErrCodeTimeout = "SUBAGENT_TIMEOUT" // --timeout deadline fired before claude returned
-	ErrCodeFailed  = "SUBAGENT_FAILED"  // non-zero exit with no parseable envelope / internal error
+	ErrCodeTimeout        = "SUBAGENT_TIMEOUT"          // --timeout deadline fired before claude returned
+	ErrCodeFailed         = "SUBAGENT_FAILED"           // non-zero exit with no parseable envelope / internal error
+	ErrCodeOutputTooLarge = "SUBAGENT_OUTPUT_TOO_LARGE" // child stdout/stderr exceeded the byte cap; group killed
 )
 
 // fail builds a failure Result, stamping vendor for context (mirrors spawn.fail).


### PR DESCRIPTION
## Problem

Three read paths bounded time but not bytes, so an oversized source could exhaust memory: the `/v1/models` response (`io.ReadAll` with only a 10s request timeout), a sync subagent child's stdout/stderr (captured into an unbounded buffer), and a background `--prompt-file` / stdin (read whole into memory before launch).

## Fix

Each read now carries a byte budget and fails explicitly rather than truncating silently:

- `/v1/models` reads through `io.LimitReader`; status classification is unchanged and runs first, so an oversized 401 or 5xx still classifies normally, and only an oversized 2xx parse path returns a key-safe "too large" error.
- the background prompt materialize reads through `io.LimitReader` and fails before the child starts, so a partial prompt never reaches it.
- the sync subagent child's stdout/stderr go through a size-capped writer that kills the process group and returns `SUBAGENT_OUTPUT_TOO_LARGE` on overflow — never a silent truncation, which would misclassify the result.

The background flow streams the child to on-disk job files (bounded by disk, not memory), so it stays out of scope.

## Tests

`go build`, `go vet`, `gofmt -l`, and `go test -race ./...` pass. New unit cases cover an oversized models body (rejected) alongside oversized 401/5xx (still classified), an oversized prompt (rejected before start), and a child that floods stdout — and both streams concurrently — past the cap (group killed, `SUBAGENT_OUTPUT_TOO_LARGE`). Real runs confirm no regression on the normal paths: a refresh caches its model list and a sync subagent returns its computed answer with no key leak.
