### PR TITLE
feat(workflow): harden run budgets, observability, and lifecycle

### DIFF
--- a/cmd/cc-fleet/workflow.go
+++ b/cmd/cc-fleet/workflow.go
@@ -30,6 +30,7 @@ type workflowEnvelope struct {
 	Runs      []subagent.WorkflowRun   `json:"runs,omitempty"`
 	Jobs      []subagent.Result        `json:"jobs,omitempty"`
 	Saved     []subagent.SavedWorkflow `json:"saved,omitempty"`
+	Removed   int                      `json:"removed,omitempty"`   // rm/prune: number of runs deleted
 	RunError  string                   `json:"run_error,omitempty"` // a failed run's cause (distinct from the command-level Error)
 	Error     string                   `json:"error,omitempty"`
 }
@@ -48,7 +49,66 @@ so they group into one run tree on the board. List runs and inspect a run's jobs
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
-	cmd.AddCommand(newWorkflowNewCmd(), newWorkflowListCmd(), newWorkflowStatusCmd(), newWorkflowRunCmd(), newWorkflowStopCmd(), newWorkflowWatchCmd(), newWorkflowSavedCmd())
+	cmd.AddCommand(newWorkflowNewCmd(), newWorkflowListCmd(), newWorkflowStatusCmd(), newWorkflowRunCmd(), newWorkflowStopCmd(), newWorkflowWatchCmd(), newWorkflowSavedCmd(), newWorkflowRmCmd(), newWorkflowPruneCmd())
+	return cmd
+}
+
+// newWorkflowRmCmd builds `cc-fleet workflow rm <run-id>` — delete a run and all its jobs (the board
+// never auto-clears, so runs accumulate). A still-live engine is stopped and confirmed dead first; a
+// run whose engine can't be confirmed dead aborts rather than delete under it. Wraps PurgeRun under the
+// per-run execution lock so it can't race a concurrent restart/resume.
+func newWorkflowRmCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:           "rm <run-id>",
+		Short:         "Delete a workflow run and its jobs (stops a live engine first)",
+		Args:          cobra.ExactArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			if err := subagent.ValidateRunID(id); err != nil {
+				return reportWorkflowErr(err, asJSON)
+			}
+			if err := subagent.WithRunLock(id, func() error { return subagent.PurgeRun(id) }); err != nil {
+				return reportWorkflowErr(err, asJSON)
+			}
+			if asJSON {
+				return emitWorkflow(workflowEnvelope{OK: true, RunID: id, Removed: 1})
+			}
+			fmt.Printf("removed %s\n", id)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit a machine-readable JSON envelope")
+	return cmd
+}
+
+// newWorkflowPruneCmd builds `cc-fleet workflow prune` — delete every run whose engine is no longer
+// alive (crashed/killed runs still stuck "running", plus terminal ones), sparing any run with a live
+// engine. Each delete runs under the per-run execution lock; the sweep is best-effort, so one run that
+// won't delete doesn't abort the rest.
+func newWorkflowPruneCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:           "prune",
+		Short:         "Delete every run with no live engine (spares running ones)",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			removed, err := subagent.PruneRuns()
+			if err != nil {
+				return reportWorkflowErr(err, asJSON)
+			}
+			if asJSON {
+				return emitWorkflow(workflowEnvelope{OK: true, Removed: removed})
+			}
+			fmt.Printf("pruned %d run(s)\n", removed)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit a machine-readable JSON envelope")
 	return cmd
 }
 
@@ -125,6 +185,8 @@ func newWorkflowRunCmd() *cobra.Command {
 		argsJSON       string
 		noPersistIO    bool
 		budgetUSD      float64
+		budgetTokens   int64
+		noBudget       bool
 		leadSessionID  string
 		saved          string
 		asJSON         bool
@@ -156,7 +218,17 @@ watch the board. --foreground runs inline to completion instead.`,
 			default:
 				return reportWorkflowErr(fmt.Errorf("workflow run needs a script path or --saved <name>"), asJSON)
 			}
-			opts := workflow.Options{RunID: runID, Resume: resume, Concurrency: maxConcurrency, ArgsJSON: argsJSON, NoPersistIO: noPersistIO, BudgetUSD: budgetUSD}
+			// --no-budget clears BOTH caps via the -1 sentinel (normalized to 0 in Launch); an
+			// explicit positive --budget-usd / --budget-tokens wins over it.
+			if noBudget {
+				if budgetUSD == 0 {
+					budgetUSD = -1
+				}
+				if budgetTokens == 0 {
+					budgetTokens = -1
+				}
+			}
+			opts := workflow.Options{RunID: runID, Resume: resume, Concurrency: maxConcurrency, ArgsJSON: argsJSON, NoPersistIO: noPersistIO, BudgetUSD: budgetUSD, BudgetTokens: budgetTokens}
 			// Capture the launching Claude session on a genuine FRESH launch only (the detached
 			// --run-id re-exec reads it back off the manifest; a --resume preserves it), so the
 			// board groups runs by session like the teammates board. An explicit flag wins.
@@ -225,7 +297,11 @@ watch the board. --foreground runs inline to completion instead.`,
 	cmd.Flags().BoolVar(&noPersistIO, "no-persist-io", false,
 		"Don't persist leaf prompts/answers for board drill-in (persistence is default-on)")
 	cmd.Flags().Float64Var(&budgetUSD, "budget-usd", 0,
-		"Cap total vendor spend in USD; agent() fails once reached (0 = uncapped)")
+		"Cap total spend in USD (an Anthropic list-price estimate, not the vendor's actual charge); agent() fails once reached (0 = uncapped)")
+	cmd.Flags().Int64Var(&budgetTokens, "budget-tokens", 0,
+		"Cap total tokens (input+output, the exact vendor-neutral ceiling); agent() fails once reached (0 = uncapped)")
+	cmd.Flags().BoolVar(&noBudget, "no-budget", false,
+		"Uncap both budgets (on resume, override an inherited cap; an explicit --budget-* value wins)")
 	cmd.Flags().StringVar(&leadSessionID, "lead-session-id", "",
 		"Parent Claude session id for board grouping (default: auto-detect)")
 	cmd.Flags().StringVar(&saved, "saved", "",

--- a/internal/config/lock_test.go
+++ b/internal/config/lock_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -123,13 +124,15 @@ func TestWithTeamLock_SerializesGoroutines(t *testing.T) {
 	}
 }
 
-// TestWithTeamLock_DifferentTeamsConcurrent verifies the lock is per-team,
-// not global — two distinct teams can run in parallel.
+// TestWithTeamLock_DifferentTeamsConcurrent verifies the lock is per-team, not
+// global — two distinct teams can hold their locks at the same time. It asserts
+// OVERLAP (the peak count of simultaneous holders reaches 2), not wall-clock
+// time, so it is independent of scheduler jitter (a slow CI runner can't flake
+// it): a global lock would block the second holder on acquire, pinning the peak
+// at 1.
 func TestWithTeamLock_DifferentTeamsConcurrent(t *testing.T) {
 	isolateHome(t)
-	const hold = 100 * time.Millisecond
-
-	start := time.Now()
+	var inside, peak atomic.Int32
 	var wg sync.WaitGroup
 	for _, team := range []string{"teamA", "teamB"} {
 		team := team
@@ -137,19 +140,23 @@ func TestWithTeamLock_DifferentTeamsConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_ = WithTeamLock(team, func() error {
-				time.Sleep(hold)
+				n := inside.Add(1)
+				for { // raise the high-water mark to this holder's count
+					p := peak.Load()
+					if n <= p || peak.CompareAndSwap(p, n) {
+						break
+					}
+				}
+				time.Sleep(100 * time.Millisecond) // hold long enough for the sibling to enter its own lock
+				inside.Add(-1)
 				return nil
 			})
 		}()
 	}
 	wg.Wait()
-	elapsed := time.Since(start)
-	// Two parallel 100ms holders on different locks should finish in well
-	// under 2*hold. We allow up to 1.5*hold for scheduler overhead.
-	max := 3 * hold / 2
-	if elapsed > max {
-		t.Fatalf("two parallel 100ms holders on different teams took %v, want < %v (locks not per-team)",
-			elapsed, max)
+	if peak.Load() < 2 {
+		t.Fatalf("two different-team holders never overlapped (peak concurrency %d) — the per-team lock serialized them like a global lock",
+			peak.Load())
 	}
 }
 

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -67,6 +67,9 @@ type jobMeta struct {
 	// JournalKey is the leaf's content-hash key, carried so finalizeSyncJob/StatusFor can
 	// stamp the terminal Result with it (the board needs it to restart this single leaf).
 	JournalKey string `json:"journal_key,omitempty"`
+	// Attempt is the 1-based schema-retry ordinal this job last ran at (>1 = re-ran on a
+	// schema mismatch); 0 backfills a legacy meta. Carried onto the reconstructed Result.
+	Attempt int `json:"attempt,omitempty"`
 
 	// PersistIO records that this job opted into board drill-in, so finalizeSyncJob
 	// writes the answer side file (<id>.answer) on completion. The result CACHE stays
@@ -386,7 +389,23 @@ func StatusFor(jobID string) Result {
 				r.PromptProfile = meta.PromptProfile
 				r.SlimDowngrade = meta.SlimDowngrade
 			}
+			if r.Attempt == 0 {
+				r.Attempt = meta.Attempt
+			}
 			return r
+		}
+	}
+
+	// A queued placeholder: the workflow engine minted it (PID=0, Status="queued") before the
+	// leaf got a pool slot, and no terminal result is cached yet. Report it AS queued — otherwise
+	// processAlive(0)=false falls through to classify an empty stdout as a dead/failed leaf.
+	if meta.Status == "queued" && meta.PID == 0 {
+		return Result{
+			OK: true, JobID: jobID, Status: "queued",
+			Vendor: meta.Vendor, Model: meta.Model, StartedAt: meta.StartedAt,
+			LeadSessionID: meta.LeadSessionID, RunID: meta.RunID, Phase: meta.Phase, Label: meta.Label,
+			JournalKey: meta.JournalKey, PromptProfile: meta.PromptProfile, SlimDowngrade: meta.SlimDowngrade,
+			Attempt: meta.Attempt,
 		}
 	}
 
@@ -407,6 +426,7 @@ func StatusFor(jobID string) Result {
 			JournalKey:    meta.JournalKey,
 			PromptProfile: meta.PromptProfile,
 			SlimDowngrade: meta.SlimDowngrade,
+			Attempt:       meta.Attempt,
 		}
 	}
 
