### PR TITLE
Harden workflow run restart/stop and refine the Workflows board

### DIFF
--- a/cmd/cc-fleet/workflow.go
+++ b/cmd/cc-fleet/workflow.go
@@ -181,7 +181,22 @@ watch the board. --foreground runs inline to completion instead.`,
 				return nil
 			}
 
-			id, err := workflow.Launch(ctx, script, opts, foreground)
+			// A detached --resume serializes against the board's restart and any concurrent
+			// resume/stop via the per-run execution lock; a foreground resume IS the engine
+			// running inline (it self-stamps its pid synchronously) and must not hold the lock
+			// around Execute, so it is not wrapped.
+			id, err := func() (string, error) {
+				if resume != "" && !foreground {
+					var rid string
+					lerr := subagent.WithRunLock(resume, func() error {
+						var e error
+						rid, e = workflow.Launch(ctx, script, opts, foreground)
+						return e
+					})
+					return rid, lerr
+				}
+				return workflow.Launch(ctx, script, opts, foreground)
+			}()
 			if err != nil {
 				return reportWorkflowErr(err, asJSON)
 			}
@@ -368,8 +383,14 @@ func newWorkflowStopCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run, err := subagent.StopRun(args[0])
-			if err != nil {
+			// Serialize stop against a concurrent restart/resume of the same run via the per-run
+			// execution lock (so a stop can't race the pre-launch pid window into skipping the kill).
+			var run subagent.WorkflowRun
+			if err := subagent.WithRunLock(args[0], func() error {
+				var e error
+				run, e = subagent.StopRun(args[0])
+				return e
+			}); err != nil {
 				return reportWorkflowErr(err, asJSON)
 			}
 			if asJSON {

--- a/internal/config/lock.go
+++ b/internal/config/lock.go
@@ -135,6 +135,15 @@ func withFlock(path string, fn func() error) error {
 	return fn()
 }
 
+// WithFlock is the exported generic blocking-exclusive flock primitive (the same
+// withFlock the three config scopes use), for any cross-process critical section
+// keyed by a file path. The CALLER owns path validation and choosing a safe lock
+// path (it is created lazily and the kernel locks its inode). See
+// subagent.WithRunLock for the workflow runtime's per-run execution lock.
+func WithFlock(path string, fn func() error) error {
+	return withFlock(path, fn)
+}
+
 // teamLockPath returns $HOME/.claude/teams/<team>/.cc-fleet-lock.
 //
 // $HOME is required — XDG does not apply here because Claude Code reads

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -665,12 +665,11 @@ func PurgeJobs() (dir string, removedFinished []string, running []string, err er
 	sort.Strings(removedFinished)
 	sort.Strings(running)
 
-	// Drop the (now-empty) dir only when nothing is left running. os.Remove is
-	// best-effort: a kept running job — or a stray non-job file — keeps the dir,
-	// which is correct. The runs/ subdir is removed by purgeRunManifests when no
-	// run has a live member, so it no longer orphans this dir at uninstall.
+	// Drop the dir when nothing is left running. RemoveAll (not Remove) so a leftover
+	// per-run .lock file — deliberately not a GC'd sidecar — can't strand the dir at an
+	// exclusive uninstall; with nothing running, no lock is held, so this is safe.
 	if len(running) == 0 {
-		_ = os.Remove(dir)
+		_ = os.RemoveAll(dir)
 	}
 	return dir, removedFinished, running, nil
 }

--- a/internal/subagent/restart_cluster_test.go
+++ b/internal/subagent/restart_cluster_test.go
@@ -1,0 +1,87 @@
+package subagent
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestWithRunLock_WiringAndInvariants: WithRunLock runs fn under a flock on runs/<id>.lock, propagates
+// fn's error, and a different id is independent. The cross-process MUTUAL EXCLUSION is flock's OS-level
+// guarantee (the three config scopes rely on the same primitive; the race detector can't observe it, and
+// the single-threaded board never contends in-process). The load-bearing invariant tested here is that
+// `.lock` is NOT a GC'd sidecar — GC must never unlink a possibly-held flock (unlink+recreate = new inode
+// = lost exclusion).
+func TestWithRunLock_WiringAndInvariants(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	const runID = "33333333-3333-3333-3333-333333333333"
+	ran := false
+	if err := WithRunLock(runID, func() error { ran = true; return nil }); err != nil {
+		t.Fatalf("WithRunLock: %v", err)
+	}
+	if !ran {
+		t.Fatal("WithRunLock must run fn")
+	}
+	lockPath, err := RunLockPath(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, serr := os.Stat(lockPath); serr != nil {
+		t.Fatalf("the lock file runs/<id>.lock should exist after WithRunLock: %v", serr)
+	}
+	for _, ext := range runSidecarExts {
+		if ext == ".lock" {
+			t.Fatal(".lock must NOT be in runSidecarExts — GC unlinking a held flock would break mutual exclusion")
+		}
+	}
+	sentinel := errors.New("boom")
+	if werr := WithRunLock(runID, func() error { return sentinel }); werr != sentinel {
+		t.Fatalf("WithRunLock must propagate fn's error, got %v", werr)
+	}
+	if werr := WithRunLock("44444444-4444-4444-4444-444444444444", func() error { return nil }); werr != nil {
+		t.Fatalf("a different run id must be independent: %v", werr)
+	}
+}
+
+// TestFinalizeRunLeaves: finalizeRunLeaves writes a terminal failure cache for every leaf of the run that
+// the dead engine left without a result, and touches nothing else — not a finished leaf (already cached),
+// not another run's leaf.
+func TestFinalizeRunLeaves(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const runID = "11111111-1111-1111-1111-111111111111"
+	write := func(jobID, rid, status string, withResult bool) {
+		meta := jobMeta{JobID: jobID, RunID: rid, Vendor: "glm", Model: "m", Status: status,
+			StartedAt: time.Now().Format(time.RFC3339)}
+		data, _ := json.Marshal(meta)
+		if werr := os.WriteFile(filepath.Join(dir, jobID+".json"), data, 0o600); werr != nil {
+			t.Fatal(werr)
+		}
+		if withResult {
+			r, _ := json.Marshal(Result{OK: true, JobID: jobID, Status: "done"})
+			_ = os.WriteFile(filepath.Join(dir, jobID+".result.json"), r, 0o600)
+		}
+	}
+	write("ghost", runID, "running", false)                                  // mid-flight leaf of this run
+	write("finished", runID, "done", true)                                   // already cached
+	write("other", "22222222-2222-2222-2222-222222222222", "running", false) // a different run
+
+	finalizeRunLeaves(runID)
+
+	if _, err := os.Stat(filepath.Join(dir, "ghost.result.json")); err != nil {
+		t.Fatalf("the run's mid-flight leaf must be finalized with a result cache: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "other.result.json")); !os.IsNotExist(err) {
+		t.Fatalf("a different run's leaf must NOT be finalized")
+	}
+}

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fileutil"
 	"github.com/ethanhq/cc-fleet/internal/ids"
 )
@@ -174,6 +175,28 @@ func RunJournalPath(runID string) (string, error) { return runSidecarPath(runID,
 // engine→watcher stream `cc-fleet workflow watch` tails for a flowing live log.
 func RunEventsPath(runID string) (string, error) { return runSidecarPath(runID, ".events") }
 
+// RunLockPath returns runs/<id>.lock — the per-run execution lock file. It is
+// deliberately NOT in runSidecarExts: a flock locks an inode, so GC / removeRun must
+// never unlink a possibly-held lock (unlink + recreate yields a new inode and
+// silently breaks mutual exclusion). Leftover empty lock files are bounded by
+// distinct-run-count and cleared by PurgeJobs' RemoveAll at an exclusive uninstall.
+func RunLockPath(runID string) (string, error) { return runSidecarPath(runID, ".lock") }
+
+// WithRunLock serializes a run's lifecycle decisions (restart / resume / stop /
+// delete) across processes via a blocking exclusive flock on runs/<id>.lock — the
+// workflow runtime's per-run execution lock. It is a STANDALONE flock scope,
+// independent of the three config scopes (the run-lifecycle paths take none of
+// vendors/team/server). It must wrap an entry point's whole decision and NEVER the
+// engine's Execute: the detached engine runs lock-free, so there is no re-entrancy
+// or deadlock when Restart composes stop + launch under one lock.
+func WithRunLock(runID string, fn func() error) error {
+	path, err := RunLockPath(runID)
+	if err != nil {
+		return err
+	}
+	return config.WithFlock(path, fn)
+}
+
 // RunScriptPath returns the saved-script path runs/<id>.star — the run's source,
 // persisted so a stopped run can be restarted (resumed).
 func RunScriptPath(runID string) (string, error) { return runSidecarPath(runID, ".star") }
@@ -289,15 +312,72 @@ func StopRun(runID string) (WorkflowRun, error) {
 	if run.Status != "" && run.Status != "running" {
 		return run, nil // already terminal — don't clobber done/failed/stopped
 	}
-	if run.EnginePID > 0 && pidAlive(run.EnginePID) && engineCmdlineMatches(run.EnginePID, runID) {
+	switch {
+	case run.EnginePID > 0 && pidAlive(run.EnginePID) && engineCmdlineMatches(run.EnginePID, runID):
+		// Verifiably this run's live detached engine: reap it + confirm dead before finalizing its leaves.
 		reapEngineTree(run.EnginePID) // reaps the engine + its in-flight leaf children
+		if !WaitEngineStopped(runID, stopReapTimeout) {
+			// Won't die — do NOT flip stopped or clear the pid, or a caller (Restart / PurgeRun) would
+			// falsely read it as dead and act under a still-live engine. Fail closed.
+			return WorkflowRun{}, fmt.Errorf("subagent: run %s engine did not stop in time", runID)
+		}
+		// Confirmed dead: finalize the engine's mid-flight leaves (left "running" because its
+		// finalizeSyncJob defer died with it) — never racing that defer, since the engine is gone.
+		finalizeRunLeaves(runID)
+	case EngineAlive(run):
+		// The engine MIGHT still be live but we cannot verify it is THIS run's (its argv is unreadable),
+		// so we must neither kill it (fail SAFE) nor flip the run stopped — a caller would then rewrite
+		// the journal / delete / launch under a possibly-live engine. Fail closed.
+		return WorkflowRun{}, fmt.Errorf("subagent: run %s engine (pid %d) is alive but unverifiable; cannot stop safely", runID, run.EnginePID)
+	case run.EnginePID > 0:
+		// A recorded detached pid that is DEFINITIVELY gone (dead, or recycled to a different process):
+		// its mid-flight leaves are ghosts — finalize them. (A foreground EnginePID==0 run has nothing to
+		// reap and no ghost leaves here; it just flips stopped below, clearing a stale "running".)
+		finalizeRunLeaves(runID)
 	}
 	run.Status = "stopped"
 	run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	run.EnginePID = 0 // a stopped run has no engine; clear the stale pid
 	if serr := SaveRun(run); serr != nil {
 		return WorkflowRun{}, serr
 	}
 	return run, nil
+}
+
+// stopReapTimeout bounds how long StopRun waits for a reaped engine to actually die before
+// finalizing its leaves — long enough for a SIGTERM'd engine to exit, short enough to not wedge.
+const stopReapTimeout = 5 * time.Second
+
+// finalizeRunLeaves writes a terminal failure Result for every leaf of runID that a now-dead engine
+// left without a result cache, so a stopped run shows no phantom "running" leaf. The caller invokes it
+// ONLY after the engine is confirmed dead (StopRun's reap + WaitEngineStopped), so it never races the
+// engine's own finalizeSyncJob defer; the result.json-absence gate skips any leaf that already
+// finished. finalizeSyncJob writes the sanitized (answer/Raw-stripped) cache, so the synthetic
+// canonical-string Result keeps no raw bytes or keys.
+func finalizeRunLeaves(runID string) {
+	dir, err := jobsDir()
+	if err != nil {
+		return
+	}
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
+			continue
+		}
+		jobID := strings.TrimSuffix(name, ".json")
+		if _, serr := os.Stat(filepath.Join(dir, jobID+".result.json")); serr == nil {
+			continue // already finished — only the killed-mid-flight ghosts need finalizing
+		}
+		meta, merr := readMeta(dir, jobID)
+		if merr != nil || meta.RunID != runID {
+			continue
+		}
+		finalizeSyncJob(jobID, fail(ErrCodeFailed, "engine stopped before the leaf finished", meta.Vendor, ""))
+	}
 }
 
 // engineCmdlineMatches reports whether pid is THIS run's DETACHED workflow engine — its

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -63,6 +63,9 @@ type WorkflowRun struct {
 	// at `workflow run`, or a --lead-session-id override) — so the board groups runs by
 	// session like the teammates board. Empty when launched outside a Claude session.
 	SessionID string `json:"session_id,omitempty"`
+	// Cwd is the directory `workflow run` was invoked from (the project dir); the board shows it on
+	// the run header. Captured at mint in the foreground launcher and preserved across resume.
+	Cwd string `json:"cwd,omitempty"`
 	// Launch options replayed on restart (resume re-execs with the SAME inputs, else a leaf's
 	// key — and thus its cache validity — would shift). Persisted at mint; the engine carries
 	// them so every manifest overwrite preserves them. ArgsJSON is the script's `args` input.

--- a/internal/subagent/run_controls_test.go
+++ b/internal/subagent/run_controls_test.go
@@ -47,10 +47,10 @@ func TestSyncJobPersistsIOOptIn(t *testing.T) {
 	}
 }
 
-// TestStopRunReuseGuardSpareForeignPID: StopRun must NOT kill a pid whose cmdline is not
-// this run's workflow engine (a recycled-pid guard). The test process's own pid stands in
-// for a "recycled" pid — its argv is the test binary, not `workflow run --run-id …`, so
-// the guard refuses the kill and the run is merely flipped to stopped.
+// TestStopRunReuseGuardSparesForeignPID: StopRun must NOT kill a pid whose cmdline is not
+// this run's workflow engine (a recycled-pid guard). The test process's own (live) pid stands
+// in for a "recycled" pid, with the argv seam driven to a non-engine argv so the guard reads it
+// as foreign on every platform, refuses the kill, and merely flips the run to stopped.
 func TestStopRunReuseGuardSparesForeignPID(t *testing.T) {
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
@@ -60,6 +60,12 @@ func TestStopRunReuseGuardSparesForeignPID(t *testing.T) {
 		RunID: "stoprun", StartedAt: time.Now().UTC().Format(time.RFC3339),
 		Status: "running", EnginePID: os.Getpid(),
 	})
+	// Drive the argv seam to a readable non-engine argv so the recycled-pid guard reads this live
+	// pid as foreign deterministically — the real reader is platform-specific (and unreadable on
+	// Windows, where the liveness soft-fail would otherwise read an unverifiable live pid as ours).
+	orig := reuseGuardArgv
+	t.Cleanup(func() { reuseGuardArgv = orig })
+	reuseGuardArgv = func(int) ([]string, bool) { return []string{"some", "other", "proc"}, true }
 	run, err := StopRun("stoprun")
 	if err != nil {
 		t.Fatalf("StopRun: %v", err)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -123,6 +123,10 @@ type Model struct {
 	// wfDeleteArm holds the run id armed for deletion: the first `d` arms it (status prompt), a second
 	// `d` on the same run confirms; any other key disarms (guards against an accidental single keypress).
 	wfDeleteArm string
+	// wfRestarting is the per-run in-flight guard: a run id is added when a stop/restart/delete is
+	// dispatched and removed when its workflowCtlMsg lands, so a second x/r/d on the same run is a
+	// no-op until the first completes (and a restart shows a transient "restarting …" status meanwhile).
+	wfRestarting map[string]bool
 	// Save-workflow name prompt: `s` on a focused run opens wfSaveInput (prefilled with the run name);
 	// while wfSaving, keys route to the input (enter saves to ~/.config/cc-fleet/workflows/<name>.star,
 	// esc cancels).
@@ -469,7 +473,10 @@ func loadWorkflows(epoch int, resolve bool) tea.Cmd {
 // left + re-entered (epoch++) is dropped (mirror workflowsMsg's gate).
 func stopRunCmd(runID string, epoch int) tea.Cmd {
 	return func() tea.Msg {
-		_, err := subagent.StopRun(runID)
+		err := subagent.WithRunLock(runID, func() error {
+			_, e := subagent.StopRun(runID)
+			return e
+		})
 		return workflowCtlMsg{verb: "stop", runID: runID, err: err, epoch: epoch}
 	}
 }
@@ -490,7 +497,7 @@ func restartCmd(runID, journalKey string, epoch int) tea.Cmd {
 // accumulate until deleted). Mirrors stopRunCmd's epoch-gated workflowCtlMsg outcome.
 func deleteRunCmd(runID string, epoch int) tea.Cmd {
 	return func() tea.Msg {
-		err := subagent.PurgeRun(runID)
+		err := subagent.WithRunLock(runID, func() error { return subagent.PurgeRun(runID) })
 		return workflowCtlMsg{verb: "delete", runID: runID, err: err, epoch: epoch}
 	}
 }
@@ -835,6 +842,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.epoch != m.workflowsEpoch {
 			return m, nil
 		}
+		delete(m.wfRestarting, msg.runID) // the op completed — clear the in-flight guard
 		// Surface the control outcome on the board status line, then reload so the run's status
 		// reflects the new state (mirror paneVisMsg). workflowsMsg does NOT touch workflowStatus, so
 		// the message survives the refresh. A successful restart clears the line instead — the leaf
@@ -1086,6 +1094,7 @@ func (m Model) toWorkflows() (tea.Model, tea.Cmd) {
 	m.loading = true
 	m.workflowsEpoch++
 	m.workflowStatus = ""
+	m.wfRestarting = map[string]bool{}
 	m.wfActivity = nil
 	m.wfRunCursor, m.wfPhaseCursor, m.wfAgentCursor = 0, 0, 0
 	m.rerootWorkflows(true) // fresh 0/1/>1 routing on entry
@@ -1264,6 +1273,10 @@ func (m Model) armOrDelete(runID string) (tea.Model, tea.Cmd) {
 		if m.workflowStatus == deleteArmPrompt {
 			m.workflowStatus = "" // clear the prompt; the delete's own outcome replaces it
 		}
+		if m.wfBusy(runID) {
+			return m, nil // a stop/restart/delete is already in flight — don't dispatch a second
+		}
+		m = m.markBusy(runID)
 		return m, deleteRunCmd(runID, m.workflowsEpoch)
 	}
 	m.wfDeleteArm = runID
@@ -1412,6 +1425,28 @@ func (m Model) clampCardScroll(v int) int {
 // restartFocusedLeaf restarts ONLY the focused agent — workflow.Restart drops its journal entry and
 // resumes, re-running just this leaf (+ any downstream leaf whose input shifted). A leaf with no
 // persisted JournalKey falls back to a whole-run restart so r is never a silent no-op.
+// wfBusy reports whether a stop/restart/delete is already in flight for runID — the in-flight guard
+// that makes a second x/r/d on the same run a no-op until its workflowCtlMsg lands.
+func (m Model) wfBusy(runID string) bool { return m.wfRestarting[runID] }
+
+// markBusy adds runID to the in-flight guard (lazily creating the map).
+func (m Model) markBusy(runID string) Model {
+	if m.wfRestarting == nil {
+		m.wfRestarting = map[string]bool{}
+	}
+	m.wfRestarting[runID] = true
+	return m
+}
+
+// armRestarting marks runID in-flight AND shows a transient "restarting <masked>…" status; the
+// workflowCtlMsg handler clears the guard, and on success the status, when the restart completes.
+func (m Model) armRestarting(runID string) Model {
+	m = m.markBusy(runID)
+	m.workflowStatusErr = false
+	m.workflowStatus = "restarting " + shortRunID(sessiontitle.CleanTitle(runID)) + "…"
+	return m
+}
+
 func (m Model) restartFocusedLeaf() (tea.Model, tea.Cmd) {
 	job, ok := m.selectedLeaf()
 	if !ok {
@@ -1421,6 +1456,10 @@ func (m Model) restartFocusedLeaf() (tea.Model, tea.Cmd) {
 	if !rok {
 		return m, nil
 	}
+	if m.wfBusy(runID) {
+		return m, nil
+	}
+	m = m.armRestarting(runID)
 	return m, restartCmd(runID, job.JournalKey, m.workflowsEpoch)
 }
 
@@ -1435,8 +1474,16 @@ func (m Model) wfControl(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.String() {
 	case "x":
+		if m.wfBusy(runID) {
+			return m, nil
+		}
+		m = m.markBusy(runID) // stop surfaces its own "stop: ok" outcome
 		return m, stopRunCmd(runID, m.workflowsEpoch)
 	case "r":
+		if m.wfBusy(runID) {
+			return m, nil
+		}
+		m = m.armRestarting(runID)
 		return m, restartCmd(runID, "", m.workflowsEpoch) // whole run (no single leaf focused)
 	case "d":
 		return m.armOrDelete(runID)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -399,11 +399,13 @@ func boardTick(epoch int) tea.Cmd {
 // (owningScreen → screenWorkflows) AND carries the workflowsEpoch that scheduled it, so a stale
 // refresh from a prior visit is dropped on re-entry (epoch++) or leaving.
 type workflowsMsg struct {
-	jobs     []subagent.Result
-	runs     []subagent.WorkflowRun
-	activity map[string]activitySnapshot // job id → per-leaf tool snapshot (+ live usage while running)
-	epoch    int
-	err      error
+	jobs           []subagent.Result
+	runs           []subagent.WorkflowRun
+	activity       map[string]activitySnapshot // job id → per-leaf tool snapshot (+ live usage while running)
+	sessionTitles  map[string]string           // launching-session id → /rename title (for the picker headers)
+	titlesResolved bool                        // set only on entry / manual-refresh loads; a live tick leaves m.sessionTitles untouched
+	epoch          int
+	err            error
 }
 
 func (workflowsMsg) owningScreen() screen { return screenWorkflows }
@@ -417,7 +419,7 @@ type workflowsTickMsg struct{ epoch int }
 // manifests, and — for each leaf — its activity snapshot (tool calls + a running leaf's live tokens
 // from the <jobID>.activity sidecar). ALL disk reads happen here on the refresh goroutine; render
 // helpers stay pure. It carries the first non-nil manifest/jobs error so a data-source failure surfaces.
-func loadWorkflows(epoch int) tea.Cmd {
+func loadWorkflows(epoch int, resolve bool) tea.Cmd {
 	return func() tea.Msg {
 		all, jErr := subagent.ListJobs()
 		var jobs []subagent.Result
@@ -441,7 +443,23 @@ func loadWorkflows(epoch int) tea.Cmd {
 		if err == nil {
 			err = rErr
 		}
-		return workflowsMsg{jobs: jobs, runs: runs, activity: activity, epoch: epoch, err: err}
+		// Resolve the runs' launching-session /rename titles so the picker shows the conversation name
+		// (the agent-status board resolves only teammate sessions, not workflow-only ones). Each Lookup
+		// scans the projects tree and titles change rarely, so only the entry / manual-refresh loads
+		// resolve; a live tick carries no titles and leaves m.sessionTitles as the last resolve left it.
+		var titles map[string]string
+		if resolve {
+			var sids []string
+			seen := map[string]bool{}
+			for _, r := range runs {
+				if r.SessionID != "" && !seen[r.SessionID] {
+					seen[r.SessionID] = true
+					sids = append(sids, r.SessionID)
+				}
+			}
+			titles = sessiontitle.Resolve(sids)
+		}
+		return workflowsMsg{jobs: jobs, runs: runs, activity: activity, sessionTitles: titles, titlesResolved: resolve, epoch: epoch, err: err}
 	}
 }
 
@@ -801,6 +819,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.workflowRuns = msg.runs
 		m.workflowsErr = msg.err
 		m.wfActivity = msg.activity
+		// Only a resolve load carries titles; a live tick leaves the last-resolved map in place so an
+		// out-of-order tick can't clobber a fresh resolve back to a pre-resolve snapshot.
+		if msg.titlesResolved {
+			m.sessionTitles = msg.sessionTitles
+		}
 		// Re-derive focus on a run-set change (a GC'd focused run, the 0/1/>1 routing) and
 		// clamp the run/phase/agent cursors to the new data.
 		m.rerootWorkflows(false)
@@ -831,7 +854,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.workflowStatusErr = false
 			m.workflowStatus = fmt.Sprintf("%s %s: ok", msg.verb, runID)
 		}
-		return m, loadWorkflows(m.workflowsEpoch)
+		return m, loadWorkflows(m.workflowsEpoch, true)
 
 	case wfDetailMsg:
 		// Drop a read that answers a prior focused leaf (a slow leaf-A read landing after the
@@ -847,7 +870,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case workflowsTickMsg:
 		if m.screen == screenWorkflows && msg.epoch == m.workflowsEpoch {
-			return m, tea.Batch(loadWorkflows(msg.epoch), workflowsTick(msg.epoch, m.workflowsTickInterval()))
+			return m, tea.Batch(loadWorkflows(msg.epoch, false), workflowsTick(msg.epoch, m.workflowsTickInterval()))
 		}
 		return m, nil
 
@@ -1066,7 +1089,7 @@ func (m Model) toWorkflows() (tea.Model, tea.Cmd) {
 	m.wfActivity = nil
 	m.wfRunCursor, m.wfPhaseCursor, m.wfAgentCursor = 0, 0, 0
 	m.rerootWorkflows(true) // fresh 0/1/>1 routing on entry
-	return m, tea.Batch(loadWorkflows(m.workflowsEpoch), workflowsTick(m.workflowsEpoch, m.workflowsTickInterval()))
+	return m, tea.Batch(loadWorkflows(m.workflowsEpoch, true), workflowsTick(m.workflowsEpoch, m.workflowsTickInterval()))
 }
 
 // wfGroups is the board's run→phase→agent tree (newest-first) — the single source the picker, phases,
@@ -1190,7 +1213,7 @@ func (m Model) updateWorkflows(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "R", "ctrl+r":
 		m.loading = true
-		return m, loadWorkflows(m.workflowsEpoch)
+		return m, loadWorkflows(m.workflowsEpoch, true)
 	case "tab":
 		return m.toList()
 	case "q":

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -312,6 +313,31 @@ func (m Model) boardWidth() int {
 	return 100
 }
 
+// boardMargin is the horizontal inset of the header + box; the full-width header rule overhangs the
+// inset box by this much on each side.
+const boardMargin = 2
+
+// boardInner is the content width of the inset header + box (boardWidth minus the two-side margin).
+func (m Model) boardInner() int {
+	return m.boardWidth() - 2*boardMargin
+}
+
+// headerRule is the full-width divider drawn between the run header and the inset box, so it overhangs
+// the box top border by boardMargin on each side.
+func (m Model) headerRule() string {
+	return borderStyle.Render(strings.Repeat("─", m.boardWidth()))
+}
+
+// indentBox left-pads every line of s by n columns — the board content inset that lets the full-width
+// header rule overhang the box.
+func indentBox(s string, n int) string {
+	if n <= 0 {
+		return s
+	}
+	pad := strings.Repeat(" ", n)
+	return pad + strings.ReplaceAll(s, "\n", "\n"+pad)
+}
+
 // phaseAgentCounts / runAgentCounts return (done, total) where done counts terminal (non-running) leaves.
 func phaseAgentCounts(p runPhaseGroup) (done, total int) {
 	for _, j := range p.jobs {
@@ -332,26 +358,56 @@ func runAgentCounts(g runGroup) (done, total int) {
 	return
 }
 
-// renderRunHeader is the persistent native header, TWO lines: the bold run name on line 1 (bounded to the
-// box width so a long name can't wrap onto a third row and shift the fixed-height box down); the faint
-// description (left) + the right-aligned "<done>/<total> agents · <elapsed>" on line 2 (just the counts
-// when there's no description).
+// runTokens sums the input+output tokens across every leaf of the run — the live snapshot for a running
+// leaf, the final Result for a done one (the same source as the per-leaf "tok" column).
+func (m Model) runTokens(g runGroup) int {
+	total := 0
+	for _, p := range g.phases {
+		for _, j := range p.jobs {
+			in, out, _ := m.leafCounts(j)
+			total += in + out
+		}
+	}
+	return total
+}
+
+// renderRunHeader is the persistent native header, THREE lines: line 1 is the bold run name (left) and, when
+// the run recorded it, the launching project dir (right-aligned); a blank spacer; then the description
+// (left) + the right-aligned "<done>/<total> agents · <elapsed> · ↓ <tokens> tokens" (just the summary when there's no
+// description). Each text line is width-bounded so a long name/path/description can't wrap onto an extra row
+// and shift the fixed-height box down.
 func (m Model) renderRunHeader(g runGroup) string {
 	done, total := runAgentCounts(g)
-	name := titleStyle.Render(truncCols(m.runLabel(g), m.boardWidth()))
-	right := faintStyle.Render(fmt.Sprintf("%d/%d agents · %s", done, total, g.elapsed()))
+	bw := m.boardInner() // header aligns with the inset box; the full-width rule overhangs both
+	// Line 1: run name (left) + project dir (right-aligned, home-abbreviated, tail kept). The name takes
+	// the width the dir leaves; both bounded so neither wraps.
+	dir, nameW := "", bw
+	if g.cwd != "" {
+		dir = faintStyle.Render(leftTruncCols(sessiontitle.CleanTitle(prettyDir(g.cwd)), bw/2))
+		nameW = bw - lipgloss.Width(dir) - 1
+	}
+	name := titleStyle.Render(truncCols(m.runLabel(g), nameW))
+	line1 := name
+	if dir != "" {
+		gap := bw - lipgloss.Width(name) - lipgloss.Width(dir)
+		if gap < 1 {
+			gap = 1
+		}
+		line1 = name + strings.Repeat(" ", gap) + dir
+	}
+	right := liveStyle.Render(fmt.Sprintf("%d/%d agents · %s · ↓ %s tokens", done, total, g.elapsed(), humanTokens(m.runTokens(g))))
 	left := ""
 	if g.description != "" {
-		left = faintStyle.Render(trunc(sessiontitle.CleanTitle(g.description), 80))
+		left = liveStyle.Render(trunc(sessiontitle.CleanTitle(g.description), 80))
 	}
-	gap := m.boardWidth() - lipgloss.Width(left) - lipgloss.Width(right)
+	gap := bw - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 1 {
-		// A long description must not wrap line 2 onto a third line — that would shift the fixed-height
+		// A long description must not wrap the third line onto a fourth — that would shift the fixed-height
 		// box down. Truncate the description to fit beside the right summary.
-		left = boxCell(left, m.boardWidth()-lipgloss.Width(right)-1)
+		left = boxCell(left, bw-lipgloss.Width(right)-1)
 		gap = 1
 	}
-	return name + "\n" + left + strings.Repeat(" ", gap) + right
+	return line1 + "\n\n" + left + strings.Repeat(" ", gap) + right
 }
 
 // boardBodyHeight is the inner row budget for the master-detail box (drives right-pane scroll). It
@@ -361,7 +417,7 @@ func (m Model) boardBodyHeight() int {
 	if h < 12 {
 		h = 24
 	}
-	avail := h - 9 // header (2 lines) + blank + box top/bottom + status + footer + margin
+	avail := h - 10 // header (3 lines: name / blank / desc) + rule + box top/bottom + status + footer + margin
 	if avail < 5 {
 		avail = 5
 	}
@@ -479,12 +535,12 @@ func leftWidth(title string, lines []string, boardW int) int {
 	return w
 }
 
-// paneWidths derives the right pane from a content-sized left: left + right + 11 == boardWidth (the 11
+// paneWidths derives the right pane from a content-sized left: left + right + 11 == boardInner (the 11
 // non-content columns are the two outer borders, the divider, and TWO spaces on each side of each cell).
-// leftW is CAPPED to always leave ≥20 columns for the detail pane, so the box never overflows (the
-// floor only bites on a sub-41-column terminal, where the box must wrap regardless).
+// leftW is CAPPED to always leave ≥20 columns for the detail pane, so the box never overflows its inset
+// width (the floor only bites on a sub-45-column terminal, where the box must wrap regardless).
 func (m Model) paneWidths(leftW int) (left, right int) {
-	avail := m.boardWidth() - 11
+	avail := m.boardInner() - 11
 	if avail < 30 {
 		avail = 30
 	}
@@ -554,12 +610,12 @@ func (m Model) viewWfPhases() string {
 		}
 		leftLines = append(leftLines, fmt.Sprintf("%s%s %s%s", marker, glyph, title, counts))
 	}
-	leftW, rightW := m.paneWidths(leftWidth("Phases", leftLines, m.boardWidth()))
+	leftW, rightW := m.paneWidths(leftWidth("Phases", leftLines, m.boardInner()))
 	rightTitle, rightLines := m.phaseAgentLines(rightW)
 	bodyH := m.boardBodyHeight()
 	leftLines = windowLines(leftLines, m.wfPhaseCursor, bodyH)
-	return m.renderRunHeader(g) + "\n\n" +
-		renderBoard("Phases", leftLines, rightTitle, rightLines, leftW, rightW, bodyH, 0)
+	return indentBox(m.renderRunHeader(g), boardMargin) + "\n" + m.headerRule() + "\n" +
+		indentBox(renderBoard("Phases", leftLines, rightTitle, rightLines, leftW, rightW, bodyH, 0), boardMargin)
 }
 
 // phaseAgentLines returns the title + full agent rows (right pane) for the focused phase ("Not started
@@ -598,7 +654,7 @@ func (m Model) agentLeftLines() (title string, lines []string) {
 // scroll clamp wraps the detail to the same column budget the render uses.
 func (m Model) wfAgentRightWidth() int {
 	title, lines := m.agentLeftLines()
-	_, rightW := m.paneWidths(leftWidth(title, lines, m.boardWidth()))
+	_, rightW := m.paneWidths(leftWidth(title, lines, m.boardInner()))
 	return rightW
 }
 
@@ -610,7 +666,7 @@ func (m Model) viewWfAgent() string {
 		return faintStyle.Render("(no workflow runs)")
 	}
 	listTitle, leftLines := m.agentLeftLines()
-	leftW, rightW := m.paneWidths(leftWidth(listTitle, leftLines, m.boardWidth()))
+	leftW, rightW := m.paneWidths(leftWidth(listTitle, leftLines, m.boardInner()))
 	cardTitle := "agent"
 	if j, jok := m.selectedLeaf(); jok {
 		if t := trunc(sessiontitle.CleanTitle(j.Label), rightW-6); t != "" {
@@ -620,8 +676,8 @@ func (m Model) viewWfAgent() string {
 	rightLines := m.agentDetailLines(rightW)
 	bodyH := m.boardBodyHeight()
 	leftLines = windowLines(leftLines, m.wfAgentCursor, bodyH)
-	return m.renderRunHeader(g) + "\n\n" +
-		renderBoard(listTitle, leftLines, cardTitle, rightLines, leftW, rightW, bodyH, m.clampCardScroll(m.wfCardScroll))
+	return indentBox(m.renderRunHeader(g), boardMargin) + "\n" + m.headerRule() + "\n" +
+		indentBox(renderBoard(listTitle, leftLines, cardTitle, rightLines, leftW, rightW, bodyH, m.clampCardScroll(m.wfCardScroll)), boardMargin)
 }
 
 // renderAgentRowFull is one agent row for a phase's agent list (right pane): "<dot> <label>  <model>"
@@ -707,10 +763,11 @@ func (m Model) leafCounts(j subagent.Result) (in, out, tools int) {
 	return in, out, snap.toolCount()
 }
 
-// agentDetailLines is the focused agent's inline detail (the L2 right pane, scrollable): status/model,
-// tokens·tool-calls, the Activity feed (last 3 tool signatures), the Outcome, and — when the io files
-// are loaded for THIS leaf (PersistIO opt-in) — the Prompt + Output. The Output reads from the leaf's
-// .answer side file (focused-single-agent surface, CleanTitle-scrubbed), NEVER Result.Result on a row.
+// agentDetailLines is the focused agent's inline detail (the L2 right pane, scrollable): status/model and
+// tokens·tool-calls, then a fixed Prompt → Activity → Output → Outcome order — the Prompt, the Activity
+// feed (last 3 tool signatures), the Output (when the io files are loaded for THIS leaf via the PersistIO
+// opt-in), and the Outcome. The Output reads from the leaf's .answer side file (focused-single-agent
+// surface, CleanTitle-scrubbed), NEVER Result.Result on a row.
 func (m Model) agentDetailLines(rightW int) []string {
 	j, ok := m.selectedLeaf()
 	if !ok {
@@ -721,17 +778,8 @@ func (m Model) agentDetailLines(rightW int) []string {
 	lines := []string{
 		statusLabel(j.Status) + faintStyle.Render(" · "+trunc(sessiontitle.CleanTitle(j.Model), 28)),
 		faintStyle.Render(fmt.Sprintf("%s tok · %d tool calls", humanTokens(in+out), tools)),
-		"",
-		faintStyle.Render(fmt.Sprintf("Activity · last 3 of %d tool calls", tools)),
 	}
-	sigs := snap.lastSigs(3)
-	if len(sigs) == 0 {
-		lines = append(lines, faintStyle.Render(" (no tool calls)"))
-	}
-	for _, s := range sigs {
-		lines = append(lines, " "+contentStyle.Render(truncCols(sessiontitle.CleanTitle(s), rightW-2)))
-	}
-	lines = append(lines, "", faintStyle.Render("Outcome"), " "+m.renderOutcome(j))
+	// Prompt first.
 	switch {
 	case m.wfDetailJob.JobID != j.JobID:
 		lines = append(lines, "", faintStyle.Render("(loading…)"))
@@ -754,9 +802,23 @@ func (m Model) agentDetailLines(rightW int) []string {
 				lines = append(lines, " "+faintStyle.Render(fmt.Sprintf("… %d more lines", more))) // body-aligned (indent 1)
 			}
 		}
+	}
+	// Then the Activity feed.
+	lines = append(lines, "", faintStyle.Render(fmt.Sprintf("Activity · last 3 of %d tool calls", tools)))
+	sigs := snap.lastSigs(3)
+	if len(sigs) == 0 {
+		lines = append(lines, faintStyle.Render(" (no tool calls)"))
+	}
+	for _, s := range sigs {
+		lines = append(lines, " "+contentStyle.Render(truncCols(sessiontitle.CleanTitle(s), rightW-2)))
+	}
+	// Then the Output, when this leaf's io files are loaded.
+	if m.wfDetailJob.JobID == j.JobID && m.wfDetailIO {
 		lines = append(lines, "", faintStyle.Render("Output"))
 		lines = append(lines, ioLines(m.wfDetailAnswer, rightW, liveStyle)...)
 	}
+	// Outcome last.
+	lines = append(lines, "", faintStyle.Render("Outcome"), " "+m.renderOutcome(j))
 	return lines
 }
 
@@ -820,6 +882,35 @@ func truncCols(s string, w int) string {
 		return s
 	}
 	return ansi.Truncate(s, w, "…")
+}
+
+// prettyDir abbreviates $HOME to ~ for a compact project-dir display.
+func prettyDir(dir string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if dir == home {
+			return "~"
+		}
+		if strings.HasPrefix(dir, home+string(os.PathSeparator)) {
+			return "~" + dir[len(home):]
+		}
+	}
+	return dir
+}
+
+// leftTruncCols keeps the TRAILING w display columns of s (a path's tail is the useful part), prefixing
+// "…" when it cut. CJK-aware via ansi.StringWidth.
+func leftTruncCols(s string, w int) string {
+	if w < 1 {
+		w = 1
+	}
+	if ansi.StringWidth(s) <= w {
+		return s
+	}
+	r := []rune(s)
+	for len(r) > 0 && ansi.StringWidth(string(r)) > w-1 {
+		r = r[1:]
+	}
+	return "…" + string(r)
 }
 
 // wrapTo hard-wraps a plain (un-styled) string to w DISPLAY columns — CJK-aware (a wide glyph counts
@@ -1067,21 +1158,23 @@ type runGroup struct {
 	name        string
 	description string
 	sessionID   string // launching Claude session (picker grouping); "" when launched outside one
+	cwd         string // launching project dir (shown right-aligned on the run header); "" when unknown
 	status      string
 	startedAt   string
 	updatedAt   string
 	phases      []runPhaseGroup
 }
 
-// elapsed renders the run's wall-clock from StartedAt to its last heartbeat
-// (UpdatedAt) when set, else to now. A run with no parseable StartedAt renders "—".
+// elapsed renders the run's wall-clock from StartedAt. A running run ticks live to now (the board
+// re-renders each frame); a terminal run freezes at its last heartbeat (UpdatedAt) so the duration
+// stops growing once it ends. A run with no parseable StartedAt renders "—".
 func (g runGroup) elapsed() string {
 	start, err := time.Parse(time.RFC3339, g.startedAt)
 	if err != nil {
 		return "—"
 	}
 	end := time.Now()
-	if g.updatedAt != "" {
+	if g.status != "running" && g.updatedAt != "" {
 		if u, uerr := time.Parse(time.RFC3339, g.updatedAt); uerr == nil {
 			end = u
 		}
@@ -1128,6 +1221,7 @@ func groupByRun(jobs []subagent.Result, runs []subagent.WorkflowRun) []runGroup 
 			g.name = r.Name
 			g.description = r.Description
 			g.sessionID = r.SessionID
+			g.cwd = r.Cwd
 			g.status = r.Status
 			g.startedAt = r.StartedAt
 			g.updatedAt = r.UpdatedAt

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -332,23 +332,26 @@ func runAgentCounts(g runGroup) (done, total int) {
 	return
 }
 
-// renderRunHeader is the persistent native header: the run name (bold) + description (faint) on the
-// left, and the right-aligned "<done>/<total> agents · <elapsed>".
+// renderRunHeader is the persistent native header, TWO lines: the bold run name on line 1 (bounded to the
+// box width so a long name can't wrap onto a third row and shift the fixed-height box down); the faint
+// description (left) + the right-aligned "<done>/<total> agents · <elapsed>" on line 2 (just the counts
+// when there's no description).
 func (m Model) renderRunHeader(g runGroup) string {
 	done, total := runAgentCounts(g)
-	left := titleStyle.Render(m.runLabel(g))
-	if g.description != "" {
-		left += faintStyle.Render("  " + trunc(sessiontitle.CleanTitle(g.description), 60))
-	}
+	name := titleStyle.Render(truncCols(m.runLabel(g), m.boardWidth()))
 	right := faintStyle.Render(fmt.Sprintf("%d/%d agents · %s", done, total, g.elapsed()))
+	left := ""
+	if g.description != "" {
+		left = faintStyle.Render(trunc(sessiontitle.CleanTitle(g.description), 80))
+	}
 	gap := m.boardWidth() - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 1 {
-		// A long name+description must not wrap the header onto a second line — that would shift the
-		// fixed-height box down. Truncate the left side to fit one line beside the right summary.
+		// A long description must not wrap line 2 onto a third line — that would shift the fixed-height
+		// box down. Truncate the description to fit beside the right summary.
 		left = boxCell(left, m.boardWidth()-lipgloss.Width(right)-1)
 		gap = 1
 	}
-	return left + strings.Repeat(" ", gap) + right
+	return name + "\n" + left + strings.Repeat(" ", gap) + right
 }
 
 // boardBodyHeight is the inner row budget for the master-detail box (drives right-pane scroll). It
@@ -358,7 +361,7 @@ func (m Model) boardBodyHeight() int {
 	if h < 12 {
 		h = 24
 	}
-	avail := h - 8 // header + blank + box top/bottom + status + footer + margin
+	avail := h - 9 // header (2 lines) + blank + box top/bottom + status + footer + margin
 	if avail < 5 {
 		avail = 5
 	}
@@ -504,7 +507,7 @@ func (m Model) viewWfPicker() string {
 	for i, g := range m.wfGroups() {
 		if g.sessionID != lastSession {
 			lastSession = g.sessionID
-			b.WriteString(sessionHdrStyle.Render("◆ "+m.sessionLabel(g.sessionID)) + "\n")
+			b.WriteString(sessionHdrStyle.Render("◆ "+m.sessionLabelFull(g.sessionID)) + "\n")
 		}
 		marker := "  "
 		name := trunc(m.runLabel(g), 42)
@@ -742,9 +745,13 @@ func (m Model) agentDetailLines(rightW int) []string {
 		} else {
 			total := promptLineCount(m.wfDetailPrompt)
 			lines = append(lines, faintStyle.Render(fmt.Sprintf("Prompt · %d lines · ⏎ expand", total)))
-			lines = append(lines, ioLines(firstLogicalLines(m.wfDetailPrompt, promptPreviewLines), rightW, contentStyle)...)
+			prev := ioLines(firstLogicalLines(m.wfDetailPrompt, promptPreviewLines), rightW, contentStyle)
+			for len(prev) > 0 && strings.TrimSpace(prev[len(prev)-1]) == "" {
+				prev = prev[:len(prev)-1] // drop a trailing blank preview row so "… N more lines" doesn't gap
+			}
+			lines = append(lines, prev...)
 			if more := total - promptPreviewLines; more > 0 {
-				lines = append(lines, faintStyle.Render(fmt.Sprintf("… %d more lines", more)))
+				lines = append(lines, " "+faintStyle.Render(fmt.Sprintf("… %d more lines", more))) // body-aligned (indent 1)
 			}
 		}
 		lines = append(lines, "", faintStyle.Render("Output"))
@@ -1248,6 +1255,20 @@ func (m Model) sessionLabel(id string) string {
 		return trunc(title, 48) + " (" + short + ")"
 	}
 	return short
+}
+
+// sessionLabelFull is sessionLabel for the run-picker header (a free-standing line, not boxed): the
+// /rename title first when known, then the FULL session id in parens (not truncated) so a run is
+// findable by its id. Both stay CleanTitle-scrubbed.
+func (m Model) sessionLabelFull(id string) string {
+	if id == "" {
+		return "(no session)"
+	}
+	full := sessiontitle.CleanTitle(id)
+	if title := sessiontitle.CleanTitle(m.sessionTitles[id]); title != "" {
+		return trunc(title, 48) + " (" + full + ")"
+	}
+	return full
 }
 
 func shortSessionID(id string) string {

--- a/internal/tui/workflow_board_test.go
+++ b/internal/tui/workflow_board_test.go
@@ -505,7 +505,8 @@ func TestWfDelete_TwoPressConfirm(t *testing.T) {
 func TestWfAgentRow_LabelThenModelThenMetrics(t *testing.T) {
 	jobs, runs := oneRun()
 	out := workflowsModel(t, jobs, runs, nil).viewWorkflows() // phases view, map phase's agent m1
-	li, mi, ti := strings.Index(out, "m1"), strings.Index(out, "glm-4.6"), strings.Index(out, "tok")
+	// "tok ·" is the agent row's metric marker; the run-header total uses "tokens", so anchor on the former.
+	li, mi, ti := strings.Index(out, "m1"), strings.Index(out, "glm-4.6"), strings.Index(out, "tok ·")
 	if li < 0 || mi < 0 || ti < 0 || !(li < mi && mi < ti) {
 		t.Fatalf("agent row should read label → model → metrics (idx %d,%d,%d):\n%s", li, mi, ti, out)
 	}
@@ -578,21 +579,24 @@ func TestWfPromptPreview_BlankLineAndIndent(t *testing.T) {
 	}
 }
 
-// TestWfRunHeader_TwoLines: the run header is two lines — the bold name on line 1, the description +
-// right-aligned counts on line 2.
-func TestWfRunHeader_TwoLines(t *testing.T) {
+// TestWfRunHeader_Layout: the run header is three lines — the bold name on line 1, a blank spacer on
+// line 2, the description + right-aligned counts on line 3.
+func TestWfRunHeader_Layout(t *testing.T) {
 	jobs, runs := oneRun()
 	m := workflowsModel(t, jobs, runs, nil)
 	g, _ := m.focusedGroup()
 	parts := strings.Split(m.renderRunHeader(g), "\n")
-	if len(parts) != 2 {
-		t.Fatalf("run header must be 2 lines, got %d", len(parts))
+	if len(parts) != 3 {
+		t.Fatalf("run header must be 3 lines (name / blank / description), got %d", len(parts))
 	}
 	if !strings.Contains(parts[0], "sweep") || strings.Contains(parts[0], "agents") {
 		t.Fatalf("line 1 must be the name with no counts: %q", parts[0])
 	}
-	if !strings.Contains(parts[1], "a sweep run") || !strings.Contains(parts[1], "agents") {
-		t.Fatalf("line 2 must be the description + counts: %q", parts[1])
+	if strings.TrimSpace(parts[1]) != "" {
+		t.Fatalf("line 2 must be a blank spacer: %q", parts[1])
+	}
+	if !strings.Contains(parts[2], "a sweep run") || !strings.Contains(parts[2], "agents") {
+		t.Fatalf("line 3 must be the description + counts: %q", parts[2])
 	}
 }
 
@@ -632,6 +636,69 @@ func TestWfTickKeepsResolvedTitles(t *testing.T) {
 	m, _ = step(t, m, workflowsMsg{jobs: jobs, runs: runs, sessionTitles: nil, titlesResolved: false, epoch: m.workflowsEpoch})
 	if m.sessionTitles["sess-x"] != "My Chat" {
 		t.Fatalf("a live tick must not clobber resolved titles, got %v", m.sessionTitles)
+	}
+}
+
+// TestWfRunHeader_ProjectDir: a run that recorded its launch cwd shows it right-aligned on header line 1
+// (right of the run name), and line 1 stays within the box width.
+func TestWfRunHeader_ProjectDir(t *testing.T) {
+	runs := []subagent.WorkflowRun{{
+		RunID: "run-1", Name: "sweep", Description: "d", Cwd: "/tmp/projects/my-app",
+		StartedAt: "2026-06-01T00:00:00Z", UpdatedAt: "2026-06-01T00:00:30Z",
+		Phases: []subagent.RunPhase{{Title: "map"}},
+	}}
+	jobs := []subagent.Result{{RunID: "run-1", Phase: "map", Label: "m1", Status: "running", JobID: "job-m1"}}
+	m := workflowsModel(t, jobs, runs, nil)
+	g, _ := m.focusedGroup()
+	line1 := strings.Split(m.renderRunHeader(g), "\n")[0]
+	if !strings.Contains(line1, "/tmp/projects/my-app") || !strings.Contains(line1, "sweep") {
+		t.Fatalf("header line 1 must show the run name and the project dir: %q", line1)
+	}
+	if strings.Index(line1, "sweep") > strings.Index(line1, "my-app") {
+		t.Fatalf("the project dir must be right of the run name: %q", line1)
+	}
+	if w := ansi.StringWidth(line1); w > m.boardWidth() {
+		t.Fatalf("header line 1 width %d exceeds box width %d: %q", w, m.boardWidth(), line1)
+	}
+}
+
+// TestWfBoard_RuleOverhangsBox: a full-width rule sits directly above the box and overhangs the inset
+// box top border on both sides.
+func TestWfBoard_RuleOverhangsBox(t *testing.T) {
+	jobs, runs := oneRun()
+	m := workflowsModel(t, jobs, runs, nil)
+	m.width = 80
+	lines := strings.Split(m.viewWorkflows(), "\n")
+	boxIdx := -1
+	for i, l := range lines {
+		if strings.Contains(l, "╭") {
+			boxIdx = i
+			break
+		}
+	}
+	if boxIdx <= 0 {
+		t.Fatalf("no box top border found in:\n%s", m.viewWorkflows())
+	}
+	ruleW, boxW := ansi.StringWidth(lines[boxIdx-1]), ansi.StringWidth(lines[boxIdx])
+	if ruleW != m.boardWidth() {
+		t.Fatalf("the header rule should be full board width %d, got %d", m.boardWidth(), ruleW)
+	}
+	if ruleW <= boxW {
+		t.Fatalf("the header rule (%d cols) must overhang the box top border (%d cols)", ruleW, boxW)
+	}
+}
+
+// TestRunElapsed_LiveVsTerminal: a running run's elapsed ticks to now (not frozen at its last heartbeat);
+// a terminal run freezes at UpdatedAt-StartedAt so it shows the final duration.
+func TestRunElapsed_LiveVsTerminal(t *testing.T) {
+	g := runGroup{startedAt: "2020-01-01T00:00:00Z", updatedAt: "2020-01-01T00:00:05Z"}
+	g.status = "done"
+	if got := g.elapsed(); got != "5s" {
+		t.Fatalf("a terminal run should freeze at UpdatedAt-StartedAt = 5s, got %q", got)
+	}
+	g.status = "running"
+	if got := g.elapsed(); got == "5s" {
+		t.Fatalf("a running run must tick to now, not freeze at 5s, got %q", got)
 	}
 }
 

--- a/internal/tui/workflow_board_test.go
+++ b/internal/tui/workflow_board_test.go
@@ -523,3 +523,107 @@ func TestBoxCell_CJKExactWidth(t *testing.T) {
 		t.Fatalf("boxCell must pad to 6 columns, got %d", w)
 	}
 }
+
+// TestWfPromptPreview_BlankLineAndIndent: the collapsed prompt's "… N more lines" trailer is body-
+// indented (one column, like the preview) with no blank-line gap when a preview line is blank.
+func TestWfPromptPreview_BlankLineAndIndent(t *testing.T) {
+	jobs, runs := oneRun()
+	m := workflowsModel(t, jobs, runs, nil)
+	m, _ = press(t, m, "enter") // → agent detail
+	leaf, _ := m.selectedLeaf()
+	// A prompt whose 2nd logical line is blank (a paragraph break): 4 logical lines, preview = 2.
+	m.wfDetailJob, m.wfDetailPrompt, m.wfDetailAnswer, m.wfDetailIO = leaf, "title line\n\nbody one\nbody two", "", true
+	lines := m.agentDetailLines(m.wfAgentRightWidth())
+	ti := -1
+	for i, l := range lines {
+		if strings.Contains(l, "… 2 more lines") {
+			ti = i
+			break
+		}
+	}
+	if ti < 0 {
+		t.Fatalf("trailer '… 2 more lines' missing:\n%q", lines)
+	}
+	if !strings.HasPrefix(lines[ti], " ") {
+		t.Fatalf("the trailer must be body-indented (leading space), got %q", lines[ti])
+	}
+	if strings.TrimSpace(lines[ti-1]) == "" {
+		t.Fatalf("a blank line precedes the trailer (gap not trimmed): %q", lines[ti-1])
+	}
+}
+
+// TestWfRunHeader_TwoLines: the run header is two lines — the bold name on line 1, the description +
+// right-aligned counts on line 2.
+func TestWfRunHeader_TwoLines(t *testing.T) {
+	jobs, runs := oneRun()
+	m := workflowsModel(t, jobs, runs, nil)
+	g, _ := m.focusedGroup()
+	parts := strings.Split(m.renderRunHeader(g), "\n")
+	if len(parts) != 2 {
+		t.Fatalf("run header must be 2 lines, got %d", len(parts))
+	}
+	if !strings.Contains(parts[0], "sweep") || strings.Contains(parts[0], "agents") {
+		t.Fatalf("line 1 must be the name with no counts: %q", parts[0])
+	}
+	if !strings.Contains(parts[1], "a sweep run") || !strings.Contains(parts[1], "agents") {
+		t.Fatalf("line 2 must be the description + counts: %q", parts[1])
+	}
+}
+
+// TestWfRunHeader_NameBounded: a run name wider than the box must not let header line 1 overflow the box
+// width — an over-width line 1 soft-wraps onto a third row and shifts the fixed-height box down.
+func TestWfRunHeader_NameBounded(t *testing.T) {
+	long := strings.Repeat("very-long-workflow-name-", 4) // ~96 cols, past any narrow box
+	runs := []subagent.WorkflowRun{{
+		RunID: "run-1", Name: long, Description: "d",
+		StartedAt: "2026-06-01T00:00:00Z", UpdatedAt: "2026-06-01T00:00:30Z",
+		Phases: []subagent.RunPhase{{Title: "map"}},
+	}}
+	jobs := []subagent.Result{{RunID: "run-1", Phase: "map", Label: "m1", Status: "running", JobID: "job-m1"}}
+	m := workflowsModel(t, jobs, runs, nil)
+	m.width = 50 // boardWidth == 50
+	g, _ := m.focusedGroup()
+	line1 := strings.Split(m.renderRunHeader(g), "\n")[0]
+	if w := ansi.StringWidth(line1); w > m.boardWidth() {
+		t.Fatalf("header line 1 width %d exceeds box width %d: %q", w, m.boardWidth(), line1)
+	}
+	if !strings.Contains(line1, "…") {
+		t.Fatalf("an over-width name must be truncated with an ellipsis: %q", line1)
+	}
+}
+
+// TestWfTickKeepsResolvedTitles: a live-tick refresh (titlesResolved=false) carries no titles and must NOT
+// overwrite the map a prior resolve produced — only a resolve load replaces it. Guards against an
+// out-of-order tick clobbering freshly resolved picker titles back to a pre-resolve snapshot.
+func TestWfTickKeepsResolvedTitles(t *testing.T) {
+	jobs, runs := oneRun()
+	m := workflowsModel(t, jobs, runs, nil)
+	resolved := map[string]string{"sess-x": "My Chat"}
+	m, _ = step(t, m, workflowsMsg{jobs: jobs, runs: runs, sessionTitles: resolved, titlesResolved: true, epoch: m.workflowsEpoch})
+	if m.sessionTitles["sess-x"] != "My Chat" {
+		t.Fatalf("a resolve load must set titles, got %v", m.sessionTitles)
+	}
+	m, _ = step(t, m, workflowsMsg{jobs: jobs, runs: runs, sessionTitles: nil, titlesResolved: false, epoch: m.workflowsEpoch})
+	if m.sessionTitles["sess-x"] != "My Chat" {
+		t.Fatalf("a live tick must not clobber resolved titles, got %v", m.sessionTitles)
+	}
+}
+
+// TestWfPicker_FullSessionIdAndTitle: the run-picker session header shows the /rename title first + the
+// FULL session id in parens (not truncated to 8 + …).
+func TestWfPicker_FullSessionIdAndTitle(t *testing.T) {
+	full := "347597cf-1234-5678-9abc-def012345678"
+	runs := []subagent.WorkflowRun{
+		{RunID: "r1", Name: "research", SessionID: full, StartedAt: "2026-06-01T00:00:20Z"},
+		{RunID: "r2", Name: "other", SessionID: "sess-untitled-long", StartedAt: "2026-06-01T00:00:10Z"},
+	}
+	m := workflowsModel(t, nil, runs, nil)
+	m.sessionTitles = map[string]string{full: "my conversation"}
+	out := m.viewWorkflows()
+	if !strings.Contains(out, "my conversation ("+full+")") {
+		t.Fatalf("picker header should show title + full session id:\n%s", out)
+	}
+	if !strings.Contains(out, "sess-untitled-long") {
+		t.Fatalf("an untitled session should show its full id (not truncated):\n%s", out)
+	}
+}

--- a/internal/tui/workflow_board_test.go
+++ b/internal/tui/workflow_board_test.go
@@ -215,7 +215,9 @@ func TestWfControlsTargetRun(t *testing.T) {
 	if _, cmd := press(t, m, "x"); cmd == nil {
 		t.Fatal("x should stop the focused run even with no agents in the phase")
 	}
-	if _, cmd := press(t, m, "r"); cmd == nil {
+	// Fresh model: x above marked the run in-flight (the guard shares its map), which would correctly
+	// block a back-to-back r on the SAME model — here we just assert r dispatches on its own.
+	if _, cmd := press(t, workflowsModel(t, nil, runs, nil), "r"); cmd == nil {
 		t.Fatal("r should restart the focused run even with no agents")
 	}
 	m2, _ := press(t, m, "s")
@@ -229,6 +231,30 @@ func TestWfControlsTargetRun(t *testing.T) {
 	m3, _ := press(t, m2, "esc")
 	if m3.wfSaving {
 		t.Fatal("esc should cancel the save prompt")
+	}
+}
+
+// TestWfInFlightGuard: a restart marks the run in-flight with a transient "restarting" status; a second
+// r (or x) while it is in flight is a no-op; the completing workflowCtlMsg clears the guard so r works again.
+func TestWfInFlightGuard(t *testing.T) {
+	jobs, runs := oneRun()
+	m := workflowsModel(t, jobs, runs, nil)
+	m1, cmd := press(t, m, "r")
+	if cmd == nil {
+		t.Fatal("first r should dispatch a restart")
+	}
+	if !strings.Contains(m1.viewWorkflows(), "restarting") {
+		t.Fatalf("first r should show a transient 'restarting' status:\n%s", m1.viewWorkflows())
+	}
+	if _, c2 := press(t, m1, "r"); c2 != nil {
+		t.Fatal("a second r while a restart is in flight must be a no-op")
+	}
+	if _, cx := press(t, m1, "x"); cx != nil {
+		t.Fatal("x on a run with a restart in flight must be a no-op")
+	}
+	m2, _ := step(t, m1, workflowCtlMsg{verb: "restart", runID: "run-1", epoch: m1.workflowsEpoch})
+	if _, c3 := press(t, m2, "r"); c3 == nil {
+		t.Fatal("after the restart completes (guard cleared), r should dispatch again")
 	}
 }
 

--- a/internal/workflow/builtins.go
+++ b/internal/workflow/builtins.go
@@ -40,6 +40,7 @@ type engine struct {
 	metaModel string // meta.model: default model for agents that omit model= (applied before journalKey)
 	whenToUse string // meta.whenToUse: display/board text
 	sessionID string // parent Claude session (board grouping); seeded from the manifest, re-persisted every save
+	cwd       string // launching project dir (board run header); seeded from the manifest, re-persisted every save
 	argsJSON  string // --args-json, re-persisted so a restart resumes with the SAME args (else leaf keys shift)
 	// Budget accounting (USD), GIL-protected. budgetTotal<=0 means uncapped. budgetSpent
 	// accumulates each completed leaf's CostUSD; agent() raises once spent>=total.
@@ -469,6 +470,7 @@ func (e *engine) saveManifest(status, errText string) {
 		// Carried in engine state so every whole-file overwrite preserves them (the board
 		// groups by SessionID; a restart resumes with the same args/persistIO/budget).
 		SessionID:   e.sessionID,
+		Cwd:         e.cwd,
 		ArgsJSON:    e.argsJSON,
 		NoPersistIO: !e.persistIO,
 		BudgetUSD:   e.budgetTotal,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -83,7 +83,22 @@ func Prepare(scriptPath string) (subagent.WorkflowRun, error) {
 	if err != nil {
 		return subagent.WorkflowRun{}, err
 	}
+	// Resolve the whole script (not just meta) BEFORE minting: a resolve error — e.g. a reassigned
+	// top-level global — must fail with NO manifest left behind, not mint a 0-leaf run the board then
+	// lists forever. SourceProgramOptions resolves without executing the body.
+	if _, _, rerr := starlark.SourceProgramOptions(fileOptions, scriptPath, src, scriptPredeclared()); rerr != nil {
+		return subagent.WorkflowRun{}, rerr
+	}
 	return subagent.NewRunWithMeta(meta.Name, meta.Description, meta.WhenToUse, metaPhases(meta))
+}
+
+// scriptPredeclared reports the names a workflow script may reference without defining them — the
+// builtins() environment plus `args` (runtime-predeclared only with --args-json, but always allowed
+// here so the Prepare resolve doesn't reject a script that legitimately uses it). Universe builtins
+// (len/range/…) are resolved by the resolver itself.
+func scriptPredeclared() func(string) bool {
+	base := (&engine{}).builtins(Options{})
+	return func(name string) bool { return name == "args" || base.Has(name) }
 }
 
 // metaPhases converts a parsed script meta's phase plan into the manifest's RunPhase

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -170,6 +170,7 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 		whenToUse:   meta.WhenToUse,
 		budgetTotal: opts.BudgetUSD,
 		sessionID:   prepared.SessionID, // from the minted manifest; re-persisted on every save
+		cwd:         prepared.Cwd,       // launching project dir; ditto
 		argsJSON:    opts.ArgsJSON,
 	}
 	// Load the run's content-hash journal (resume). The path is derived from the
@@ -313,6 +314,9 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		run.ArgsJSON = opts.ArgsJSON
 		run.NoPersistIO = opts.NoPersistIO
 		run.BudgetUSD = opts.BudgetUSD
+		if cwd, cerr := os.Getwd(); cerr == nil {
+			run.Cwd = cwd
+		}
 		if serr := subagent.SaveRun(run); serr != nil {
 			return "", fmt.Errorf("workflow: persist run options: %w", serr)
 		}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -266,6 +266,15 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 			return "", fmt.Errorf("workflow: cannot resume: %w", rerr)
 		}
 		run = existing
+		// One engine per run: refuse to resume a run that still has a LIVE engine — a verifiably-live
+		// detached one, or a foreground/unreapable run (EnginePID<=0) still claiming to run. The board
+		// Restart path stops the old engine first (so the status is no longer running when it reaches
+		// here); a crashed/killed detached run (recorded pid now dead) falls through and resumes as-is.
+		// This guards the public `workflow run --resume` entry, which would otherwise launch a second
+		// concurrent engine. (Mirrors restart.go's fail-closed liveness check.)
+		if run.Status == "running" && (subagent.EngineAlive(run) || run.EnginePID <= 0) {
+			return "", fmt.Errorf("workflow: run %s already has a live engine; stop it first", opts.Resume)
+		}
 		// Replay the run's original launch options on resume so a leaf's content key — and thus
 		// its journal-cache validity — doesn't shift. A non-zero/non-empty opts value overrides
 		// (e.g. resuming with a larger --budget-usd); a zero/empty one reads as "not set" and
@@ -288,6 +297,7 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		// run can't be tracked or protected, so fail the resume rather than launch blind.
 		run.Status = "running"
 		run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		run.EnginePID = 0 // clear the prior engine's pid; the new child re-stamps, and WaitEngineStarted waits for exactly that
 		if serr := subagent.SaveRun(run); serr != nil {
 			return "", fmt.Errorf("workflow: stamp resume liveness: %w", serr)
 		}
@@ -318,10 +328,49 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 	if foreground {
 		return run.RunID, Execute(ctx, abs, run.RunID, opts)
 	}
-	if lerr := launchDetached(abs, run.RunID, opts); lerr != nil {
+	pid, reaper, lerr := launchDetached(abs, run.RunID, opts)
+	if lerr != nil {
 		run.Status = "failed"
 		_ = subagent.SaveRun(run)
 		return "", lerr
 	}
+	if !WaitEngineStarted(run.RunID, pid) {
+		// The detached child did not self-stamp its pid within the startup budget (slow OR
+		// dead). Kill + reap it BEFORE failing the run, so a slow-but-live child can't later
+		// overwrite the failed manifest and run on as a second engine.
+		reaper.kill()
+		_ = reaper.wait()
+		run.Status, run.Error, run.EnginePID = "failed", "workflow: engine did not register within the startup budget", 0
+		_ = subagent.SaveRun(run)
+		return "", fmt.Errorf("workflow: engine failed to start")
+	}
+	// Registered: reap the child asynchronously so it never lingers as a zombie under a
+	// long-lived parent (the TUI board). A short-lived CLI launcher exits before this
+	// goroutine completes; init then adopts and reaps the orphan.
+	go func() { _ = reaper.wait() }()
 	return run.RunID, nil
+}
+
+// engineStartupBudget bounds how long a launcher waits — under the per-run execution lock —
+// for a freshly detached engine child to self-stamp its pid into the manifest. (A var so a test can
+// shorten it; production never reassigns it.)
+var engineStartupBudget = 10 * time.Second
+
+// WaitEngineStarted blocks until the detached child has self-stamped EnginePID == childPID
+// (its first manifest write in Execute's pre-run saveManifest) or the startup budget
+// elapses. The launcher holds the per-run execution lock across this wait, so a serialized
+// second restart/stop/resume always observes a fully-registered engine — never the
+// pre-stamp EnginePID==0 window. Returns false on timeout; the caller must then kill+reap
+// the child before failing the run.
+func WaitEngineStarted(runID string, childPID int) bool {
+	deadline := time.Now().Add(engineStartupBudget)
+	for {
+		if run, err := subagent.ReadRun(runID); err == nil && run.EnginePID == childPID {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }

--- a/internal/workflow/launch.go
+++ b/internal/workflow/launch.go
@@ -10,18 +10,39 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
+// detachedReaper owns a launched detached engine's lifecycle handles: its wait4 (which
+// reaps the child so it never lingers as a `<defunct>` zombie under a long-lived parent
+// like the TUI board) and the /dev/null fd kept open for the child's stdio. EXACTLY ONE
+// path drives it: the success path runs wait() in a goroutine (fire-and-forget reaper);
+// the startup-timeout path kill()s then wait()s synchronously so the pid is truly gone
+// before the run is failed. They are mutually exclusive owners of cmd.Wait.
+type detachedReaper struct {
+	cmd     *exec.Cmd
+	devnull *os.File
+}
+
+func (r *detachedReaper) wait() error {
+	werr := r.cmd.Wait()
+	r.devnull.Close()
+	return werr
+}
+
+func (r *detachedReaper) kill() { _ = r.cmd.Process.Kill() }
+
 // launchDetached re-execs cc-fleet as a detached `workflow run --foreground --run-id`
 // child that runs the engine to completion after the launching CLI exits, so the main
 // session is never blocked for the run's duration (a fan-out easily outlasts a single
 // Bash-call timeout). It reuses the subagent leaf's process-group primitive
-// (SetDetachGroup) + Process.Release — the same proven detach, no new platform code.
-// The child's stdio goes to /dev/null (the detached engine keeps no stderr log); its
-// observable state is the manifest + the live-event channel + board, and the engine's
-// top-level recover finalizes status even on a panic.
-func launchDetached(scriptPath, runID string, opts Options) error {
+// (SetDetachGroup), no new platform code. The child's stdio goes to /dev/null (the
+// detached engine keeps no stderr log); its observable state is the manifest + the
+// live-event channel + board, and the engine's top-level recover finalizes status even
+// on a panic. It returns the child pid + a detachedReaper the caller MUST drive (instead
+// of Process.Release, which leaves a zombie under a long-lived parent): on success
+// `go reaper.wait()`; on a startup timeout `reaper.kill()` then `reaper.wait()`.
+func launchDetached(scriptPath, runID string, opts Options) (int, *detachedReaper, error) {
 	self, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("workflow: locate cc-fleet binary: %w", err)
+		return 0, nil, fmt.Errorf("workflow: locate cc-fleet binary: %w", err)
 	}
 	argv := []string{"workflow", "run", scriptPath, "--foreground", "--run-id", runID}
 	if opts.Concurrency > 0 {
@@ -38,9 +59,8 @@ func launchDetached(scriptPath, runID string, opts Options) error {
 	}
 	devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {
-		return fmt.Errorf("workflow: open %s: %w", os.DevNull, err)
+		return 0, nil, fmt.Errorf("workflow: open %s: %w", os.DevNull, err)
 	}
-	defer devnull.Close()
 
 	cmd := exec.Command(self, argv...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = devnull, devnull, devnull
@@ -51,8 +71,8 @@ func launchDetached(scriptPath, runID string, opts Options) error {
 	cmd.Env = childenv.Clean(os.Environ())
 	subagent.SetDetachGroup(cmd)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("workflow: start detached run: %w", err)
+		devnull.Close()
+		return 0, nil, fmt.Errorf("workflow: start detached run: %w", err)
 	}
-	// Detach: stop tracking the child so this process can exit cleanly while it runs on.
-	return cmd.Process.Release()
+	return cmd.Process.Pid, &detachedReaper{cmd: cmd, devnull: devnull}, nil
 }

--- a/internal/workflow/parsefail_test.go
+++ b/internal/workflow/parsefail_test.go
@@ -1,0 +1,44 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// TestPrepare_ResolveFailLeavesNoManifest: a script that PARSES but fails to RESOLVE (a reassigned
+// top-level global — the same `cannot reassign global` class seen in the wild) must error from Prepare
+// with NO run manifest minted, so it never leaves a 0-leaf corpse the board lists forever.
+func TestPrepare_ResolveFailLeavesNoManifest(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	script := filepath.Join(t.TempDir(), "bad.star")
+	src := "meta = {\"name\": \"n\", \"description\": \"d\"}\nfor r in [1, 2]:\n    pass\nfor r in [3, 4]:\n    pass\n"
+	if err := os.WriteFile(script, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Prepare(script); err == nil {
+		t.Fatal("Prepare must fail on a reassign-global resolve error")
+	}
+	if runs, _ := subagent.ListRuns(); len(runs) != 0 {
+		t.Fatalf("a resolve-failed script must leave NO run manifest, got %d", len(runs))
+	}
+}
+
+// TestPrepare_ValidScriptMints: a script that resolves cleanly (uses builtins + args) still mints
+// exactly one run manifest — the resolve check rejects only invalid scripts.
+func TestPrepare_ValidScriptMints(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	script := filepath.Join(t.TempDir(), "ok.star")
+	src := "meta = {\"name\": \"ok\", \"description\": \"d\"}\nphase(\"p\")\nlog(str(args))\n"
+	if err := os.WriteFile(script, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Prepare(script); err != nil {
+		t.Fatalf("valid script (builtins + args): %v", err)
+	}
+	if runs, _ := subagent.ListRuns(); len(runs) != 1 {
+		t.Fatalf("a valid script should mint exactly 1 run, got %d", len(runs))
+	}
+}

--- a/internal/workflow/restart.go
+++ b/internal/workflow/restart.go
@@ -25,7 +25,14 @@ const stopBarrierTimeout = 5 * time.Second
 // detached run (recorded pid now dead) is resumed as-is; a foreground run with no killable engine
 // fails closed. The resume replays the run's original launch options (args / persistIO / budget) off
 // the manifest so a leaf's key — and thus its cache validity — doesn't shift.
+// The whole decision runs under the per-run execution lock so a concurrent restart / resume / stop never
+// acts on stale state or races the pre-launch pid window; the lock releases when Launch returns (after the
+// child registers) and is NEVER held around the engine's Execute. StopRun/Launch internals stay lock-free.
 func Restart(ctx context.Context, runID, journalKey string) error {
+	return subagent.WithRunLock(runID, func() error { return restartLocked(ctx, runID, journalKey) })
+}
+
+func restartLocked(ctx context.Context, runID, journalKey string) error {
 	run, err := subagent.ReadRun(runID)
 	if err != nil {
 		return err

--- a/internal/workflow/restart_cluster_e2e_test.go
+++ b/internal/workflow/restart_cluster_e2e_test.go
@@ -1,0 +1,151 @@
+//go:build unix
+
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// blockingFakeClaude blocks until the test removes $GATE_FILE, so a workflow leaf stays in-flight and its
+// engine stays live — long enough to fire a restart storm against it.
+const blockingFakeClaude = `#!/bin/sh
+cat > /dev/null
+while [ -f "$GATE_FILE" ]; do sleep 0.05; done
+printf '{"type":"result","subtype":"success","is_error":false,"result":"ok","num_turns":1,"total_cost_usd":0.001,"usage":{"input_tokens":5,"output_tokens":5}}'
+`
+
+// TestT3_RestartStormOneEngine is the T3 real-restart e2e: a detached engine runs a leaf that BLOCKS (so
+// the engine stays live), then N concurrent Restart calls hit the same run. The per-run execution lock must
+// serialize them so exactly ONE engine survives — no multi-engine pile-up. Real detached engines are spawned
+// via the TestMain re-dispatch (each appends its pid to $PID_LOG).
+func TestT3_RestartStormOneEngine(t *testing.T) {
+	env := newE2EEnv(t)
+	gate := filepath.Join(env.home, "gate")
+	if err := os.WriteFile(gate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pidLog := filepath.Join(env.home, "pids")
+	t.Setenv("GATE_FILE", gate)
+	t.Setenv("PID_LOG", pidLog)
+	if err := os.WriteFile(env.fakePath, []byte(blockingFakeClaude), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(env.home, "block.star")
+	body := "meta = {\"name\": \"t3\", \"description\": \"d\"}\nphase(\"p\")\nagent(\"block\", vendor=\"fake\", label=\"b\")\n"
+	if err := os.WriteFile(script, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Launch a detached run; its single leaf blocks on the gate, so the engine stays live.
+	runID, err := Launch(context.Background(), script, Options{NoPersistIO: true}, false)
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(gate); _, _ = subagent.StopRun(runID) }) // unblock + reap on exit
+	if !waitEngineLive(t, runID, 5*time.Second) {
+		t.Fatal("the initial detached engine never registered as live")
+	}
+	run0, err := subagent.ReadRun(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialPID := run0.EnginePID
+	if initialPID <= 0 {
+		t.Fatalf("the initial engine pid should be recorded, got %d", initialPID)
+	}
+
+	// Restart storm: N concurrent whole-run restarts. The per-run lock must serialize them — each fully
+	// kills the previous engine and registers a new one before releasing, so they never pile up.
+	const n = 6
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if e := Restart(context.Background(), runID, ""); e != nil {
+				mu.Lock()
+				errs = append(errs, e)
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if len(errs) > 0 {
+		t.Fatalf("every serialized restart must succeed, got %d error(s); first: %v", len(errs), errs[0])
+	}
+
+	run, err := subagent.ReadRun(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A restart ACTUALLY replaced the engine (proves the storm was not a no-op): a new, live pid.
+	if !subagent.EngineAlive(run) {
+		t.Fatalf("after the storm the run should still have ONE live engine (manifest pid %d)", run.EnginePID)
+	}
+	if run.EnginePID == initialPID {
+		t.Fatalf("the restart storm did not replace the engine — pid is still the initial %d", initialPID)
+	}
+	// The pid side channel is populated (initial + restart engines) and names the survivor.
+	pids := readPIDs(pidLog)
+	if len(pids) < 2 || !containsInt(pids, run.EnginePID) {
+		t.Fatalf("PID_LOG %v must record the initial + restart engines and include the survivor %d", pids, run.EnginePID)
+	}
+	// And NO engine besides the survivor is still alive — i.e. no multi-engine pile-up.
+	stray := 0
+	for _, pid := range pids {
+		if pid != run.EnginePID && syscall.Kill(pid, 0) == nil {
+			stray++
+		}
+	}
+	if stray != 0 {
+		t.Fatalf("multi-engine pile-up: %d engine pid(s) besides the survivor (%d) are still alive", stray, run.EnginePID)
+	}
+}
+
+func containsInt(xs []int, v int) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func waitEngineLive(t *testing.T, runID string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if run, err := subagent.ReadRun(runID); err == nil && subagent.EngineAlive(run) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func readPIDs(path string) []int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if p, perr := strconv.Atoi(strings.TrimSpace(line)); perr == nil && p > 0 {
+			pids = append(pids, p)
+		}
+	}
+	return pids
+}

--- a/internal/workflow/restart_cluster_test.go
+++ b/internal/workflow/restart_cluster_test.go
@@ -1,0 +1,45 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// TestLaunch_ResumeLiveGuard: Launch's resume branch refuses a run that still claims to be running with a
+// live (or foreground/unverifiable EnginePID<=0) engine, so a public `workflow run --resume` can't launch a
+// second engine over a live one. A freshly minted run is Status="running", EnginePID=0 → the guard fires.
+func TestLaunch_ResumeLiveGuard(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	run, err := subagent.NewRunWithMeta("n", "d", "", nil) // mints Status="running", EnginePID=0
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, lerr := Launch(context.Background(), "/nonexistent.star", Options{Resume: run.RunID}, false)
+	if lerr == nil || !strings.Contains(lerr.Error(), "already has a live engine") {
+		t.Fatalf("Launch --resume of a still-running run must refuse with a live-engine error, got: %v", lerr)
+	}
+}
+
+// TestWaitEngineStarted_Timeout: WaitEngineStarted returns false when the child never self-stamps the
+// expected pid into the manifest within the (test-shortened) startup budget — the path on which Launch
+// kills + reaps the child and fails the run.
+func TestWaitEngineStarted_Timeout(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	old := engineStartupBudget
+	engineStartupBudget = 150 * time.Millisecond
+	defer func() { engineStartupBudget = old }()
+
+	run, err := subagent.NewRunWithMeta("n", "d", "", nil) // EnginePID=0, never becomes 12345
+	if err != nil {
+		t.Fatal(err)
+	}
+	if WaitEngineStarted(run.RunID, 12345) {
+		t.Fatal("WaitEngineStarted must return false when the child never stamps its pid")
+	}
+}

--- a/internal/workflow/t3_main_test.go
+++ b/internal/workflow/t3_main_test.go
@@ -1,0 +1,62 @@
+//go:build unix
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// TestMain lets a T3 test drive REAL detached engines. launchDetached re-execs os.Executable() — here the
+// TEST binary — as `workflow run <script> --foreground --run-id <id> ...`; intercepting that argv and
+// running the engine (Execute) instead of the test suite makes a detached "child" a genuine second process
+// running the real engine code path. Any other invocation runs the tests normally. When PID_LOG is set, the
+// child appends its pid so a test can assert how many engines stayed alive (the one-engine-per-run check).
+func TestMain(m *testing.M) {
+	if len(os.Args) >= 3 && os.Args[1] == "workflow" && os.Args[2] == "run" {
+		os.Exit(runEngineChild(os.Args[3:]))
+	}
+	os.Exit(m.Run())
+}
+
+func runEngineChild(args []string) int {
+	var script, runID string
+	opts := Options{}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--foreground":
+		case "--run-id":
+			i++
+			runID = args[i]
+			opts.RunID = runID
+		case "--max-concurrency":
+			i++
+			opts.Concurrency, _ = strconv.Atoi(args[i])
+		case "--args-json":
+			i++
+			opts.ArgsJSON = args[i]
+		case "--no-persist-io":
+			opts.NoPersistIO = true
+		case "--budget-usd":
+			i++
+			opts.BudgetUSD, _ = strconv.ParseFloat(args[i], 64)
+		default:
+			if script == "" && args[i] != "" && args[i][0] != '-' {
+				script = args[i]
+			}
+		}
+	}
+	if pidLog := os.Getenv("PID_LOG"); pidLog != "" {
+		if f, err := os.OpenFile(pidLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
+			fmt.Fprintf(f, "%d\n", os.Getpid())
+			f.Close()
+		}
+	}
+	if err := Execute(context.Background(), script, runID, opts); err != nil {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
This branch hardens the `cc-fleet workflow` run lifecycle and refines the Workflows board that renders it: restart, resume, stop, and delete become mutually exclusive and crash-safe, and a run's header and per-agent detail get more informative without ever surfacing raw output or keys.

Run lifecycle:

- A per-run flock serializes every restart / resume / stop / delete, so a repeated restart no longer piles up multiple engines racing on one manifest.
- The detached engine is reaped rather than released, so a long-lived parent stops accumulating `<defunct>` zombies.
- Stopping a run whose engine can't be verified dead fails closed with no mutation; once the engine is confirmed gone, the run's in-flight leaves are finalized to a terminal state instead of lingering as phantom "running" rows.
- A script that parses but fails to resolve (e.g. a reassigned global) is resolved before anything is persisted, so it no longer mints a zero-leaf run the board lists forever.

Workflows board:

- The run header gains a right-aligned launching project directory (captured at run mint and carried through the manifest so it survives resume), a total-token count, and a full-width rule, and the elapsed clock ticks live while a run is running.
- The per-agent detail reads Prompt → Activity → Output → Outcome, and the header's first line is width-bounded so a long name or path can't wrap the fixed-height box.
- The picker shows the launching conversation's resolved title with its full session id, and the collapsed prompt preview aligns with the body.
- A transient "restarting" status with an in-flight guard reflects a restart in progress.

Everything the board renders stays masked or CleanTitle-scrubbed, tokens are integer counts, and the only raw content shown is the focused leaf's own prompt and answer.