@@ -427,6 +447,7 @@ func StatusFor(jobID string) Result {
 	res.JournalKey = meta.JournalKey
 	res.PromptProfile = meta.PromptProfile
 	res.SlimDowngrade = meta.SlimDowngrade
+	res.Attempt = meta.Attempt
 	if res.OK {
 		res.Status = "done"
 	} else {
@@ -519,8 +540,8 @@ func GC(olderThan time.Duration) Result {
 		resultPath := filepath.Join(dir, jobID+".result.json")
 		_, resultErr := os.Stat(resultPath)
 		resultCached := resultErr == nil
-		if !resultCached && processAlive(meta.PID, meta.SettingsPath) {
-			continue // truly running (no result cache + alive process)
+		if !resultCached && (processAlive(meta.PID, meta.SettingsPath) || queuedPlaceholder(meta)) {
+			continue // truly running (no result cache + alive process), or a not-yet-started queued leaf
 		}
 		if started, perr := time.Parse(time.RFC3339, meta.StartedAt); perr == nil && started.After(cutoff) {
 			continue // finished but too recent
@@ -680,12 +701,12 @@ func PurgeJobs() (dir string, removedFinished []string, running []string, err er
 		// meta we can't read can't be polled, so it falls through to removal.
 		resultPath := filepath.Join(dir, jobID+".result.json")
 		if _, resultErr := os.Stat(resultPath); resultErr != nil {
-			if meta, merr := readMeta(dir, jobID); merr == nil && processAlive(meta.PID, meta.SettingsPath) {
+			if meta, merr := readMeta(dir, jobID); merr == nil && (processAlive(meta.PID, meta.SettingsPath) || queuedPlaceholder(meta)) {
 				running = append(running, jobID)
 				if meta.RunID != "" {
 					runningRuns[meta.RunID] = true
 				}
-				continue // live → keep this job's file group
+				continue // live (or a not-yet-started queued leaf) → keep this job's file group
 			}
 		}
 		// Finished (or dead / unreadable) → remove its full file group now, even
@@ -739,6 +760,15 @@ func purgeRunManifests(jobsDir string, runningRuns map[string]bool) {
 // procRoot is the procfs mount point. A package var so tests can point the
 // PID-reuse guard at a fixture tree instead of the live /proc.
 var procRoot = "/proc"
+
+// queuedPlaceholder reports whether meta is a workflow queued placeholder the engine minted before
+// the leaf got a pool slot (PID=0, Status="queued", no process yet). GC/PurgeJobs treat it as live —
+// mirroring StatusFor's queued branch — so a `subagent-gc --older-than 0s` (which clears done entries)
+// can't remove an active not-yet-started leaf out from under the engine. It flips to running
+// (registerSyncJob) or terminal (finalize) shortly; a crashed engine's orphan is reaped by run prune/rm.
+func queuedPlaceholder(meta jobMeta) bool {
+	return meta.Status == "queued" && meta.PID == 0
+}
 
 // processAlive reports whether pid is alive AND (when settingsPath is known)
 // still the claude subagent this job launched. A bare kill(pid,0) only proves
@@ -950,11 +980,18 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 		Phase:         req.Phase,
 		Label:         req.Label,
 		JournalKey:    req.JournalKey,
+		Attempt:       req.Attempt,
 		PersistIO:     req.PersistIO,
 		PromptProfile: effective,
 		SlimDowngrade: downgrade,
 		// SettingsPath deliberately empty (see processAlive). Sync writes no .out
 		// file, so the deferred result cache is the authoritative done signal.
+	}
+	// A REUSED job id (the engine's queued→running flip, or a schema retry re-registering an
+	// already-finalized attempt) must start clean: drop any terminal cache + stale answer/activity
+	// so the board re-reads this attempt as running, not the prior done/answer. No-op for a fresh id.
+	for _, ext := range []string{".result.json", ".answer", ".activity"} {
+		_ = os.Remove(filepath.Join(dir, jobID+ext))
 	}
 	if err := writeMetaFn(dir, meta); err != nil {
 		return false
@@ -966,6 +1003,61 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 		_ = os.WriteFile(filepath.Join(dir, jobID+".prompt"), []byte(req.IOPrompt), 0o600)
 	}
 	return true
+}
+
+// MintQueuedLeaf records a leaf the workflow engine has admitted but not yet given a pool slot:
+// a PLACEHOLDER jobMeta with Status="queued" and PID=0 (no process yet), so the board shows it as
+// a queued ◌ row immediately instead of only once it starts running. The engine passes the returned
+// id back as Request.JobID, so the SAME on-disk job flips queued→running (registerSyncJob) →terminal
+// (finalizeSyncJob) as one file. It writes NO prompt/answer (key-safety, same as registerSyncJob).
+// Best-effort: "" on any error, so board bookkeeping never fails the run; an empty id makes the
+// engine fall back to minting at run time.
+func MintQueuedLeaf(req Request, model string) string {
+	jobID := mintSyncJobID()
+	if jobID == "" {
+		return ""
+	}
+	dir, err := jobsDir()
+	if err != nil {
+		return ""
+	}
+	meta := jobMeta{
+		JobID:         jobID,
+		PID:           0, // no process yet — StatusFor reports queued until registerSyncJob flips it
+		Vendor:        req.Vendor,
+		Model:         model,
+		StartedAt:     time.Now().UTC().Format(time.RFC3339),
+		Status:        "queued",
+		OutputFormat:  req.OutputFormat,
+		JSON:          req.JSON,
+		LeadSessionID: req.LeadSessionID,
+		RunID:         req.RunID,
+		Phase:         req.Phase,
+		Label:         req.Label,
+		JournalKey:    req.JournalKey,
+		Attempt:       req.Attempt,
+		PersistIO:     req.PersistIO,
+		PromptProfile: req.PromptProfile,
+	}
+	if err := writeMetaFn(dir, meta); err != nil {
+		return ""
+	}
+	return jobID
+}
+
+// FinalizeQueuedLeafFailed marks a leaf's (reused) job terminal-failed when the engine abandoned it
+// without a success: a queued placeholder cancelled before its slot or whose worktree failed, a
+// pre-flight vendor failure (subagent.Run returned before registering), or a schema-exhausted leaf
+// whose last attempt cached "done". A res carrying a real error class is preserved (so the board keeps
+// e.g. INSUFFICIENT_BALANCE); otherwise a canonical SUBAGENT_FAILED is written. No-op for an empty id.
+func FinalizeQueuedLeafFailed(jobID string, res Result) {
+	if jobID == "" {
+		return
+	}
+	if res.OK || res.ErrorCode == "" {
+		res = fail(ErrCodeFailed, "leaf did not complete", res.Vendor, "")
+	}
+	finalizeSyncJob(jobID, res)
 }
 
 // finalizeSyncJob flips a sync job from running → done/failed by writing a
@@ -1014,6 +1106,7 @@ func finalizeSyncJob(jobID string, res Result) {
 		Phase:          meta.Phase,
 		Label:          meta.Label,
 		JournalKey:     meta.JournalKey,
+		Attempt:        meta.Attempt,
 		PromptProfile:  meta.PromptProfile,
 		SlimDowngrade:  meta.SlimDowngrade,
 	}

--- a/internal/subagent/queued_test.go
+++ b/internal/subagent/queued_test.go
@@ -1,0 +1,170 @@
+package subagent
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMintQueuedLeafThenStatusForQueued: a minted queued placeholder (PID=0, Status="queued", no
+// result cache) is reported BY StatusFor as queued — not classified as a dead/failed empty leaf — and
+// carries its run grouping. registerSyncJob flips the SAME id to running; finalize makes it done.
+func TestMintQueuedLeafThenStatusForQueued(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	req := Request{Vendor: "v", Model: "m", RunID: "r1", Phase: "map", Label: "leaf-a", JournalKey: "k1"}
+	jobID := MintQueuedLeaf(req, "m")
+	if jobID == "" {
+		t.Fatal("MintQueuedLeaf returned empty id")
+	}
+	st := StatusFor(jobID)
+	if st.Status != "queued" {
+		t.Fatalf("StatusFor on a queued placeholder = %q, want queued", st.Status)
+	}
+	if st.RunID != "r1" || st.Phase != "map" || st.Label != "leaf-a" {
+		t.Errorf("queued placeholder lost its run grouping: %+v", st)
+	}
+	// Flip queued→running (subagent.Run reuses the id via registerSyncJob).
+	if !registerSyncJob(jobID, req, "m", "", "") {
+		t.Fatal("registerSyncJob(reuse) failed")
+	}
+	if st := StatusFor(jobID); st.Status != "running" {
+		t.Fatalf("after registerSyncJob, status = %q, want running", st.Status)
+	}
+	// Finalize → done, terminal cache served.
+	finalizeSyncJob(jobID, Result{OK: true, NumTurns: 1})
+	if st := StatusFor(jobID); st.Status != "done" {
+		t.Fatalf("after finalize, status = %q, want done", st.Status)
+	}
+}
+
+// TestRegisterSyncJobClearsStaleCacheOnReuse: re-registering a reused job id (a schema retry on the
+// engine's one-job-per-leaf) drops a prior attempt's terminal cache + answer so the board re-reads it
+// as running, not the stale done; the carried Attempt updates.
+func TestRegisterSyncJobClearsStaleCacheOnReuse(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	req := Request{Vendor: "v", RunID: "r", Phase: "p", Label: "l", PersistIO: true, IOPrompt: "hi", Attempt: 1}
+	jobID := MintQueuedLeaf(req, "m")
+	registerSyncJob(jobID, req, "m", "", "")
+	finalizeSyncJob(jobID, Result{OK: true, Result: "first-answer", NumTurns: 1}) // attempt 1 → done cache + .answer
+	if StatusFor(jobID).Status != "done" {
+		t.Fatal("attempt 1 should be cached done")
+	}
+	// Attempt 2 re-registers the SAME id (schema retry). The stale done cache must be cleared.
+	req2 := req
+	req2.Attempt = 2
+	if !registerSyncJob(jobID, req2, "m", "", "") {
+		t.Fatal("re-register failed")
+	}
+	st := StatusFor(jobID)
+	if st.Status != "running" {
+		t.Fatalf("after re-register, status = %q, want running (stale done cache cleared)", st.Status)
+	}
+	if st.Attempt != 2 {
+		t.Errorf("Attempt after re-register = %d, want 2", st.Attempt)
+	}
+}
+
+// TestFinalizeQueuedLeafFailed: an abandoned queued placeholder finalizes to a terminal failed leaf
+// (no phantom queued ◌ row); a real error class on the passed Result is preserved, else canonical.
+func TestFinalizeQueuedLeafFailed(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	jobID := MintQueuedLeaf(Request{Vendor: "v", RunID: "r", Phase: "p", Label: "l"}, "m")
+	if StatusFor(jobID).Status != "queued" {
+		t.Fatal("placeholder should start queued")
+	}
+	// A pre-flight vendor failure keeps its real error class.
+	FinalizeQueuedLeafFailed(jobID, Result{OK: false, ErrorCode: ErrCodeUnknownVendor, Vendor: "v"})
+	st := StatusFor(jobID)
+	if st.Status != "failed" {
+		t.Fatalf("after finalize, status = %q, want failed (no phantom queued)", st.Status)
+	}
+	if st.ErrorCode != ErrCodeUnknownVendor {
+		t.Errorf("real error class lost: ErrorCode = %q, want %q", st.ErrorCode, ErrCodeUnknownVendor)
+	}
+	// An empty/OK Result falls back to a canonical SUBAGENT_FAILED.
+	j2 := MintQueuedLeaf(Request{Vendor: "v", RunID: "r", Phase: "p", Label: "l2"}, "m")
+	FinalizeQueuedLeafFailed(j2, Result{})
+	if st := StatusFor(j2); st.Status != "failed" || st.ErrorCode != ErrCodeFailed {
+		t.Errorf("canonical fallback: status=%q code=%q, want failed/%s", st.Status, st.ErrorCode, ErrCodeFailed)
+	}
+	FinalizeQueuedLeafFailed("", Result{}) // no-op on an empty id (engine minted nothing)
+}
+
+// TestWorkflowRunBudgetTokensRoundTrip: BudgetTokens survives a SaveRun→ReadRun manifest cycle
+// (additive, omitempty) alongside BudgetUSD.
+func TestWorkflowRunBudgetTokensRoundTrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	run := WorkflowRun{RunID: "rt-tok", StartedAt: "2026-01-01T00:00:00Z", BudgetTokens: 123456, BudgetUSD: 7.5}
+	if err := SaveRun(run); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadRun("rt-tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BudgetTokens != 123456 || got.BudgetUSD != 7.5 {
+		t.Errorf("budget round-trip: BudgetTokens=%d BudgetUSD=%v, want 123456 / 7.5", got.BudgetTokens, got.BudgetUSD)
+	}
+}
+
+// TestPruneRunsSparesLiveDeletesDead: prune removes runs with no live engine (a crashed run still
+// stuck "running", and a terminal run) while sparing a run whose detached engine is verifiably alive.
+func TestPruneRunsSparesLiveDeletesDead(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	orig := reuseGuardArgv
+	t.Cleanup(func() { reuseGuardArgv = orig })
+	// The seam reports the LIVE run's detached-engine argv for any pid, so EngineAlive matches only the
+	// run whose id is "live"; "crashed" (same pid, different id) and "terminal" (pid 0) read as not-alive.
+	reuseGuardArgv = func(int) ([]string, bool) {
+		return []string{"cc-fleet", "workflow", "run", "x.star", "--run-id", "live"}, true
+	}
+	runs := []WorkflowRun{
+		{RunID: "live", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self},
+		{RunID: "crashed", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self},
+		{RunID: "terminal", StartedAt: "2026-01-01T00:00:00Z", Status: "done"},
+		// A foreground / pre-stamp run: still "running" but with no reapable pid — prune must NOT
+		// delete it (it could be writing live), mirroring the resume/restart fail-closed guard.
+		{RunID: "foreground", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0},
+	}
+	for _, r := range runs {
+		if err := SaveRun(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, err := PruneRuns()
+	if err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("removed = %d, want 2 (crashed + terminal pruned; live + foreground spared)", removed)
+	}
+	for _, id := range []string{"live", "foreground"} {
+		if _, err := ReadRun(id); err != nil {
+			t.Errorf("run %q must be spared, got %v", id, err)
+		}
+	}
+	for _, id := range []string{"crashed", "terminal"} {
+		if _, err := ReadRun(id); err == nil {
+			t.Errorf("run %q should have been pruned", id)
+		}
+	}
+}
+
+// TestGCKeepsQueuedPlaceholderUntilTerminal: a `subagent-gc --older-than 0s` (the board's "clear done"
+// sweep, cutoff = now) must NOT remove an active queued placeholder — it has no result cache and PID=0,
+// but it is a not-yet-started leaf, not finished. Once finalized terminal it becomes GC-eligible.
+func TestGCKeepsQueuedPlaceholderUntilTerminal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	jobID := MintQueuedLeaf(Request{Vendor: "v", RunID: "r", Phase: "p", Label: "l"}, "m")
+	GC(0) // no age limit
+	if st := StatusFor(jobID); st.Status != "queued" {
+		t.Fatalf("GC removed an active queued placeholder: status = %q, want queued", st.Status)
+	}
+	FinalizeQueuedLeafFailed(jobID, Result{}) // now terminal (has a result cache)
+	GC(0)
+	if st := StatusFor(jobID); st.OK || st.ErrorCode != ErrCodeBadArgs {
+		t.Errorf("a finalized queued leaf should be GC-reaped; StatusFor = {status:%q code:%q}, want unknown-job", st.Status, st.ErrorCode)
+	}
+}

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -72,6 +72,9 @@ type WorkflowRun struct {
 	ArgsJSON    string  `json:"args_json,omitempty"`
 	NoPersistIO bool    `json:"no_persist_io,omitempty"`
 	BudgetUSD   float64 `json:"budget_usd,omitempty"`
+	// BudgetTokens is the run-level token cap (Usage.InputTokens+OutputTokens summed across
+	// leaves, cache-read excluded); 0 = uncapped. Replayed on resume like BudgetUSD.
+	BudgetTokens int64 `json:"budget_tokens,omitempty"`
 }
 
 // runsDir is ConfigDir/subagent-jobs/runs.
@@ -485,6 +488,42 @@ func PurgeRun(runID string) error {
 	}
 	removeRun(filepath.Join(dir, runsDirName), runID)
 	return nil
+}
+
+// PruneRuns deletes every run whose engine is no longer alive — crashed/killed runs still stuck
+// "running", plus terminal ones — while sparing any run with a live engine. Each delete runs under the
+// per-run execution lock so it can't race a concurrent restart/resume, and the sweep is best-effort:
+// one run that won't delete (an unverifiable-live engine PurgeRun refuses) doesn't abort the rest.
+// Returns the number of runs removed.
+func PruneRuns() (int, error) {
+	runs, err := ListRuns()
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	for _, r := range runs {
+		id := r.RunID
+		_ = WithRunLock(id, func() error {
+			fresh, rerr := ReadRun(id)
+			if rerr != nil || isLiveOrUnverifiable(fresh) {
+				return nil // gone already, or possibly-live → spare it
+			}
+			if perr := PurgeRun(id); perr == nil {
+				removed++
+			}
+			return nil
+		})
+	}
+	return removed, nil
+}
+
+// isLiveOrUnverifiable reports whether a run might still be writing — a verifiably-live detached
+// engine, OR a still-"running" run with no reapable pid (a --foreground run, or a detached run in the
+// mint→stamp-pid window). PruneRuns spares both: deleting under either could yank files from a live
+// engine. Mirrors the fail-closed liveness guard the resume/restart paths use. A terminal run, or a
+// crashed detached run (recorded pid now dead), is not protected — exactly what prune reaps.
+func isLiveOrUnverifiable(run WorkflowRun) bool {
+	return EngineAlive(run) || (run.Status == "running" && run.EnginePID <= 0)
 }
 
 // WaitEngineStopped polls a run's engine liveness until it is gone or the deadline passes (true once

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/childenv"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
+	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/leadsession"
 	"github.com/ethanhq/cc-fleet/internal/profile"
 	"github.com/ethanhq/cc-fleet/internal/vendorclass"
@@ -198,8 +199,15 @@ func Run(req Request) Result {
 	}
 
 	// Mint the job id BEFORE buildArgv so a slim run can write its
-	// <jobID>.slimprompt sidecar and reference it via --system-prompt-file.
-	jobID := mintSyncJobID()
+	// <jobID>.slimprompt sidecar and reference it via --system-prompt-file. A workflow leaf
+	// passes the id of its queued placeholder so the SAME job flips queued→running→terminal
+	// (one file); the bare-CLI path leaves it empty and mints fresh, byte-identical to before.
+	// A reused id becomes a filesystem path component, so validate it (the engine always passes a
+	// uuid; a malformed/path-unsafe id falls back to a fresh mint rather than escaping the jobs dir).
+	jobID := req.JobID
+	if jobID == "" || ids.ValidateJobID(jobID) != nil {
+		jobID = mintSyncJobID()
+	}
 
 	slim, slimErr := buildSlimArgv(effective, jobID, req, model)
 	if slimErr != nil {

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -49,6 +49,15 @@ type Request struct {
 	RunID string // run this job belongs to
 	Phase string // phase label within the run
 	Label string // human label for this agent within the run
+	// JobID, when set, REUSES an existing job record instead of minting a fresh one — the
+	// workflow engine mints a queued placeholder (PID=0) before a leaf gets a pool slot and
+	// passes its id here so the same on-disk job flips queued→running→terminal as ONE file.
+	// Empty (the bare-CLI path) mints a fresh id, byte-identical to before.
+	JobID string
+	// Attempt is the 1-based schema-retry ordinal (1 = first try). The engine sets it per
+	// retry so the board can show "attempt N" for a leaf that re-ran on a schema mismatch.
+	// Zero (a non-schema or non-workflow call) renders no marker.
+	Attempt int
 
 	// PersistIO opts this job into board drill-in: persist the prompt + answer to
 	// per-job 0600 side files (<id>.prompt / <id>.answer) for the Workflows detail card.
@@ -123,6 +132,9 @@ type Result struct {
 	// JournalKey is the leaf's content-hash key, persisted so the board can restart THIS leaf
 	// (invalidate its journal entry + resume). A sha256 hex — never a secret.
 	JournalKey string `json:"journal_key,omitempty"`
+	// Attempt is the 1-based schema-retry ordinal the leaf ran at (>1 means it re-ran on a
+	// schema mismatch); 0 backfills a legacy cache that predates the field.
+	Attempt int `json:"attempt,omitempty"`
 
 	// PromptProfile is the EFFECTIVE profile this run used (post-version-gate);
 	// SlimDowngrade is non-empty when a slim request ran full instead (the reason).

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -482,10 +482,11 @@ func stopRunCmd(runID string, epoch int) tea.Cmd {
 }
 
 // restartCmd restarts a run via workflow.Restart: an empty journalKey resumes the WHOLE run
-// (re-running only un-journaled / failed leaves); a leaf's journalKey drops just that leaf's cache
-// so the resume re-runs only it (+ any downstream leaf whose input shifted). workflow.Restart stops
-// a live run first, replays the run's original launch options off the manifest, and (for a keyed
-// restart) invalidates the leaf's journal entry. epoch gates a stale result like stopRunCmd.
+// (re-running only un-journaled / failed leaves); a leaf's journalKey additionally drops that leaf's
+// cache so the resume re-runs it (+ any downstream leaf whose input shifted). On a still-running run
+// the engine is stopped first, so every in-flight sibling that had not journaled re-runs too — a keyed
+// restart is scoped to the one leaf only once the run is already terminal. workflow.Restart replays the
+// run's original launch options off the manifest. epoch gates a stale result like stopRunCmd.
 func restartCmd(runID, journalKey string, epoch int) tea.Cmd {
 	return func() tea.Msg {
 		err := workflow.Restart(context.Background(), runID, journalKey)
@@ -1422,9 +1423,11 @@ func (m Model) clampCardScroll(v int) int {
 	}
 }
 
-// restartFocusedLeaf restarts ONLY the focused agent — workflow.Restart drops its journal entry and
-// resumes, re-running just this leaf (+ any downstream leaf whose input shifted). A leaf with no
-// persisted JournalKey falls back to a whole-run restart so r is never a silent no-op.
+// restartFocusedLeaf restarts the focused agent — workflow.Restart drops its journal entry and resumes,
+// re-running it (+ any downstream leaf whose input shifted). On a still-running run the engine is stopped
+// first, so every un-journaled in-flight sibling re-runs as well; the single-leaf scope is exact only once
+// the run is terminal. A leaf with no persisted JournalKey falls back to a whole-run restart so r is never
+// a silent no-op.
 // wfBusy reports whether a stop/restart/delete is already in flight for runID — the in-flight guard
 // that makes a second x/r/d on the same run a no-op until its workflowCtlMsg lands.
 func (m Model) wfBusy(runID string) bool { return m.wfRestarting[runID] }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -338,11 +338,22 @@ func indentBox(s string, n int) string {
 	return pad + strings.ReplaceAll(s, "\n", "\n"+pad)
 }
 
-// phaseAgentCounts / runAgentCounts return (done, total) where done counts terminal (non-running) leaves.
+// isTerminalLeaf reports whether a leaf status is finished. cached counts as done (it completed in a
+// prior run and is being replayed); queued / running / "" (not-yet-started) are all in-progress — so a
+// queued placeholder never inflates the done counter into showing a phase complete before any work runs.
+func isTerminalLeaf(status string) bool {
+	switch status {
+	case "done", "failed", "stopped", "cached":
+		return true
+	}
+	return false
+}
+
+// phaseAgentCounts / runAgentCounts return (done, total) where done counts only TERMINAL leaves.
 func phaseAgentCounts(p runPhaseGroup) (done, total int) {
 	for _, j := range p.jobs {
 		total++
-		if j.Status != "" && j.Status != "running" {
+		if isTerminalLeaf(j.Status) {
 			done++
 		}
 	}
@@ -358,14 +369,17 @@ func runAgentCounts(g runGroup) (done, total int) {
 	return
 }
 
-// runTokens sums the input+output tokens across every leaf of the run — the live snapshot for a running
-// leaf, the final Result for a done one (the same source as the per-leaf "tok" column).
+// runTokens sums each leaf's cumulative OUTPUT tokens across the run — the run header's "↓ tokens".
+// Output is the one cross-leaf-additive figure (the generated text accumulates); input is each leaf's
+// PEAK context window, so summing it across leaves is dimensionally meaningless — the header shows
+// output only, and per-leaf input lives in the agent detail (↑ ctx). Live snapshot while running, the
+// final Result once done. Cache-read is excluded throughout.
 func (m Model) runTokens(g runGroup) int {
 	total := 0
 	for _, p := range g.phases {
 		for _, j := range p.jobs {
-			in, out, _ := m.leafCounts(j)
-			total += in + out
+			_, out, _ := m.leafCounts(j)
+			total += out
 		}
 	}
 	return total
@@ -681,10 +695,11 @@ func (m Model) viewWfAgent() string {
 }
 
 // renderAgentRowFull is one agent row for a phase's agent list (right pane): "<dot> <label>  <model>"
-// left, "<tok> tok · <N> tools · <dur>" RIGHT-ALIGNED to width. Live tokens/tools for a RUNNING leaf
-// come from its activity snapshot; a done leaf uses its final Result metrics. No answer text.
+// left, "↓ <out> out · <N> tools · <dur>" RIGHT-ALIGNED to width — output tokens only, so the rows sum
+// to the header total (input is the leaf's peak context, shown per-leaf in the detail, never summed).
+// Live for a RUNNING leaf from its activity snapshot; a done leaf uses its final Result. No answer text.
 func (m Model) renderAgentRowFull(j subagent.Result, width int) string {
-	in, out, tools := m.leafCounts(j)
+	_, out, tools := m.leafCounts(j)
 	label := sessiontitle.CleanTitle(j.Label)
 	model := sessiontitle.CleanTitle(j.Model)
 	left := statusDot(j.Status) + " "
@@ -699,7 +714,7 @@ func (m Model) renderAgentRowFull(j subagent.Result, width int) string {
 	default:
 		left += faintStyle.Render("agent")
 	}
-	metrics := fmt.Sprintf("%s tok · %d tools", humanTokens(in+out), tools)
+	metrics := fmt.Sprintf("↓ %s out · %d tools", humanTokens(out), tools)
 	if d := leafDuration(j); d != "" {
 		metrics += " · " + d
 	}
@@ -749,9 +764,11 @@ func leafDuration(j subagent.Result) string {
 	return fmt.Sprintf("%dm %ds", int(d/time.Minute), int(d.Seconds())%60)
 }
 
-// leafCounts returns the leaf's (input, output) tokens + tool-call count: live from the activity
-// snapshot (a monotonic count) while running, the accurate final from the Result once done. Tool
-// count always comes from the snapshot (the final Result doesn't carry it).
+// leafCounts returns the leaf's (input, output) tokens + tool-call count. input is the PEAK context
+// window (max over turns, non-cumulative — so it is shown per-leaf, never summed across leaves);
+// output is CUMULATIVE generated tokens (additive, what the run header sums); cache-read is excluded.
+// Live from the activity snapshot while running, the accurate final from the Result once done; the
+// tool count always comes from the snapshot (the final Result doesn't carry it).
 func (m Model) leafCounts(j subagent.Result) (in, out, tools int) {
 	if j.Usage != nil {
 		in, out = j.Usage.InputTokens, j.Usage.OutputTokens
@@ -763,8 +780,9 @@ func (m Model) leafCounts(j subagent.Result) (in, out, tools int) {
 	return in, out, snap.toolCount()
 }
 
-// agentDetailLines is the focused agent's inline detail (the L2 right pane, scrollable): status/model and
-// tokens·tool-calls, then a fixed Prompt → Activity → Output → Outcome order — the Prompt, the Activity
+// agentDetailLines is the focused agent's inline detail (the L2 right pane, scrollable): status/model
+// (with an "attempt N" marker on a schema re-run) and ↑ ctx · ↓ out · tool-calls, then a fixed
+// Prompt → Activity → Output → Outcome order — the Prompt, the Activity
 // feed (last 3 tool signatures), the Output (when the io files are loaded for THIS leaf via the PersistIO
 // opt-in), and the Outcome. The Output reads from the leaf's .answer side file (focused-single-agent
 // surface, CleanTitle-scrubbed), NEVER Result.Result on a row.
@@ -775,9 +793,15 @@ func (m Model) agentDetailLines(rightW int) []string {
 	}
 	in, out, tools := m.leafCounts(j)
 	snap := m.wfActivity[j.JobID]
+	status := statusLabel(j.Status) + faintStyle.Render(" · "+trunc(sessiontitle.CleanTitle(j.Model), 28))
+	if j.Attempt > 1 {
+		// A schema-retry leaf re-ran on a rejected reply; surface which attempt it landed on.
+		status += faintStyle.Render(fmt.Sprintf(" · attempt %d", j.Attempt))
+	}
 	lines := []string{
-		statusLabel(j.Status) + faintStyle.Render(" · "+trunc(sessiontitle.CleanTitle(j.Model), 28)),
-		faintStyle.Render(fmt.Sprintf("%s tok · %d tool calls", humanTokens(in+out), tools)),
+		status,
+		// ↑ peak input context · ↓ cumulative output (the header sums only output across leaves).
+		faintStyle.Render(fmt.Sprintf("↑ %s ctx · ↓ %s out · %d tool calls", humanTokens(in), humanTokens(out), tools)),
 	}
 	// Prompt first.
 	switch {
@@ -942,11 +966,11 @@ func wrapTo(s string, w int) []string {
 }
 
 // renderOutcome is the key-safe outcome line: status + a canonical summary, NEVER Result.Result. A
-// done leaf shows "done · N turns"; a failed one its error class; a running one "Still running…".
+// done leaf shows "done · N turns"; a failed one its error class; a running/queued one "Still running…".
 func (m Model) renderOutcome(j subagent.Result) string {
 	switch {
-	case j.Status == "running" || j.Status == "":
-		return faintStyle.Render("Still running…")
+	case j.Status == "running" || j.Status == "queued" || j.Status == "":
+		return faintStyle.Render("Still running…") // queued has OK=true but isn't done — keep it in-progress
 	case j.OK || j.Status == "done":
 		return faintStyle.Render(fmt.Sprintf("done · %d turns", j.NumTurns))
 	default:

--- a/internal/tui/workflow_board_test.go
+++ b/internal/tui/workflow_board_test.go
@@ -67,8 +67,9 @@ func TestWfPhasesPane(t *testing.T) {
 	}
 }
 
-// TestWfAgentRow_LiveTokens: a running leaf's tokens + tool count come from the live activity
-// snapshot (not the still-empty final Result); a done leaf uses its final Result metrics.
+// TestWfAgentRow_LiveTokens: a running leaf's OUTPUT tokens + tool count come from the live activity
+// snapshot (not the still-empty final Result); a done leaf uses its final Result. The row shows output
+// only (↓), so the leaf's input (its peak context) never inflates it — honest cross-leaf-summable tokens.
 func TestWfAgentRow_LiveTokens(t *testing.T) {
 	jobs, runs := oneRun()
 	activity := map[string]activitySnapshot{
@@ -78,21 +79,22 @@ func TestWfAgentRow_LiveTokens(t *testing.T) {
 	// Move to the build phase (the running leaf) so its row renders on the right.
 	m, _ = press(t, m, "down")
 	out := m.viewWorkflows()
-	if !strings.Contains(out, "12.8k tok") {
-		t.Fatalf("running leaf should show live tokens (12.8k) from the snapshot:\n%s", out)
+	if !strings.Contains(out, "↓ 800 out") {
+		t.Fatalf("running leaf should show its live OUTPUT tokens (800) from the snapshot, not in+out:\n%s", out)
 	}
 	if !strings.Contains(out, "2 tools") {
 		t.Fatalf("running leaf should show the live tool count (2):\n%s", out)
 	}
-	// The done leaf (map phase) shows its final 51.9k (50.7k in + 1.2k out) once re-selected.
+	// The done leaf (map phase) shows its final 1.2k OUTPUT once re-selected (the 50.7k input is the
+	// peak context, shown per-leaf in the detail card as "↑ ctx", never summed on the row).
 	m, _ = press(t, m, "up")
-	if out := m.viewWorkflows(); !strings.Contains(out, "51.9k tok") {
-		t.Fatalf("done leaf should show final tokens:\n%s", out)
+	if out := m.viewWorkflows(); !strings.Contains(out, "↓ 1.2k out") {
+		t.Fatalf("done leaf should show its final output tokens (1.2k):\n%s", out)
 	}
 }
 
-// TestWfAgentCard: drilling into a phase shows the agent detail card with status/model, tok·tools,
-// the Activity last-3 feed, and the Outcome line.
+// TestWfAgentCard: drilling into a phase shows the agent detail card with status/model, ↑ ctx · ↓ out
+// · tool-calls, the Activity last-3 feed, and the Outcome line.
 func TestWfAgentCard(t *testing.T) {
 	jobs, runs := oneRun()
 	activity := map[string]activitySnapshot{
@@ -505,8 +507,8 @@ func TestWfDelete_TwoPressConfirm(t *testing.T) {
 func TestWfAgentRow_LabelThenModelThenMetrics(t *testing.T) {
 	jobs, runs := oneRun()
 	out := workflowsModel(t, jobs, runs, nil).viewWorkflows() // phases view, map phase's agent m1
-	// "tok ·" is the agent row's metric marker; the run-header total uses "tokens", so anchor on the former.
-	li, mi, ti := strings.Index(out, "m1"), strings.Index(out, "glm-4.6"), strings.Index(out, "tok ·")
+	// "out ·" is the agent row's output-token metric marker; the run-header total uses "tokens", so anchor on the former.
+	li, mi, ti := strings.Index(out, "m1"), strings.Index(out, "glm-4.6"), strings.Index(out, "out ·")
 	if li < 0 || mi < 0 || ti < 0 || !(li < mi && mi < ti) {
 		t.Fatalf("agent row should read label → model → metrics (idx %d,%d,%d):\n%s", li, mi, ti, out)
 	}
@@ -718,5 +720,69 @@ func TestWfPicker_FullSessionIdAndTitle(t *testing.T) {
 	}
 	if !strings.Contains(out, "sess-untitled-long") {
 		t.Fatalf("an untitled session should show its full id (not truncated):\n%s", out)
+	}
+}
+
+// TestPhaseAgentCountsTerminalOnly: the done counter counts only TERMINAL leaves — done/failed/stopped/
+// cached — so a queued or running leaf is in-progress and never inflates a phase to "complete" early.
+func TestPhaseAgentCountsTerminalOnly(t *testing.T) {
+	p := runPhaseGroup{jobs: []subagent.Result{
+		{Status: "done"}, {Status: "cached"}, {Status: "failed"}, // terminal
+		{Status: "queued"}, {Status: "running"}, {Status: ""}, // in-progress
+	}}
+	done, total := phaseAgentCounts(p)
+	if total != 6 {
+		t.Errorf("total = %d, want 6", total)
+	}
+	if done != 3 {
+		t.Errorf("done = %d, want 3 (done/cached/failed terminal; queued/running/\"\" in-progress)", done)
+	}
+}
+
+// TestWfAgentCardAttemptMarker: a leaf that re-ran on a schema mismatch (Attempt>1) shows a faint
+// "attempt N" in its detail card; a first-attempt leaf shows none.
+func TestWfAgentCardAttemptMarker(t *testing.T) {
+	runs := []subagent.WorkflowRun{{
+		RunID: "run-1", Name: "n", StartedAt: "2026-06-01T00:00:00Z", Phases: []subagent.RunPhase{{Title: "map"}},
+	}}
+	jobs := []subagent.Result{{RunID: "run-1", Phase: "map", Label: "m1", Model: "glm-4.6", Status: "done", Attempt: 2, JobID: "j1", NumTurns: 1}}
+	m := workflowsModel(t, jobs, runs, nil)
+	m, _ = press(t, m, "enter") // drill into the agent detail card
+	if out := m.viewWorkflows(); !strings.Contains(out, "attempt 2") {
+		t.Fatalf("a re-run leaf (Attempt=2) should show 'attempt 2':\n%s", out)
+	}
+
+	jobs[0].Attempt = 1 // first attempt → no marker
+	m = workflowsModel(t, jobs, runs, nil)
+	m, _ = press(t, m, "enter")
+	if out := m.viewWorkflows(); strings.Contains(out, "attempt") {
+		t.Fatalf("a first-attempt leaf must show no attempt marker:\n%s", out)
+	}
+}
+
+// TestWfNewSurfacesKeySafe: the queued row, attempt marker, and token figure render only canonical
+// status + integer tokens — never the leaf's answer/error. A canary key + a NUL planted in a leaf's
+// Result/ErrorMsg must not reach the rendered board.
+func TestWfNewSurfacesKeySafe(t *testing.T) {
+	const canary = "sk-CANARYdeadbeef12345678"
+	runs := []subagent.WorkflowRun{{
+		RunID: "run-1", Name: "n", StartedAt: "2026-06-01T00:00:00Z", Phases: []subagent.RunPhase{{Title: "map"}},
+	}}
+	jobs := []subagent.Result{{
+		RunID: "run-1", Phase: "map", Label: "m1", Status: "queued", Attempt: 2, JobID: "j1",
+		Result:   canary + "\x00",  // the (never-rendered-on-a-row) answer
+		ErrorMsg: "boom " + canary, // a raw error
+		Usage:    &subagent.Usage{InputTokens: 40000, OutputTokens: 1200},
+	}}
+	m := workflowsModel(t, jobs, runs, nil)
+	out := m.viewWorkflows() // phases view: the queued row + its token figure
+	if strings.Contains(out, "sk-CANARY") {
+		t.Fatalf("the queued row must never render the leaf's answer/error (canary key leaked):\n%q", out)
+	}
+	if strings.ContainsRune(out, '\x00') {
+		t.Fatalf("a NUL from the leaf's answer must never reach the board")
+	}
+	if !strings.Contains(out, "↓ 1.2k out") {
+		t.Errorf("the queued leaf should still show its integer output tokens:\n%s", out)
 	}
 }

--- a/internal/workflow/background.go
+++ b/internal/workflow/background.go
@@ -37,6 +37,11 @@ type bgHandle struct {
 	resolved bool      // result already known (journal cache hit on resume)
 	cached   string    // the cached result, when resolved
 	deadline time.Time // wall-clock timeout enforced at wait() (zero = none); the launch itself is deadline-less
+	// est/estTok carry the leaf's budget RESERVATION from launchBg through to resolveHandle, which
+	// releases it (and charges the real cost) at await. A resolved handle (journal hit) never
+	// reserved, so both stay 0 and its release is a no-op.
+	est    float64
+	estTok int64
 	// display/event tags
 	vendor, model, phase, label string
 }
@@ -60,11 +65,15 @@ type slimReq struct {
 
 // launchBg starts a leaf detached (subagent --background) and returns a handle. It admits
 // against the lifetime cap but takes NO live-pool slot (a detached leaf isn't bounded by
-// the in-process pool); its result is journaled at await time, not now. GIL-held caller.
-func (e *engine) launchBg(vendor, model, prompt, phaseTag, label, key string, timeoutSec, maxBudget float64, maxTurns int, slim slimReq) (starlark.Value, error) {
+// the in-process pool); its result is journaled at await time, not now. It owns the budget
+// RESERVATION for the detached leaf: it reserves (usdEst, tokEst) before the launch, releases on a
+// launch failure, and carries the estimate on the handle so resolveHandle frees it (and charges
+// real) at await. GIL-held caller.
+func (e *engine) launchBg(vendor, model, prompt, phaseTag, label, key string, timeoutSec, maxBudget float64, maxTurns int, usdEst float64, tokEst int64, slim slimReq) (starlark.Value, error) {
 	if !e.sched.admit() {
 		return nil, fmt.Errorf("agent: run exceeded the %d-leaf lifetime cap", maxLifetimeAgents)
 	}
+	e.budgetReserve(usdEst, tokEst)
 	e.emitLeaf("launch", phaseTag, label, vendor, model)
 	var res subagent.Result
 	e.sched.runBlocking(func() {
@@ -90,10 +99,11 @@ func (e *engine) launchBg(vendor, model, prompt, phaseTag, label, key string, ti
 		})
 	})
 	if !res.OK {
+		e.budgetRelease(usdEst, tokEst) // launch failed → no handle will carry the reservation; free it here
 		e.emitLeaf("failed", phaseTag, label, vendor, model)
 		return nil, fmt.Errorf("agent(%s): background launch: %s: %s", vendor, res.ErrorCode, res.ErrorMsg)
 	}
-	h := &bgHandle{jobID: res.JobID, key: key, vendor: vendor, model: model, phase: phaseTag, label: label}
+	h := &bgHandle{jobID: res.JobID, key: key, est: usdEst, estTok: tokEst, vendor: vendor, model: model, phase: phaseTag, label: label}
 	// A detached background job outlives the launcher, so its timeout is enforced at wait() (resolveHandle
 	// reaps an overrun); with no script timeout it falls back to the backstop so an AWAITED leaf can never
 	// poll forever.
@@ -153,6 +163,15 @@ func (e *engine) resolveHandle(h *bgHandle) (starlark.Value, error) {
 		e.emitLeaf("cached", h.phase, h.label, h.vendor, h.model)
 		return starlark.String(h.cached), nil
 	}
+	// Free the leaf's budget reservation on EVERY terminal exit below (timeout / cancel / fail /
+	// success); success charges its real cost first. Registered AFTER the resolved short-circuit
+	// (a resolved handle never reserved), and runs GIL-held on the unwind. Zero the estimate after
+	// releasing so awaiting the SAME handle again (its failure paths don't set resolved) can't double-
+	// release and free another leaf's reservation.
+	defer func() {
+		e.budgetRelease(h.est, h.estTok)
+		h.est, h.estTok = 0, 0
+	}()
 	var res subagent.Result
 	cancelled, timedOut := false, false
 	e.sched.runBlocking(func() {
@@ -186,10 +205,10 @@ func (e *engine) resolveHandle(h *bgHandle) (starlark.Value, error) {
 		e.emitLeaf("failed", h.phase, h.label, h.vendor, h.model)
 		return nil, fmt.Errorf("agent(%s, background): %s: %s", h.vendor, res.ErrorCode, res.ErrorMsg)
 	}
-	e.budgetSpent += res.CostUSD
+	e.budgetCharge(res.CostUSD, leafTokens(res))
 	e.journal.append(h.key, res.Result)
 	// Mark resolved so a second wait(h) returns the cached result instead of re-polling,
-	// double-counting CostUSD, and appending a duplicate journal entry.
+	// double-counting cost, and appending a duplicate journal entry.
 	h.resolved = true
 	h.cached = res.Result
 	e.emitLeaf("done", h.phase, h.label, h.vendor, h.model)

--- a/internal/workflow/budget.go
+++ b/internal/workflow/budget.go
@@ -3,17 +3,88 @@ package workflow
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"go.starlark.net/starlark"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
-// budgetValue is the predeclared `budget` object, mirroring native: budget.total
-// (Float, or None when no cap is set), budget.spent() (Float, USD spent so far), and
-// budget.remaining() (Float; +Inf when uncapped). It is a thin view over the engine's
-// GIL-protected accounting (budgetTotal / budgetSpent), so every read happens
-// single-threaded under the GIL — no separate lock. agent() enforces the cap (raises
-// once spent >= total before launching a new leaf), and accumulates each completed
-// leaf's CostUSD; a journal cache hit costs nothing.
+// defaultLeafEstimate / defaultLeafTokenEstimate are the per-leaf pessimistic RESERVATION an
+// in-flight leaf holds against its budget cap until it reconciles to its real cost. Each is a
+// deliberate over-estimate of a typical leaf, so a concurrent fan-out can't admit the whole batch
+// against a near-zero spent and overshoot the cap by the in-flight set; reconcile-to-real frees the
+// estimate the moment a leaf finishes, so they are tunable pessimism floors, not hard ceilings (a
+// single leaf whose real cost exceeds its estimate still overshoots by that bounded error).
+const (
+	defaultLeafEstimate      = 1.0    // USD per leaf (a leaf's own max_budget_usd wins when larger)
+	defaultLeafTokenEstimate = 50_000 // tokens per leaf
+)
+
+// budgetWouldExceed reports whether reserving (usd, tok) more would breach EITHER active cap —
+// the first-to-trip-aborts gate. An unset cap (total<=0) never trips. GIL-held callers only.
+func (e *engine) budgetWouldExceed(usd float64, tok int64) bool {
+	if e.budgetTotal > 0 && e.budgetSpent+e.budgetReserved+usd > e.budgetTotal {
+		return true
+	}
+	if e.budgetTokensTotal > 0 && e.budgetTokensSpent+e.budgetTokensReserved+tok > e.budgetTokensTotal {
+		return true
+	}
+	return false
+}
+
+// budgetReserve / budgetRelease move a leaf's pessimistic estimate in/out of *Reserved; budgetCharge
+// books its reconciled real cost into *Spent. This is the SINGLE reservation mechanism both caps
+// share (USD + tokens). GIL-held callers only, so the counters stay exact across a parallel fan-out.
+func (e *engine) budgetReserve(usd float64, tok int64) {
+	e.budgetReserved += usd
+	e.budgetTokensReserved += tok
+}
+
+func (e *engine) budgetRelease(usd float64, tok int64) {
+	if e.budgetReserved -= usd; e.budgetReserved < 0 {
+		e.budgetReserved = 0
+	}
+	if e.budgetTokensReserved -= tok; e.budgetTokensReserved < 0 {
+		e.budgetTokensReserved = 0
+	}
+}
+
+func (e *engine) budgetCharge(usd float64, tok int64) {
+	e.budgetSpent += usd
+	e.budgetTokensSpent += tok
+}
+
+// budgetExceededErr is the gate's refusal, naming only the active cap(s): USD (a list-price
+// estimate) and/or tokens (exact). GIL-held caller.
+func (e *engine) budgetExceededErr() error {
+	var parts []string
+	if e.budgetTotal > 0 {
+		parts = append(parts, fmt.Sprintf("$%.4f of $%.2f (list-price estimate)", e.budgetSpent+e.budgetReserved, e.budgetTotal))
+	}
+	if e.budgetTokensTotal > 0 {
+		parts = append(parts, fmt.Sprintf("%d of %d tokens", e.budgetTokensSpent+e.budgetTokensReserved, e.budgetTokensTotal))
+	}
+	return fmt.Errorf("agent: budget exceeded — %s", strings.Join(parts, "; "))
+}
+
+// leafTokens is a completed leaf's token spend: input + output (the growing context plus the
+// generated text), EXCLUDING cache-read — the exact, vendor-neutral unit --budget-tokens caps.
+func leafTokens(res subagent.Result) int64 {
+	if res.Usage == nil {
+		return 0
+	}
+	return int64(res.Usage.InputTokens + res.Usage.OutputTokens)
+}
+
+// budgetValue is the predeclared `budget` object, mirroring native: budget.total / .spent() /
+// .remaining() report the USD cap (a Float, or None/+Inf when uncapped) and tokens_total /
+// tokens_spent() / tokens_remaining() report the token cap (an Int, or None/a large int when
+// uncapped). The USD figure is an Anthropic LIST-PRICE estimate (claude's own metering, not the
+// third-party vendor's actual charge); the token figure (input+output, cache-read excluded) is the
+// exact vendor-neutral count. It is a thin view over the engine's GIL-protected accounting, so every
+// read happens single-threaded under the GIL — no separate lock. agent() enforces the caps (the
+// first to trip aborts) and books each completed leaf's real cost; a journal cache hit costs nothing.
 type budgetValue struct{ e *engine }
 
 var (
@@ -27,11 +98,15 @@ func (b budgetValue) Freeze()               {}
 func (b budgetValue) Truth() starlark.Bool  { return starlark.True }
 func (b budgetValue) Hash() (uint32, error) { return 0, fmt.Errorf("budget is unhashable") }
 
-func (b budgetValue) AttrNames() []string { return []string{"remaining", "spent", "total"} }
+func (b budgetValue) AttrNames() []string {
+	return []string{"remaining", "spent", "tokens_remaining", "tokens_spent", "tokens_total", "total"}
+}
 
-// Attr returns budget.total (Float|None) or the spent()/remaining() methods. A method
-// reads the engine's budget fields under the GIL (all Starlark runs under it), so the
-// value is consistent even when called from a parallel/pipeline goroutine.
+// Attr returns budget.total / tokens_total (Float|Int|None) or the spent()/remaining() methods. A
+// method reads the engine's budget fields under the GIL (all Starlark runs under it), so the value is
+// consistent even when called from a parallel/pipeline goroutine. The token figures mirror the USD
+// ones in Int: tokens_total is None when uncapped; tokens_remaining is MaxInt64 when uncapped (the
+// Int analog of the USD +Inf, so a `while budget.tokens_remaining() > N` loop stays unbounded).
 func (b budgetValue) Attr(name string) (starlark.Value, error) {
 	switch name {
 	case "total":
@@ -49,6 +124,22 @@ func (b budgetValue) Attr(name string) (starlark.Value, error) {
 				return starlark.Float(math.Inf(1)), nil
 			}
 			return starlark.Float(b.e.budgetTotal - b.e.budgetSpent), nil
+		}), nil
+	case "tokens_total":
+		if b.e.budgetTokensTotal <= 0 {
+			return starlark.None, nil // uncapped
+		}
+		return starlark.MakeInt64(b.e.budgetTokensTotal), nil
+	case "tokens_spent":
+		return starlark.NewBuiltin("tokens_spent", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+			return starlark.MakeInt64(b.e.budgetTokensSpent), nil
+		}), nil
+	case "tokens_remaining":
+		return starlark.NewBuiltin("tokens_remaining", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+			if b.e.budgetTokensTotal <= 0 {
+				return starlark.MakeInt64(math.MaxInt64), nil
+			}
+			return starlark.MakeInt64(b.e.budgetTokensTotal - b.e.budgetTokensSpent), nil
 		}), nil
 	}
 	return nil, nil // unknown attribute → Starlark reports "budget has no .<name>"

--- a/internal/workflow/budget_test.go
+++ b/internal/workflow/budget_test.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"context"
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,22 +13,150 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
+// TestNormalizeBudgetSentinels: the --no-budget -1 sentinel becomes 0 (explicit uncap); 0 and positive
+// values pass through — so the engine and manifest never see -1, and a token cap survives a USD uncap.
+func TestNormalizeBudgetSentinels(t *testing.T) {
+	cases := []struct {
+		inUSD, wantUSD float64
+		inTok, wantTok int64
+	}{
+		{-1, 0, -1, 0},
+		{0, 0, 0, 0},
+		{20, 20, 500_000, 500_000},
+		{-1, 0, 500_000, 500_000}, // uncap USD, keep the token cap
+	}
+	for _, c := range cases {
+		opts := Options{BudgetUSD: c.inUSD, BudgetTokens: c.inTok}
+		normalizeBudgetSentinels(&opts)
+		if opts.BudgetUSD != c.wantUSD || opts.BudgetTokens != c.wantTok {
+			t.Errorf("normalize($%v,%d) = ($%v,%d), want ($%v,%d)", c.inUSD, c.inTok, opts.BudgetUSD, opts.BudgetTokens, c.wantUSD, c.wantTok)
+		}
+	}
+}
+
+// TestResumeBudgetInheritAndUncap exercises uncap-on-resume through the real Launch→manifest path: a
+// plain resume inherits both caps off the manifest; --no-budget (the -1 sentinel) durably uncaps BOTH
+// to 0 (the engine never persists -1). Foreground so it runs inline without a detached child.
+func TestResumeBudgetInheritAndUncap(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	rec := &recorder{}
+	old := runLeaf
+	runLeaf = echoLeaf(rec)
+	t.Cleanup(func() { runLeaf = old })
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "w.star")
+	if err := os.WriteFile(script, []byte("meta = {\"name\": \"n\", \"description\": \"d\"}\nx = agent(\"a\", vendor=\"v\")\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := Launch(ctx, script, Options{BudgetUSD: 20, BudgetTokens: 500_000}, true)
+	if err != nil {
+		t.Fatalf("fresh run: %v", err)
+	}
+	if r, _ := subagent.ReadRun(id); r.BudgetUSD != 20 || r.BudgetTokens != 500_000 {
+		t.Fatalf("fresh manifest budgets = $%v / %d tok, want 20 / 500000", r.BudgetUSD, r.BudgetTokens)
+	}
+
+	if _, err := Launch(ctx, script, Options{Resume: id}, true); err != nil {
+		t.Fatalf("plain resume: %v", err)
+	}
+	if r, _ := subagent.ReadRun(id); r.BudgetUSD != 20 || r.BudgetTokens != 500_000 {
+		t.Errorf("plain resume should inherit both caps, got $%v / %d", r.BudgetUSD, r.BudgetTokens)
+	}
+
+	if _, err := Launch(ctx, script, Options{Resume: id, BudgetUSD: -1, BudgetTokens: -1}, true); err != nil {
+		t.Fatalf("uncap resume: %v", err)
+	}
+	if r, _ := subagent.ReadRun(id); r.BudgetUSD != 0 || r.BudgetTokens != 0 {
+		t.Errorf("--no-budget resume should durably uncap to 0/0, got $%v / %d", r.BudgetUSD, r.BudgetTokens)
+	}
+}
+
 func costLeaf(rec *recorder, usd float64) func(subagent.Request) subagent.Result {
 	return fakeLeaf(rec, func(c leafCall) subagent.Result {
 		return subagent.Result{OK: true, Result: "ok:" + c.prompt, CostUSD: usd}
 	})
 }
 
-// TestBudgetCapsRun: with a $1.00 cap and $0.50/leaf, the 3rd agent() (spent already
-// $1.00 >= cap) raises a budget error and aborts the run — exactly 2 leaves executed.
+func tokenLeaf(rec *recorder, in, out int) func(subagent.Request) subagent.Result {
+	return fakeLeaf(rec, func(c leafCall) subagent.Result {
+		return subagent.Result{OK: true, Result: "ok:" + c.prompt, Usage: &subagent.Usage{InputTokens: in, OutputTokens: out}}
+	})
+}
+
+// TestTokenBudgetCapsRun: the token cap aborts the run like the USD cap, via the same reservation
+// (a flat 50_000-token estimate per leaf). With a 100_000-token cap and 50_000 real tokens/leaf
+// (input 40k + output 10k = the reservation, so the gate is exact) exactly 2 leaves run, then the 3rd
+// aborts. The USD cap is unset (CostUSD 0), so only the token cap gates.
+func TestTokenBudgetCapsRun(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	rec := &recorder{}
+	old := runLeaf
+	runLeaf = tokenLeaf(rec, 40_000, 10_000)
+	t.Cleanup(func() { runLeaf = old })
+
+	eng := &engine{sched: newScheduler(context.Background(), 1), runID: "tbud", budgetTokensTotal: 100_000}
+	_, err := eng.run("b.star", `
+for i in range(10):
+    agent("x%d" % i, vendor="v")
+`, Options{})
+	if err == nil || !strings.Contains(err.Error(), "token") {
+		t.Fatalf("expected a token-budget-exceeded error, got %v", err)
+	}
+	if n := len(rec.prompts()); n != 2 {
+		t.Errorf("ran %d leaves, want 2 (cap 100k tokens at 50k/leaf)", n)
+	}
+}
+
+// TestBudgetTokenObject: the budget object exposes the token cap as Int — tokens_total / tokens_spent()
+// / tokens_remaining() reflect summed input+output (cache-read excluded), uncapped reads None/MaxInt64.
+func TestBudgetTokenObject(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	rec := &recorder{}
+	old := runLeaf
+	runLeaf = tokenLeaf(rec, 40_000, 10_000) // 50k tokens/leaf
+	t.Cleanup(func() { runLeaf = old })
+
+	eng := &engine{sched: newScheduler(context.Background(), 1), runID: "tbud2", budgetTokensTotal: 1_000_000}
+	g, err := eng.run("b.star", `
+agent("a", vendor="v")
+agent("b", vendor="v")
+ts = budget.tokens_spent()
+tr = budget.tokens_remaining()
+tt = budget.tokens_total
+uncapped_total = budget.total
+`, Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if i, _ := starlark.AsInt32(g["ts"]); i != 100_000 {
+		t.Errorf("tokens_spent = %v, want 100000", g["ts"])
+	}
+	if i, _ := starlark.AsInt32(g["tr"]); i != 900_000 {
+		t.Errorf("tokens_remaining = %v, want 900000", g["tr"])
+	}
+	if i, _ := starlark.AsInt32(g["tt"]); i != 1_000_000 {
+		t.Errorf("tokens_total = %v, want 1000000", g["tt"])
+	}
+	if g["uncapped_total"] != starlark.None {
+		t.Errorf("USD total (uncapped) = %v, want None", g["uncapped_total"])
+	}
+}
+
+// TestBudgetCapsRun: the USD cap aborts the run via the pessimistic reservation. Each leaf reserves
+// max(its max_budget_usd, the $1.00 default) = $1.00 against the cap until it reconciles to real; with
+// a $2.00 cap and $1.00/leaf (reservation == real, so the gate is exact) exactly 2 leaves run, then the
+// 3rd (spent $2.00 + its $1.00 reservation > $2.00) aborts.
 func TestBudgetCapsRun(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	rec := &recorder{}
 	old := runLeaf
-	runLeaf = costLeaf(rec, 0.5)
+	runLeaf = costLeaf(rec, 1.0)
 	t.Cleanup(func() { runLeaf = old })
 
-	eng := &engine{sched: newScheduler(context.Background(), 1), runID: "bud", budgetTotal: 1.0}
+	eng := &engine{sched: newScheduler(context.Background(), 1), runID: "bud", budgetTotal: 2.0}
 	_, err := eng.run("b.star", `
 for i in range(10):
     agent("x%d" % i, vendor="v")
@@ -35,7 +165,33 @@ for i in range(10):
 		t.Fatalf("expected a budget-exceeded error, got %v", err)
 	}
 	if n := len(rec.prompts()); n != 2 {
-		t.Errorf("ran %d leaves, want 2 (cap $1.00 at $0.50/leaf)", n)
+		t.Errorf("ran %d leaves, want 2 (cap $2.00 at $1.00/leaf)", n)
+	}
+}
+
+// TestBudgetReservationBoundsConcurrentOvershoot: a parallel() fan-out under a cap used to admit EVERY
+// leaf while spent was still ~0 (the charge only lands at completion), so a $20 cap could overshoot to
+// $90. With the pessimistic reservation, a concurrent batch admits against spent+reserved, so the real
+// total spend never exceeds the cap by more than ONE leaf's estimate.
+func TestBudgetReservationBoundsConcurrentOvershoot(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	rec := &recorder{}
+	old := runLeaf
+	// Each leaf costs $1.00 — exactly its reservation, so spent tracks reserved with no slack.
+	runLeaf = costLeaf(rec, 1.0)
+	t.Cleanup(func() { runLeaf = old })
+
+	// A $5.00 cap with a wide pool: parallel(20) leaves all race the gate. Without reservation every
+	// one would admit (spent ~0) and charge → $20 spent. With it, admission stops near the cap.
+	eng := &engine{sched: newScheduler(context.Background(), 8), runID: "bres", budgetTotal: 5.0}
+	_, _ = eng.run("b.star", `
+parallel([lambda i=i: agent("x%d" % i, vendor="v") for i in range(20)])
+`, Options{})
+	if spent := eng.budgetSpent; spent > 5.0+1.0 { // cap + one leaf's estimate (the accepted residual)
+		t.Errorf("real spend $%.2f overshot the $5.00 cap by more than one leaf's $1.00 estimate", spent)
+	}
+	if eng.budgetReserved != 0 {
+		t.Errorf("every reservation must be released; budgetReserved = %v, want 0", eng.budgetReserved)
 	}
 }
 

--- a/internal/workflow/builtins.go
+++ b/internal/workflow/builtins.go
@@ -42,10 +42,20 @@ type engine struct {
 	sessionID string // parent Claude session (board grouping); seeded from the manifest, re-persisted every save
 	cwd       string // launching project dir (board run header); seeded from the manifest, re-persisted every save
 	argsJSON  string // --args-json, re-persisted so a restart resumes with the SAME args (else leaf keys shift)
-	// Budget accounting (USD), GIL-protected. budgetTotal<=0 means uncapped. budgetSpent
-	// accumulates each completed leaf's CostUSD; agent() raises once spent>=total.
-	budgetTotal float64
-	budgetSpent float64
+	// Budget accounting, GIL-protected. A cap (<=0 = uncapped) trips on the FIRST of two
+	// counters to breach: USD (an Anthropic list-price ESTIMATE — claude's own metering, not
+	// the third-party vendor's actual charge) and tokens (Usage.InputTokens+OutputTokens, the
+	// exact vendor-neutral ceiling). *Spent accumulates each completed leaf's real cost; *Reserved
+	// holds a pessimistic per-leaf estimate from the budget gate until the leaf reconciles to real,
+	// so a concurrent fan-out admits leaves against spent+reserved (not spent alone) and can't
+	// overshoot the cap by the whole in-flight set. See budgetReserve/budgetRelease/budgetCharge.
+	budgetTotal    float64
+	budgetSpent    float64
+	budgetReserved float64
+	// Token cap twin of the USD fields (int64, exact). budgetTokensTotal<=0 = uncapped.
+	budgetTokensTotal    int64
+	budgetTokensSpent    int64
+	budgetTokensReserved int64
 }
 
 // builtins returns the predeclared environment exposed to a workflow script. It
@@ -269,23 +279,65 @@ func (e *engine) agent(thread *starlark.Thread, b *starlark.Builtin, args starla
 		}
 	}
 
-	// Budget gate: a real exec is about to spend, so refuse once the cap is reached.
-	// Placed AFTER the journal lookup (a cache hit is free and never blocked) and BEFORE
-	// admit/slot. budgetTotal<=0 is uncapped. GIL-held → budgetSpent is exact.
-	if e.budgetTotal > 0 && e.budgetSpent >= e.budgetTotal {
-		return nil, fmt.Errorf("agent: budget exceeded ($%.4f of $%.2f spent)", e.budgetSpent, e.budgetTotal)
+	// Budget gate: a real exec is about to spend, so refuse once a cap would be breached.
+	// Placed AFTER the journal lookup (a cache hit is free and never blocked) and BEFORE the
+	// bg branch + admit/slot. A leaf RESERVES a pessimistic per-leaf estimate against each cap
+	// so a concurrent fan-out admits against spent+reserved — not spent alone — and can't
+	// overshoot the cap by the whole in-flight set; the estimate reconciles to real on completion.
+	// The USD estimate over-counts a typical leaf (its own max_budget_usd wins when larger); the
+	// token estimate is the flat per-leaf floor. The gate→reserve is GIL-held (atomic), so a
+	// parallel fan-out's leaves serialize through it. First cap to trip aborts.
+	usdEst := defaultLeafEstimate
+	if maxBudget > usdEst {
+		usdEst = maxBudget
+	}
+	tokEst := int64(defaultLeafTokenEstimate)
+	if e.budgetWouldExceed(usdEst, tokEst) {
+		return nil, e.budgetExceededErr()
 	}
 
-	// Background leaf: launch detached, return a handle (NO live-pool slot; result is
-	// journaled at await time). launchBg does its own lifetime admit.
+	// Background leaf: launch detached, return a handle (NO live-pool slot; result is journaled at
+	// await time). launchBg does its own lifetime admit AND owns the reservation lifecycle — it
+	// reserves before the launch and carries the estimate on the handle so resolveHandle releases
+	// (and charges real) at await; a launch failure releases there.
 	if runInBackground {
 		return e.launchBg(vendor, model, prompt, phaseTag, label, key, timeoutSec, maxBudget, maxTurns,
-			slimReq{profile: profile, tools: keyTools, noSkills: !skills, mcp: mcp})
+			usdEst, tokEst, slimReq{profile: profile, tools: keyTools, noSkills: !skills, mcp: mcp})
 	}
 
 	if !e.sched.admit() {
 		return nil, fmt.Errorf("agent: run exceeded the %d-leaf lifetime cap", maxLifetimeAgents)
 	}
+
+	// Reserve this sync leaf's estimate (GIL-held, atomic with the gate above), then register the
+	// release defer — placed AFTER the reservation so it never over-releases a cache-hit/bg return,
+	// and it runs GIL-held on the unwind (like the slot defer below), covering EVERY exit beyond
+	// here (slot-fail, worktree-fail, leaf-fail, schema-exhausted, panic, success). Success charges
+	// real BEFORE returning, so the defer then frees only the estimate.
+	e.budgetReserve(usdEst, tokEst)
+	defer e.budgetRelease(usdEst, tokEst)
+
+	// Mint a queued placeholder (PID=0) so the board shows this leaf as a queued ◌ row WHILE it
+	// waits for a pool slot; subagent.Run reuses this id, flipping the same job queued→running→
+	// terminal as one file. The mint writes a file, so it runs GIL-released (like the slot wait).
+	var queuedJobID string
+	e.sched.runBlocking(func() {
+		queuedJobID = mintQueuedLeaf(subagent.Request{
+			Vendor: vendor, RunID: e.runID, Phase: phaseTag, Label: label,
+			JournalKey: key, PersistIO: e.persistIO, PromptProfile: profile,
+		}, model)
+	})
+	// Guarantee the reused job ends terminal: unless a success return sets leafDone, this defer
+	// finalizes it FAILED on EVERY other exit (slot-cancel, worktree-fail, pre-flight vendor fail,
+	// schema-exhausted, panic) — so a queued placeholder never lingers and a schema-invalid "done"
+	// attempt is corrected. leafErr carries a real failure's error class (preserved); else canonical.
+	leafDone := false
+	var leafErr subagent.Result
+	defer func() {
+		if !leafDone {
+			subagent.FinalizeQueuedLeafFailed(queuedJobID, leafErr)
+		}
+	}()
 
 	// Acquire a pool slot with the GIL released, so waiting for a slot never pins the
 	// interpreter. The slot is held ONLY across this leaf's actual exec and released right
@@ -336,7 +388,9 @@ func (e *engine) agent(thread *starlark.Thread, b *starlark.Builtin, args starla
 			RunID:          e.runID,
 			Phase:          phaseTag,
 			Label:          label,
-			JournalKey:     key, // persisted so the board can restart THIS leaf (invalidate + resume)
+			JobID:          queuedJobID, // reuse the queued placeholder: one job, queued→running→terminal
+			Attempt:        i + 1,       // 1-based schema-retry ordinal; the board shows "attempt N" when >1
+			JournalKey:     key,         // persisted so the board can restart THIS leaf (invalidate + resume)
 			PersistIO:      e.persistIO,
 			StreamActivity: e.persistIO, // sync leaf streams tool/usage activity for the board (gated like PersistIO)
 			IOPrompt:       sendPrompt,  // persisted only when PersistIO (subagent gates)
@@ -351,18 +405,23 @@ func (e *engine) agent(thread *starlark.Thread, b *starlark.Builtin, args starla
 		var res subagent.Result
 		e.sched.runBlocking(func() { res = runLeaf(req) })
 		if !res.OK {
+			leafErr = res // a pre-flight fail (no Run registration) keeps its real error class on the job
 			e.emitLeaf("failed", phaseTag, label, vendor, model)
 			return nil, fmt.Errorf("agent(%s): %s: %s", vendor, res.ErrorCode, res.ErrorMsg)
 		}
-		// Accumulate every OK exec's cost (incl. each schema-retry attempt) under the GIL.
-		e.budgetSpent += res.CostUSD
+		// Book every OK exec's real cost (incl. each schema-retry attempt) under the GIL: USD
+		// (claude's list-price estimate) + tokens (input+output). The reservation is freed by the
+		// defer at return; charging before it keeps spent+reserved monotonic for concurrent gates.
+		e.budgetCharge(res.CostUSD, leafTokens(res))
 		if schemaJSON == "" {
+			leafDone = true // subagent.Run finalized this job done; keep it
 			e.journal.append(key, res.Result)
 			e.emitLeaf("done", phaseTag, label, vendor, model)
 			return starlark.String(res.Result), nil
 		}
 		v, verr := decodeAndValidate(thread, res.Result, schemaVal)
 		if verr == nil {
+			leafDone = true
 			e.journal.append(key, res.Result)
 			e.emitLeaf("done", phaseTag, label, vendor, model)
 			return v, nil
@@ -611,11 +670,12 @@ func (e *engine) saveManifest(status, errText string) {
 		EnginePID:   e.enginePID,
 		// Carried in engine state so every whole-file overwrite preserves them (the board
 		// groups by SessionID; a restart resumes with the same args/persistIO/budget).
-		SessionID:   e.sessionID,
-		Cwd:         e.cwd,
-		ArgsJSON:    e.argsJSON,
-		NoPersistIO: !e.persistIO,
-		BudgetUSD:   e.budgetTotal,
+		SessionID:    e.sessionID,
+		Cwd:          e.cwd,
+		ArgsJSON:     e.argsJSON,
+		NoPersistIO:  !e.persistIO,
+		BudgetUSD:    e.budgetTotal,
+		BudgetTokens: e.budgetTokensTotal,
 	})
 }
 

--- a/internal/workflow/e2e_unix_test.go
+++ b/internal/workflow/e2e_unix_test.go
@@ -290,7 +290,7 @@ func runComprehensiveGlobals(t *testing.T, env *e2eEnv, runID string, opts Optio
 		persistIO:   !opts.NoPersistIO,
 		metaModel:   meta.Model,
 		whenToUse:   meta.WhenToUse,
-		budgetTotal: opts.BudgetUSD,
+		budgetTotal: opts.BudgetUSD, budgetTokensTotal: opts.BudgetTokens,
 	}
 	if jp, jerr := subagent.RunJournalPath(runID); jerr == nil {
 		eng.journal = loadJournal(jp)
@@ -635,7 +635,7 @@ func resumeAt(t *testing.T, env *e2eEnv, runID, mainPath string, opts Options) s
 		sched: newScheduler(context.Background(), opts.Concurrency), runID: runID,
 		name: meta.Name, description: meta.Description, startedAt: prepared.StartedAt, phases: phases,
 		persistIO: !opts.NoPersistIO, metaModel: meta.Model, whenToUse: meta.WhenToUse,
-		budgetTotal: opts.BudgetUSD,
+		budgetTotal: opts.BudgetUSD, budgetTokensTotal: opts.BudgetTokens,
 	}
 	if jp, jerr := subagent.RunJournalPath(runID); jerr == nil {
 		eng.journal = loadJournal(jp)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -42,6 +42,11 @@ var fileOptions = &syntax.FileOptions{
 // key-safe via apiKeyHelper, board-registered, tagged with run/phase/label).
 var runLeaf = subagent.Run
 
+// mintQueuedLeaf records a leaf's queued placeholder (PID=0) before it gets a pool slot — a seam so
+// the fake-leaf unit tests opt out of the disk side effect by stubbing it to return "". Production =
+// subagent.MintQueuedLeaf; the engine reuses the returned id as Request.JobID (queued→running flip).
+var mintQueuedLeaf = subagent.MintQueuedLeaf
+
 // resolveProfile maps a REQUESTED prompt profile to the effective one (the version
 // gate), pre-keying. A seam so tests drive the downgrade path without a real claude
 // binary. Production loads the fingerprint the same way Run does and resolves the
@@ -76,9 +81,15 @@ type Options struct {
 	// answer-stripped either way, so the board table is unaffected. Propagated to the
 	// detached child so the whole run honors it.
 	NoPersistIO bool
-	// BudgetUSD caps total vendor spend (sum of leaf CostUSD); agent() raises once the cap
-	// is reached. <=0 is uncapped. Propagated to the detached child.
+	// BudgetUSD caps total vendor spend in USD (a sum of leaf CostUSD — an Anthropic list-price
+	// estimate, not the third-party vendor's actual charge); agent() raises once the cap would be
+	// breached. <=0 is uncapped; a -1 sentinel from --no-budget is normalized to 0 (explicit uncap)
+	// in Launch before any persist. Propagated to the detached child.
 	BudgetUSD float64
+	// BudgetTokens caps total vendor token spend (Usage.InputTokens+OutputTokens summed across
+	// leaves, cache-read excluded — the exact vendor-neutral ceiling); <=0 uncapped, -1 normalized
+	// to 0 like BudgetUSD. The first cap to trip aborts. Propagated to the detached child.
+	BudgetTokens int64
 	// LeadSessionID is the parent Claude session this run was launched from (detected at
 	// `workflow run`). Stored on the manifest at mint so the board groups runs by session.
 	// Used only by Launch's fresh-mint path; a resume reads it back off the manifest.
@@ -139,6 +150,9 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 	if verr := subagent.ValidateRunID(runID); verr != nil {
 		return fmt.Errorf("workflow: invalid run id: %w", verr)
 	}
+	// Normalize the -1 uncap sentinel here too, not only in Launch: the detached `--run-id` re-exec
+	// reaches Execute directly, so the engine and its manifest writes never see a negative budget.
+	normalizeBudgetSentinels(&opts)
 	// Seed the engine's authoritative manifest state from the Prepare-minted manifest
 	// (best-effort) + the script's meta. The engine then OWNS the manifest, overwriting
 	// it whole on every phase()/finalize — so there is no read-modify-write to race and
@@ -180,14 +194,15 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 	eng := &engine{
 		sched: newScheduler(ctx, concurrency), runID: runID,
 		name: meta.Name, description: meta.Description, startedAt: startedAt, phases: phases,
-		persistIO:   !opts.NoPersistIO, // the board's inline prompt/answer detail is default-on
-		enginePID:   detachedEnginePID(opts),
-		metaModel:   meta.Model, // default model for agents that omit model=
-		whenToUse:   meta.WhenToUse,
-		budgetTotal: opts.BudgetUSD,
-		sessionID:   prepared.SessionID, // from the minted manifest; re-persisted on every save
-		cwd:         prepared.Cwd,       // launching project dir; ditto
-		argsJSON:    opts.ArgsJSON,
+		persistIO:         !opts.NoPersistIO, // the board's inline prompt/answer detail is default-on
+		enginePID:         detachedEnginePID(opts),
+		metaModel:         meta.Model, // default model for agents that omit model=
+		whenToUse:         meta.WhenToUse,
+		budgetTotal:       opts.BudgetUSD,
+		budgetTokensTotal: opts.BudgetTokens,
+		sessionID:         prepared.SessionID, // from the minted manifest; re-persisted on every save
+		cwd:               prepared.Cwd,       // launching project dir; ditto
+		argsJSON:          opts.ArgsJSON,
 	}
 	// Load the run's content-hash journal (resume). The path is derived from the
 	// already-validated runID; a missing file (a fresh run) yields an empty cache that
@@ -258,6 +273,18 @@ func (eng *engine) run(scriptPath string, src interface{}, opts Options) (starla
 	return g, err
 }
 
+// normalizeBudgetSentinels turns the --no-budget -1 sentinel into 0 (explicit uncap) for both caps,
+// so the engine and the manifest only ever see >=0 (0 = uncapped). Called AFTER the resume-inherit
+// decision and before any persist, so -1 never inherits the old cap and is never written.
+func normalizeBudgetSentinels(opts *Options) {
+	if opts.BudgetUSD < 0 {
+		opts.BudgetUSD = 0
+	}
+	if opts.BudgetTokens < 0 {
+		opts.BudgetTokens = 0
+	}
+}
+
 // Launch is the entry for `cc-fleet workflow run`. It prepares the run (parse + meta +
 // mint), then either runs it inline (foreground — the debug / deterministic-e2e path)
 // or re-execs cc-fleet as a DETACHED child that runs it to completion off the launching
@@ -295,9 +322,9 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		// Replay the run's original launch options on resume so a leaf's content key — and thus
 		// its journal-cache validity — doesn't shift. A non-zero/non-empty opts value overrides
 		// (e.g. resuming with a larger --budget-usd); a zero/empty one reads as "not set" and
-		// inherits the manifest. The corollary — you can't override TO the zero value on resume
-		// (uncap a capped run, blank the args) — is a faithful-continuation tradeoff, not a real
-		// use case (the CLI can't express it and Restart wants the inherit).
+		// inherits the manifest. The one way to override TO uncapped is --no-budget, which arrives
+		// as a -1 sentinel: it is non-zero so it skips the inherit, then normalizes to 0 (uncapped)
+		// below — so a capped run CAN be resumed uncapped. (Args/persistIO have no such sentinel.)
 		if opts.ArgsJSON == "" {
 			opts.ArgsJSON = existing.ArgsJSON
 		}
@@ -307,6 +334,15 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		if opts.BudgetUSD == 0 {
 			opts.BudgetUSD = existing.BudgetUSD
 		}
+		if opts.BudgetTokens == 0 {
+			opts.BudgetTokens = existing.BudgetTokens
+		}
+		// Normalize the -1 uncap sentinel to 0 AFTER the inherit decision (so -1 never inherits),
+		// then re-stamp the budgets onto the manifest so an uncap is durable from resume time — the
+		// engine never persists -1, and never re-caps a run the user just uncapped.
+		normalizeBudgetSentinels(&opts)
+		run.BudgetUSD = opts.BudgetUSD
+		run.BudgetTokens = opts.BudgetTokens
 		// Restamp liveness + flip to running BEFORE detaching, so a concurrent GC can't
 		// prune this (possibly old) run's manifest + journal in the window before the
 		// resumed engine writes its first heartbeat (GC recency keys on the later of
@@ -325,11 +361,15 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		}
 		run = minted
 		// Stamp the session + replay options onto the manifest BEFORE the child reads it, so
-		// the board can group by session and a later restart resumes with the same inputs.
+		// the board can group by session and a later restart resumes with the same inputs. A fresh
+		// --no-budget is a no-op (already uncapped) but still normalize -1→0 so the manifest never
+		// persists the sentinel.
+		normalizeBudgetSentinels(&opts)
 		run.SessionID = opts.LeadSessionID
 		run.ArgsJSON = opts.ArgsJSON
 		run.NoPersistIO = opts.NoPersistIO
 		run.BudgetUSD = opts.BudgetUSD
+		run.BudgetTokens = opts.BudgetTokens
 		if cwd, cerr := os.Getwd(); cerr == nil {
 			run.Cwd = cwd
 		}

--- a/internal/workflow/journal.go
+++ b/internal/workflow/journal.go
@@ -128,11 +128,13 @@ func (j *journal) append(key, result string) {
 }
 
 // removeJournalKey rewrites a run's journal file, dropping EVERY entry whose key matches —
-// the board's single-leaf restart primitive. A leaf's content key can appear more than once
+// the journal half of the board's single-leaf restart. A leaf's content key can appear more than once
 // (identical agent() calls share it; they are interchangeable by construction), so dropping
 // all matching entries re-runs that whole interchangeable set rather than corrupting the
 // FIFO queue by removing a positional one. On the next resume the dropped leaf finds no cache
-// and re-runs live; content-addressing then re-runs any downstream leaf whose input shifted.
+// and re-runs live; content-addressing then re-runs any downstream leaf whose input shifted. The
+// "single-leaf" scope is precise only for an already-terminal run: the caller (Restart) stops a live
+// engine first, and a stopped engine leaves every in-flight sibling un-journaled, so those re-run too.
 //
 // A missing journal (nothing cached yet) or an absent key (e.g. a leaf that failed last time,
 // never journaled) is a no-op success — the leaf re-runs on resume regardless. The rewrite

--- a/internal/workflow/launch.go
+++ b/internal/workflow/launch.go
@@ -57,6 +57,9 @@ func launchDetached(scriptPath, runID string, opts Options) (int, *detachedReape
 	if opts.BudgetUSD > 0 {
 		argv = append(argv, "--budget-usd", strconv.FormatFloat(opts.BudgetUSD, 'f', -1, 64))
 	}
+	if opts.BudgetTokens > 0 {
+		argv = append(argv, "--budget-tokens", strconv.FormatInt(opts.BudgetTokens, 10))
+	}
 	devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {
 		return 0, nil, fmt.Errorf("workflow: open %s: %w", os.DevNull, err)

--- a/internal/workflow/t3_main_test.go
+++ b/internal/workflow/t3_main_test.go
@@ -43,6 +43,11 @@ func runEngineChild(args []string) int {
 		case "--budget-usd":
 			i++
 			opts.BudgetUSD, _ = strconv.ParseFloat(args[i], 64)
+		case "--budget-tokens":
+			i++
+			opts.BudgetTokens, _ = strconv.ParseInt(args[i], 10, 64)
+		case "--no-budget":
+			opts.BudgetUSD, opts.BudgetTokens = -1, -1
 		default:
 			if script == "" && args[i] != "" && args[i][0] != '-' {
 				script = args[i]


### PR DESCRIPTION
This branch hardens the `cc-fleet workflow` runtime along four axes — budget accuracy, board observability, restart honesty, and CLI completeness — without touching the spawn pipeline, the journal key, or the four flock scopes.

Budgets:

- The USD cap is relabeled in help and prose as an Anthropic list-price estimate (claude's own metering, not the third-party vendor's actual charge); the `total_cost_usd` JSON tag is unchanged. A new run-level `--budget-tokens` caps the exact vendor-neutral count (input + output, cache-read excluded), and the first of the two caps to trip aborts.
- Both caps now gate through one pessimistic per-leaf reservation: a leaf reserves `max(its max_budget_usd, $1.00)` plus a flat token estimate at admission and reconciles to its real cost on completion, so a concurrent `parallel()` fan-out admits against spent-plus-reserved rather than spent alone. This closes the overshoot where a run admitted every leaf while spent was still near zero (a $20 cap could reach ~$90); the real total now overshoots by at most one leaf's estimate, and the reservation is freed on every exit including a background leaf's `await` and a panic.
- The `budget` object gains `tokens_total` / `tokens_spent()` / `tokens_remaining()` mirroring the USD trio. `--no-budget` clears both caps and, on resume, durably overrides an inherited cap (a `-1` sentinel normalized to `0` before any persist, so the engine and manifest never see it; an explicit positive `--budget-*` still wins). No budget field enters the content-hash journal key.

Observability:

- A leaf waiting for a pool slot is now minted as a queued placeholder job and reused as the running job's id, so one on-disk job flips queued → running → terminal; a queued leaf renders as a faint `◌`, counts as in-progress rather than done, and a leaf cancelled before its slot is finalized so no phantom queued row survives.
- A leaf re-run on a schema mismatch reuses that one job and shows a faint "attempt N" (only when greater than one); re-registering the job clears the prior attempt's terminal cache so a retry is never shadowed as done.
- The run-header token total now sums per-leaf cumulative output only — input is each leaf's peak context, shown per-leaf as `↑ ctx · ↓ out` and never summed across leaves, since that figure is not additive.

Restart honesty and CLI:

- The single-leaf restart comments and docs now state that restarting one leaf of a still-running run stops the engine first, so every un-journaled in-flight sibling (and any downstream leaf whose input shifts) re-runs too — the single-leaf scope is exact only once the run is terminal. No mechanism change.
- `cc-fleet workflow rm <id>` deletes a run and its jobs (stop-then-delete under the per-run lock; a run whose engine cannot be confirmed dead aborts), and `cc-fleet workflow prune` drops every run whose engine is no longer alive while sparing a verifiably-live or unverifiable-running one.

Every new board, CLI, and job surface stays key-safe by field source — only masked or CleanTitle-scrubbed metadata, integer token counts, and a focused leaf's own prompt/answer reach the terminal, never raw output or a key. All new persisted fields are additive and backfill on read, so old manifests and caches keep loading. Verified at T1 across the affected packages: `go test -race ./...`, `go vet`, and `gofmt` are clean (the pre-existing `TestSlimCaptureFirstRequest` capture test fails identically on `main` from an installed-claude tool-set drift, unrelated to this change).
