### PR TITLE
feat(workflow): close native-parity gaps and fix two status-read bugs

### DIFF
--- a/cmd/cc-fleet/workflow.go
+++ b/cmd/cc-fleet/workflow.go
@@ -21,18 +21,23 @@ import (
 // CLI's own envelope (one per invocation), deliberately separate from
 // subagent.Result so a workflow shape change never bloats that contract.
 type workflowEnvelope struct {
-	OK        bool                     `json:"ok"`
-	RunID     string                   `json:"run_id,omitempty"`
-	Name      string                   `json:"name,omitempty"`
-	Phases    []subagent.RunPhase      `json:"phases,omitempty"`
-	Status    string                   `json:"status,omitempty"`
-	StartedAt string                   `json:"started_at,omitempty"`
-	Runs      []subagent.WorkflowRun   `json:"runs,omitempty"`
-	Jobs      []subagent.Result        `json:"jobs,omitempty"`
-	Saved     []subagent.SavedWorkflow `json:"saved,omitempty"`
-	Removed   int                      `json:"removed,omitempty"`   // rm/prune: number of runs deleted
-	RunError  string                   `json:"run_error,omitempty"` // a failed run's cause (distinct from the command-level Error)
-	Error     string                   `json:"error,omitempty"`
+	OK        bool                `json:"ok"`
+	RunID     string              `json:"run_id,omitempty"`
+	Name      string              `json:"name,omitempty"`
+	Phases    []subagent.RunPhase `json:"phases,omitempty"`
+	Status    string              `json:"status,omitempty"`
+	StartedAt string              `json:"started_at,omitempty"`
+	// Run-level budget caps + live cumulative spend, so `status` surfaces a running total.
+	BudgetUSD    float64                  `json:"budget_usd,omitempty"`
+	BudgetTokens int64                    `json:"budget_tokens,omitempty"`
+	SpentUSD     float64                  `json:"spent_usd,omitempty"`
+	SpentTokens  int64                    `json:"spent_tokens,omitempty"`
+	Runs         []subagent.WorkflowRun   `json:"runs,omitempty"`
+	Jobs         []subagent.Result        `json:"jobs,omitempty"`
+	Saved        []subagent.SavedWorkflow `json:"saved,omitempty"`
+	Removed      int                      `json:"removed,omitempty"`   // rm/prune: number of runs deleted
+	RunError     string                   `json:"run_error,omitempty"` // a failed run's cause (distinct from the command-level Error)
+	Error        string                   `json:"error,omitempty"`
 }
 
 // newWorkflowCmd builds `cc-fleet workflow` — run orchestration over subagent
@@ -430,9 +435,23 @@ func newWorkflowStatusCmd() *cobra.Command {
 					OK: true, RunID: run.RunID, Name: run.Name,
 					Phases: run.Phases, Status: run.Status, StartedAt: run.StartedAt,
 					RunError: run.Error, Jobs: jobs,
+					BudgetUSD: run.BudgetUSD, BudgetTokens: run.BudgetTokens,
+					SpentUSD: run.SpentUSD, SpentTokens: run.SpentTokens,
 				})
 			}
 			fmt.Printf("run %s  %s  %s\n", run.RunID, run.Name, run.Status)
+			if run.SpentUSD > 0 || run.SpentTokens > 0 {
+				line := fmt.Sprintf("  spent: $%.4f · %d tokens", run.SpentUSD, run.SpentTokens)
+				switch { // 0 means uncapped — only name a cap that is actually set
+				case run.BudgetUSD > 0 && run.BudgetTokens > 0:
+					line += fmt.Sprintf("  (cap $%.2f / %d tok)", run.BudgetUSD, run.BudgetTokens)
+				case run.BudgetUSD > 0:
+					line += fmt.Sprintf("  (cap $%.2f)", run.BudgetUSD)
+				case run.BudgetTokens > 0:
+					line += fmt.Sprintf("  (cap %d tok)", run.BudgetTokens)
+				}
+				fmt.Println(line)
+			}
 			if run.Error != "" {
 				fmt.Printf("  error: %s\n", run.Error)
 			}

--- a/internal/subagent/cache_usage_test.go
+++ b/internal/subagent/cache_usage_test.go
@@ -1,0 +1,16 @@
+package subagent
+
+import "testing"
+
+// A success envelope's cache_creation_input_tokens (the prompt-cache WRITE cost) is parsed onto
+// Result.Usage alongside input/output/cache-read, so the board can surface it.
+func TestClassifyCarriesCacheCreationTokens(t *testing.T) {
+	js := `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":3,"cache_creation_input_tokens":7}}`
+	res := classify(Request{Vendor: "v", JSON: true}, "m", []byte(js), nil, 0, false, true)
+	if res.Usage == nil {
+		t.Fatal("nil usage")
+	}
+	if res.Usage.CacheCreationInputTokens != 7 {
+		t.Errorf("cache_creation = %d, want 7", res.Usage.CacheCreationInputTokens)
+	}
+}

--- a/internal/subagent/classify.go
+++ b/internal/subagent/classify.go
@@ -41,9 +41,10 @@ type innerEnvelope struct {
 }
 
 type innerUsage struct {
-	InputTokens          int `json:"input_tokens"`
-	OutputTokens         int `json:"output_tokens"`
-	CacheReadInputTokens int `json:"cache_read_input_tokens"`
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 }
 
 // classify turns a finished claude invocation into a Result. It never returns
@@ -102,9 +103,10 @@ func classify(req Request, model string, stdout, stderr []byte, exitCode int, ti
 		}
 		if inner.Usage != nil {
 			res.Usage = &Usage{
-				InputTokens:          inner.Usage.InputTokens,
-				OutputTokens:         inner.Usage.OutputTokens,
-				CacheReadInputTokens: inner.Usage.CacheReadInputTokens,
+				InputTokens:              inner.Usage.InputTokens,
+				OutputTokens:             inner.Usage.OutputTokens,
+				CacheReadInputTokens:     inner.Usage.CacheReadInputTokens,
+				CacheCreationInputTokens: inner.Usage.CacheCreationInputTokens,
 			}
 		}
 		return res

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -1163,9 +1163,12 @@ func finalizeSyncJob(jobID string, res Result) {
 		PromptProfile:  meta.PromptProfile,
 		SlimDowngrade:  meta.SlimDowngrade,
 	}
-	if res.OK {
+	switch {
+	case res.OK:
 		cached.Status = "done"
-	} else {
+	case res.ErrorCode == ErrCodeStopped:
+		cached.Status = "stopped" // a `workflow stop` reap — terminal, but not a failure
+	default:
 		cached.Status = "failed"
 	}
 	if data, merr := json.Marshal(cached); merr == nil {

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -397,10 +397,12 @@ func StatusFor(jobID string) Result {
 		}
 	}
 
-	// A queued placeholder: the workflow engine minted it (PID=0, Status="queued") before the
-	// leaf got a pool slot, and no terminal result is cached yet. Report it AS queued — otherwise
-	// processAlive(0)=false falls through to classify an empty stdout as a dead/failed leaf.
-	if meta.Status == "queued" && meta.PID == 0 {
+	// No recorded process (PID<=0) and no cached terminal result: the job has produced no terminal
+	// signal. It is a queued placeholder the engine minted before the leaf got a pool slot (or a
+	// legacy/odd meta). Report it queued — PID is the authority, not the Status string — so it never
+	// falls through to the dead-classify path below, where an empty .out + the synthetic exit code
+	// would be mis-read as a done/failed leaf.
+	if meta.PID <= 0 {
 		return Result{
 			OK: true, JobID: jobID, Status: "queued",
 			Vendor: meta.Vendor, Model: meta.Model, StartedAt: meta.StartedAt,
@@ -431,14 +433,32 @@ func StatusFor(jobID string) Result {
 		}
 	}
 
-	// Dead → classify the captured output. The detached child was Released, so
-	// we can't reap its exit code; classification keys on the envelope (json
-	// path), not the exit code, so 0 is a safe placeholder.
-	stdout, _ := os.ReadFile(filepath.Join(dir, jobID+".out"))
-	stderr, _ := os.ReadFile(filepath.Join(dir, jobID+".err"))
+	// Dead → classify the captured output. The detached child was Released, so we can't reap a real
+	// exit code; the (json) envelope or (text) answer is the only terminal signal.
+	outPath := filepath.Join(dir, jobID+".out")
+	errPath := filepath.Join(dir, jobID+".err")
+	stdout, _ := os.ReadFile(outPath)
+	stderr, _ := os.ReadFile(errPath)
 	innerJSON := meta.JSON || meta.OutputFormat == "json"
-	req := Request{Vendor: meta.Vendor, Model: meta.Model, JSON: meta.JSON, OutputFormat: meta.OutputFormat}
-	res := classify(req, meta.Model, stdout, stderr, 0, false, innerJSON)
+	// A just-dead detached background leaf (settingsPath set = a real claude child) can have its
+	// envelope write land microseconds after the process is seen gone, leaving an EMPTY capture at
+	// this instant. Re-read once after a short confirm delay before treating it as terminal, so the
+	// visible-write race doesn't cache a spurious failure. Only an empty capture races; non-empty
+	// unparseable output is already written, so it skips the wait. One-shot; the cache then short-circuits.
+	if meta.SettingsPath != "" && innerJSON && strings.TrimSpace(string(stdout)) == "" {
+		time.Sleep(statusConfirmDelay)
+		stdout, _ = os.ReadFile(outPath)
+		stderr, _ = os.ReadFile(errPath)
+	}
+	var res Result
+	if vanishedWithoutResult(stdout, innerJSON) {
+		// No envelope (json) / no answer (text) and no real exit code: the leaf ended without
+		// finishing. Fail honestly (keep any stderr clue) — never bless the synthetic exit as "done".
+		res = failVanished(meta.Vendor, stderr)
+	} else {
+		req := Request{Vendor: meta.Vendor, Model: meta.Model, JSON: meta.JSON, OutputFormat: meta.OutputFormat}
+		res = classify(req, meta.Model, stdout, stderr, 0, false, innerJSON)
+	}
 	res.JobID = jobID
 	res.StartedAt = meta.StartedAt
 	res.LeadSessionID = meta.LeadSessionID
@@ -459,6 +479,38 @@ func StatusFor(jobID string) Result {
 		_ = os.WriteFile(resultPath, data, 0o600)
 	}
 	return res
+}
+
+// statusConfirmDelay is how long StatusFor waits before re-reading a just-dead detached
+// background leaf's empty capture, to let an envelope write that lands right after the
+// process is seen gone become visible. A package var so tests can zero it.
+var statusConfirmDelay = 75 * time.Millisecond
+
+// hasResultEnvelope reports whether stdout parses as a claude result envelope.
+func hasResultEnvelope(stdout []byte) bool {
+	_, ok := parseInner(stdout)
+	return ok
+}
+
+// vanishedWithoutResult reports that a dead job left no terminal signal: no parseable envelope
+// in json mode, or no answer text in text mode. Such a job — a Released detached child with no
+// real exit code — ended without finishing and must classify failed, never a synthetic-exit "done".
+func vanishedWithoutResult(stdout []byte, innerJSON bool) bool {
+	if innerJSON {
+		return !hasResultEnvelope(stdout)
+	}
+	return strings.TrimSpace(string(stdout)) == ""
+}
+
+// failVanished is the honest terminal failure for a job that ended without a result and whose
+// exit status is unknowable (a detached child was Released). It keeps any stderr clue (key-safe
+// via stderrPreview) but never claims a clean "exited 0".
+func failVanished(vendor string, stderr []byte) Result {
+	msg := "subagent ended without a result (process gone; no exit status available)"
+	if prev := stderrPreview(stderr); prev != "" {
+		msg += ": " + prev
+	}
+	return fail(ErrCodeFailed, msg, vendor, suggestionFor(ErrCodeFailed))
 }
 
 // ListJobs scans the jobs dir and returns each background job's current Result

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -397,11 +397,9 @@ func StatusFor(jobID string) Result {
 		}
 	}
 
-	// No recorded process (PID<=0) and no cached terminal result: the job has produced no terminal
-	// signal. It is a queued placeholder the engine minted before the leaf got a pool slot (or a
-	// legacy/odd meta). Report it queued — PID is the authority, not the Status string — so it never
-	// falls through to the dead-classify path below, where an empty .out + the synthetic exit code
-	// would be mis-read as a done/failed leaf.
+	// PID<=0 with no cached result = no terminal signal yet (a queued placeholder before its pool
+	// slot). Report it queued — PID is the authority, not the Status string — so the dead-classify
+	// path below never reads its empty capture as a done/failed leaf.
 	if meta.PID <= 0 {
 		return Result{
 			OK: true, JobID: jobID, Status: "queued",
@@ -440,11 +438,9 @@ func StatusFor(jobID string) Result {
 	stdout, _ := os.ReadFile(outPath)
 	stderr, _ := os.ReadFile(errPath)
 	innerJSON := meta.JSON || meta.OutputFormat == "json"
-	// A just-dead detached background leaf (settingsPath set = a real claude child) can have its
-	// envelope write land microseconds after the process is seen gone, leaving an EMPTY capture at
-	// this instant. Re-read once after a short confirm delay before treating it as terminal, so the
-	// visible-write race doesn't cache a spurious failure. Only an empty capture races; non-empty
-	// unparseable output is already written, so it skips the wait. One-shot; the cache then short-circuits.
+	// A detached json leaf (settingsPath set) can be seen dead a moment before its envelope write
+	// lands. When the capture is empty, re-read once after a short delay before classifying, so a
+	// late write isn't cached as a failure. Non-empty output is already written and skips the wait.
 	if meta.SettingsPath != "" && innerJSON && strings.TrimSpace(string(stdout)) == "" {
 		time.Sleep(statusConfirmDelay)
 		stdout, _ = os.ReadFile(outPath)
@@ -486,18 +482,12 @@ func StatusFor(jobID string) Result {
 // process is seen gone become visible. A package var so tests can zero it.
 var statusConfirmDelay = 75 * time.Millisecond
 
-// hasResultEnvelope reports whether stdout parses as a claude result envelope.
-func hasResultEnvelope(stdout []byte) bool {
-	_, ok := parseInner(stdout)
-	return ok
-}
-
-// vanishedWithoutResult reports that a dead job left no terminal signal: no parseable envelope
-// in json mode, or no answer text in text mode. Such a job — a Released detached child with no
-// real exit code — ended without finishing and must classify failed, never a synthetic-exit "done".
+// vanishedWithoutResult reports a dead job that left no terminal signal: no parseable envelope
+// (json) or no answer text (text). It must classify failed, never a synthetic-exit "done".
 func vanishedWithoutResult(stdout []byte, innerJSON bool) bool {
 	if innerJSON {
-		return !hasResultEnvelope(stdout)
+		_, ok := parseInner(stdout)
+		return !ok
 	}
 	return strings.TrimSpace(string(stdout)) == ""
 }

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -75,6 +75,12 @@ type WorkflowRun struct {
 	// BudgetTokens is the run-level token cap (Usage.InputTokens+OutputTokens summed across
 	// leaves, cache-read excluded); 0 = uncapped. Replayed on resume like BudgetUSD.
 	BudgetTokens int64 `json:"budget_tokens,omitempty"`
+	// SpentUSD / SpentTokens are the run's LIVE cumulative spend (list-price USD estimate +
+	// input+output tokens), restamped by the engine as each leaf charges — so `workflow status`
+	// shows a run-level running total without summing per-leaf jobs (which omit in-flight leaves).
+	// A resume counts only newly-run leaves; journaled replays are free. Not a leaf determinant.
+	SpentUSD    float64 `json:"spent_usd,omitempty"`
+	SpentTokens int64   `json:"spent_tokens,omitempty"`
 }
 
 // runsDir is ConfigDir/subagent-jobs/runs.
@@ -382,7 +388,7 @@ func finalizeRunLeaves(runID string) {
 		if merr != nil || meta.RunID != runID {
 			continue
 		}
-		finalizeSyncJob(jobID, fail(ErrCodeFailed, "engine stopped before the leaf finished", meta.Vendor, ""))
+		finalizeSyncJob(jobID, fail(ErrCodeStopped, "run stopped before the leaf finished", meta.Vendor, ""))
 	}
 }
 

--- a/internal/subagent/status_vanish_test.go
+++ b/internal/subagent/status_vanish_test.go
@@ -74,6 +74,32 @@ func TestStatusForVanishedLeafHonestFailure(t *testing.T) {
 	}
 }
 
+// A still-running leaf reaped by `workflow stop` (finalizeRunLeaves) reports a neutral terminal
+// "stopped" — not "failed" — so the board distinguishes a deliberate stop from a real failure.
+func TestFinalizeRunLeavesMarksStopped(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	m := jobMeta{JobID: "s1", PID: os.Getpid(), Status: "running", RunID: "runX",
+		Vendor: "v", StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	finalizeRunLeaves("runX")
+	st := StatusFor("s1")
+	if st.Status != "stopped" {
+		t.Fatalf("stopped leaf status = %q, want stopped", st.Status)
+	}
+	if st.OK {
+		t.Errorf("a stopped leaf must have OK=false")
+	}
+}
+
 // A detached bg leaf seen dead with an as-yet-unwritten envelope is recovered by the confirm-delay
 // re-read, not cached as a spurious failure. A goroutine writes the envelope just after StatusFor's
 // first (empty) read, so only the re-read sees it.

--- a/internal/subagent/status_vanish_test.go
+++ b/internal/subagent/status_vanish_test.go
@@ -1,0 +1,111 @@
+package subagent
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// deadPID returns a pid that has exited but is not yet recycled within the test window.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	c := exec.Command("true")
+	if err := c.Start(); err != nil {
+		t.Skipf("cannot spawn a throwaway process: %v", err)
+	}
+	_ = c.Wait()
+	return c.Process.Pid
+}
+
+// A job with no recorded process (PID<=0) and no cached terminal result has produced no terminal
+// signal, so StatusFor reports it queued regardless of the Status string — never a done leaf. The
+// dead-classify path below it would otherwise read a queued placeholder's empty .out (the
+// placeholder is minted in text mode) plus the synthetic exit 0 as a "done · 0 turns" success.
+func TestStatusForNoProcessReportsQueuedNotDone(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	m := jobMeta{JobID: "joba", PID: 0, Status: "running", JSON: false,
+		Vendor: "v", Model: "mm", StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if st := StatusFor("joba"); st.Status != "queued" || !st.OK {
+		t.Fatalf("PID=0 no-output job: status=%q ok=%v, want queued/ok (never done/failed)", st.Status, st.OK)
+	}
+}
+
+// A dead detached leaf with an empty .out fails with an honest message — never the cause-erasing
+// "claude exited 0 without a result envelope". A Released detached job has no wait()-able exit code,
+// so StatusFor fabricates exitCode 0; the message must say the exit status is unknown, not assert a
+// clean "exited 0".
+func TestStatusForVanishedLeafHonestFailure(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	statusConfirmDelay = 0 // no re-read wait for a genuinely-empty capture
+	pid := deadPID(t)
+	m := jobMeta{JobID: "jobb", PID: pid, PGID: pid, Status: "running", JSON: true,
+		SettingsPath: "/no/such/profile", Vendor: "v", Model: "mm",
+		StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.WriteFile(filepath.Join(dir, "jobb.out"), nil, 0o600)
+	st := StatusFor("jobb")
+	if st.Status != "failed" {
+		t.Fatalf("dead bg leaf with empty .out: status=%q, want failed", st.Status)
+	}
+	if strings.Contains(st.ErrorMsg, "exited 0") {
+		t.Fatalf("cause-erasing message %q (no real exit code exists for a detached job)", st.ErrorMsg)
+	}
+}
+
+// A detached bg leaf seen dead with an as-yet-unwritten envelope is recovered by the confirm-delay
+// re-read, not cached as a spurious failure. A goroutine writes the envelope just after StatusFor's
+// first (empty) read, so only the re-read sees it.
+func TestStatusForConfirmDelayRecoversLateEnvelope(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	statusConfirmDelay = 100 * time.Millisecond
+	pid := deadPID(t)
+	m := jobMeta{JobID: "jobc", PID: pid, PGID: pid, Status: "running", JSON: true,
+		SettingsPath: "/no/such/profile", Vendor: "v", Model: "mm",
+		StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(dir, "jobc.out")
+	_ = os.WriteFile(outPath, nil, 0o600)
+	envelope := []byte(`{"type":"result","subtype":"success","is_error":false,"result":"late answer","num_turns":1,"total_cost_usd":0.001}`)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = os.WriteFile(outPath, envelope, 0o600)
+	}()
+	st := StatusFor("jobc")
+	if st.Status != "done" {
+		t.Fatalf("late-envelope bg leaf: status=%q, want done (confirm-delay re-read should recover it)", st.Status)
+	}
+	if st.Result != "late answer" {
+		t.Errorf("recovered result = %q, want \"late answer\"", st.Result)
+	}
+}

--- a/internal/subagent/status_vanish_test.go
+++ b/internal/subagent/status_vanish_test.go
@@ -20,10 +20,7 @@ func deadPID(t *testing.T) int {
 	return c.Process.Pid
 }
 
-// A job with no recorded process (PID<=0) and no cached terminal result has produced no terminal
-// signal, so StatusFor reports it queued regardless of the Status string — never a done leaf. The
-// dead-classify path below it would otherwise read a queued placeholder's empty .out (the
-// placeholder is minted in text mode) plus the synthetic exit 0 as a "done · 0 turns" success.
+// StatusFor reports a PID<=0 job with no cached result as queued, regardless of meta.Status — never done.
 func TestStatusForNoProcessReportsQueuedNotDone(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	dir, err := jobsDir()
@@ -43,10 +40,7 @@ func TestStatusForNoProcessReportsQueuedNotDone(t *testing.T) {
 	}
 }
 
-// A dead detached leaf with an empty .out fails with an honest message — never the cause-erasing
-// "claude exited 0 without a result envelope". A Released detached job has no wait()-able exit code,
-// so StatusFor fabricates exitCode 0; the message must say the exit status is unknown, not assert a
-// clean "exited 0".
+// A dead detached leaf with an empty .out fails with an honest unknown-exit message, never "exited 0".
 func TestStatusForVanishedLeafHonestFailure(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	dir, err := jobsDir()
@@ -100,9 +94,8 @@ func TestFinalizeRunLeavesMarksStopped(t *testing.T) {
 	}
 }
 
-// A detached bg leaf seen dead with an as-yet-unwritten envelope is recovered by the confirm-delay
-// re-read, not cached as a spurious failure. A goroutine writes the envelope just after StatusFor's
-// first (empty) read, so only the re-read sees it.
+// The confirm-delay re-read recovers a late-landing envelope instead of caching a failure (a goroutine
+// writes it just after the first empty read).
 func TestStatusForConfirmDelayRecoversLateEnvelope(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	dir, err := jobsDir()

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -110,9 +110,10 @@ type Request struct {
 
 // Usage mirrors the token-usage subset of claude's inner envelope we surface.
 type Usage struct {
-	InputTokens          int `json:"input_tokens,omitempty"`
-	OutputTokens         int `json:"output_tokens,omitempty"`
-	CacheReadInputTokens int `json:"cache_read_input_tokens,omitempty"`
+	InputTokens              int `json:"input_tokens,omitempty"`
+	OutputTokens             int `json:"output_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"` // tokens billed to WRITE the prompt cache
 }
 
 // Result is cc-fleet's stable outer envelope (mirrors spawn.Result style). It
@@ -208,6 +209,7 @@ const (
 	// cc-fleet layer.
 	ErrCodeTimeout        = "SUBAGENT_TIMEOUT"          // --timeout deadline fired before claude returned
 	ErrCodeFailed         = "SUBAGENT_FAILED"           // non-zero exit with no parseable envelope / internal error
+	ErrCodeStopped        = "SUBAGENT_STOPPED"          // a still-running leaf finalized by `workflow stop` (a stop, not a failure)
 	ErrCodeOutputTooLarge = "SUBAGENT_OUTPUT_TOO_LARGE" // child stdout/stderr exceeded the byte cap; group killed
 )
 

--- a/internal/tui/stopped_render_test.go
+++ b/internal/tui/stopped_render_test.go
@@ -1,0 +1,23 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// A stopped leaf renders neutrally (the word "stopped"), never the red error class — so a
+// `workflow stop` reads as a deliberate stop, not a failure.
+func TestStoppedLeafRendersNeutral(t *testing.T) {
+	out := Model{}.renderOutcome(subagent.Result{Status: "stopped", ErrorCode: subagent.ErrCodeStopped})
+	if !strings.Contains(out, "stopped") {
+		t.Errorf("stopped outcome = %q, want it to read 'stopped'", out)
+	}
+	if strings.Contains(out, "SUBAGENT") || strings.Contains(out, "STOPPED") {
+		t.Errorf("stopped outcome leaked the error class: %q", out)
+	}
+	if lbl := statusLabel("stopped"); !strings.Contains(lbl, "Stopped") {
+		t.Errorf("stopped status label = %q, want it to read 'Stopped'", lbl)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -977,8 +977,8 @@ func wrapTo(s string, w int) []string {
 	return out
 }
 
-// renderOutcome is the key-safe outcome line: status + a canonical summary, NEVER Result.Result. A
-// done leaf shows "done · N turns"; a failed one its error class; a running/queued one "Still running…".
+// renderOutcome is the key-safe outcome line: status + a canonical summary, NEVER Result.Result.
+// Done shows turns, stopped is neutral, a failure shows its error class, queued/running stay in progress.
 func (m Model) renderOutcome(j subagent.Result) string {
 	switch {
 	case j.Status == "running" || j.Status == "queued" || j.Status == "":

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -242,15 +242,18 @@ func (m Model) viewWorkflows() string {
 }
 
 // statusDot maps a leaf/run/phase status to a colored glyph: done ✔ (green), running ● (accent),
-// failed/stopped ● (err), cached ○ (faint), queued/unknown ◌ (faint hollow).
+// failed ● (err), stopped ■ (faint — a stop is neutral, not a failure), cached ○ (faint),
+// queued/unknown ◌ (faint hollow).
 func statusDot(status string) string {
 	switch status {
 	case "done":
 		return okStyle.Render("✔")
 	case "running":
 		return cursorStyle.Render("●")
-	case "failed", "stopped":
+	case "failed":
 		return errStyle.Render("●")
+	case "stopped":
+		return faintStyle.Render("■")
 	case "cached":
 		return faintStyle.Render("○")
 	default: // "" / queued / not-yet-started
@@ -284,13 +287,16 @@ func phaseStatus(done, total int) string {
 }
 
 // statusLabel is the detail-pane status token (glyph + word in one color): done renders an all-green
-// "✔ Done", failed/stopped a red dot + word, running/other an accent dot + a bright word.
+// "✔ Done", failed a red dot + word, stopped a faint dot + word (neutral), running/other an accent dot
+// + a bright word.
 func statusLabel(status string) string {
 	switch status {
 	case "done":
 		return okStyle.Render("✔ " + humanStatus(status))
-	case "failed", "stopped":
+	case "failed":
 		return statusDot(status) + " " + errStyle.Render(humanStatus(status))
+	case "stopped":
+		return statusDot(status) + " " + faintStyle.Render(humanStatus(status))
 	default:
 		return statusDot(status) + " " + liveStyle.Render(humanStatus(status))
 	}
@@ -798,10 +804,16 @@ func (m Model) agentDetailLines(rightW int) []string {
 		// >1 occurs only in records from engines that retried schema mismatches; surface it.
 		status += faintStyle.Render(fmt.Sprintf(" · attempt %d", j.Attempt))
 	}
+	// ↑ peak input context · ↓ cumulative output (the header sums only output across leaves) · cache-write
+	// tokens when the leaf wrote the prompt cache · tool calls.
+	tokLine := fmt.Sprintf("↑ %s ctx · ↓ %s out", humanTokens(in), humanTokens(out))
+	if j.Usage != nil && j.Usage.CacheCreationInputTokens > 0 {
+		tokLine += fmt.Sprintf(" · ⊕ %s cache-w", humanTokens(j.Usage.CacheCreationInputTokens))
+	}
+	tokLine += fmt.Sprintf(" · %d tool calls", tools)
 	lines := []string{
 		status,
-		// ↑ peak input context · ↓ cumulative output (the header sums only output across leaves).
-		faintStyle.Render(fmt.Sprintf("↑ %s ctx · ↓ %s out · %d tool calls", humanTokens(in), humanTokens(out), tools)),
+		faintStyle.Render(tokLine),
 	}
 	// Prompt first.
 	switch {
@@ -973,6 +985,8 @@ func (m Model) renderOutcome(j subagent.Result) string {
 		return faintStyle.Render("Still running…") // queued has OK=true but isn't done — keep it in-progress
 	case j.OK || j.Status == "done":
 		return faintStyle.Render(fmt.Sprintf("done · %d turns", j.NumTurns))
+	case j.Status == "stopped":
+		return faintStyle.Render("stopped") // a `workflow stop` reap — neutral, not a failure
 	default:
 		cls := j.ErrorCode
 		if cls == "" {

--- a/internal/workflow/budget.go
+++ b/internal/workflow/budget.go
@@ -53,6 +53,10 @@ func (e *engine) budgetRelease(usd float64, tok int64) {
 func (e *engine) budgetCharge(usd float64, tok int64) {
 	e.budgetSpent += usd
 	e.budgetTokensSpent += tok
+	// Persist the new running spend so an external `workflow status` reader sees a live run-level
+	// total mid-run (the manifest otherwise only restamps at phase/terminal transitions). Bounded
+	// by real leaf completions (cache hits never charge); GIL-held, so it serializes with charging.
+	e.saveManifest("running", "")
 }
 
 // budgetExceededErr is the gate's refusal, naming only the active cap(s): USD (a list-price

--- a/internal/workflow/builtins.go
+++ b/internal/workflow/builtins.go
@@ -717,6 +717,8 @@ func (e *engine) saveManifest(status, errText string) {
 		NoPersistIO:  !e.persistIO,
 		BudgetUSD:    e.budgetTotal,
 		BudgetTokens: e.budgetTokensTotal,
+		SpentUSD:     e.budgetSpent,
+		SpentTokens:  e.budgetTokensSpent,
 	})
 }
 

--- a/internal/workflow/run_spend_test.go
+++ b/internal/workflow/run_spend_test.go
@@ -1,0 +1,36 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// budgetCharge restamps the run manifest with the LIVE cumulative spend after every leaf charge,
+// so an external `workflow status` reader sees a running total mid-run — not only at the terminal
+// write. Reading the manifest between charges (no terminal save yet) proves the live persistence.
+func TestBudgetChargePersistsLiveSpend(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	const rid = "spend-live"
+	eng := &engine{runID: rid, startedAt: time.Now().UTC().Format(time.RFC3339)}
+	eng.saveManifest("running", "")
+
+	eng.budgetCharge(0.5, 1200)
+	run, _, err := subagent.RunStatus(rid)
+	if err != nil {
+		t.Fatalf("run status: %v", err)
+	}
+	if run.SpentUSD != 0.5 || run.SpentTokens != 1200 {
+		t.Fatalf("live spend after one charge = $%v / %d tok, want $0.5 / 1200", run.SpentUSD, run.SpentTokens)
+	}
+
+	eng.budgetCharge(0.25, 800)
+	run, _, err = subagent.RunStatus(rid)
+	if err != nil {
+		t.Fatalf("run status: %v", err)
+	}
+	if run.SpentUSD != 0.75 || run.SpentTokens != 2000 {
+		t.Fatalf("accumulated live spend = $%v / %d tok, want $0.75 / 2000", run.SpentUSD, run.SpentTokens)
+	}
+}

--- a/internal/workflow/schema.go
+++ b/internal/workflow/schema.go
@@ -1,13 +1,30 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"math"
+	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"go.starlark.net/lib/json"
 	"go.starlark.net/starlark"
 )
+
+// schemaError marks a structural schema defect — an unresolvable or malformed `$ref`, or nesting
+// beyond maxSchemaDepth — distinct from a value/schema MISMATCH. anyOf/oneOf must PROPAGATE it (a
+// broken branch is not "the value didn't match this branch"), never count it as a non-match.
+type schemaError struct{ err error }
+
+func (e schemaError) Error() string { return e.err.Error() }
+
+func isSchemaError(err error) bool {
+	var se schemaError
+	return errors.As(err, &se)
+}
 
 // jsonEncode / jsonDecode reuse go.starlark.net's tested JSON module instead of a
 // bespoke Go<->Starlark converter. Both are called via starlark.Call UNDER THE GIL
@@ -39,17 +56,24 @@ func encodeSchema(thread *starlark.Thread, schema starlark.Value) (string, error
 // decodeAndValidate parses the vendor reply as JSON and recursively validates it against
 // the schema. Runs under the GIL. A parse failure or any validation failure is an error —
 // terminal for a live leaf, and on resume a cached value that no longer validates is
-// treated as a miss. The supported JSON-Schema subset is deliberately the practical core —
-// `type` (object/array/string/number/integer/boolean/null), `required`, nested
-// `properties`, array `items`, and scalar `enum`; composition keywords ($ref / allOf /
-// oneOf / anyOf) are intentionally NOT enforced (over-scope for a vendor leaf that can't
-// be force-terminated anyway), so a schema using only them validates as "valid JSON".
+// treated as a miss. The supported keywords are `type` (object/array/string/number/integer/
+// boolean/null), `required`, nested `properties`, array `items`, scalar `enum`, string `pattern`
+// (RE2 best-effort — an uncompilable ECMA pattern defers to the wire) and `format`, `additionalProperties`,
+// the composition keywords `allOf` / `anyOf` / `oneOf`, and intra-document `$ref` (`#/…` JSON
+// pointers into the root schema, e.g. `#/$defs/Address`). External `$ref` URIs are not
+// resolved (surfaced as a validation error, not silently passed).
+//
+// This is a single-pass VALUE validator, not a value-independent schema linter: an unresolvable
+// `$ref` always surfaces from a composition branch, but a structural defect buried behind a value
+// mismatch in a deeply-nested non-composition keyword may not. Recursion (a deep or cyclic `$ref`)
+// is bounded by `maxSchemaDepth`, so it terminates with a depth error rather than looping. It is
+// the backstop; claude enforces the full schema on the wire via `--json-schema`.
 func decodeAndValidate(thread *starlark.Thread, reply string, schema starlark.Value) (starlark.Value, error) {
 	v, err := starlark.Call(thread, jsonDecode, starlark.Tuple{starlark.String(stripCodeFence(reply))}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("reply is not valid JSON: %v", err)
 	}
-	if err := validateAgainstSchema(v, schema, 0); err != nil {
+	if err := validateAgainstSchema(v, schema, schema, 0); err != nil {
 		return nil, err
 	}
 	return v, nil
@@ -58,13 +82,19 @@ func decodeAndValidate(thread *starlark.Thread, reply string, schema starlark.Va
 // validateAgainstSchema recursively checks value against schema (a *starlark.Dict). A
 // non-dict schema imposes no structural constraint (valid-JSON-only). Errors are wrapped
 // with the failing path (property/item) for an actionable retry message.
-func validateAgainstSchema(value, schema starlark.Value, depth int) error {
+func validateAgainstSchema(value, schema, root starlark.Value, depth int) error {
 	if depth > maxSchemaDepth {
-		return fmt.Errorf("schema nesting exceeds %d levels", maxSchemaDepth)
+		return schemaError{fmt.Errorf("schema nesting exceeds %d levels", maxSchemaDepth)}
 	}
 	sd, ok := schema.(*starlark.Dict)
 	if !ok {
 		return nil
+	}
+	// Resolve $ref + composition FIRST, so a structural defect (an unresolvable $ref, nesting too
+	// deep) surfaces as a schemaError even when a sibling keyword (e.g. a mismatching type) would
+	// otherwise short-circuit with a plain value mismatch — anyOf/oneOf must see the defect.
+	if err := checkComposition(value, sd, root, depth); err != nil {
+		return err
 	}
 	if tv, found, _ := sd.Get(starlark.String("type")); found {
 		if ts, ok := starlark.AsString(tv); ok {
@@ -76,6 +106,28 @@ func validateAgainstSchema(value, schema starlark.Value, depth int) error {
 	if ev, found, _ := sd.Get(starlark.String("enum")); found {
 		if lst, ok := ev.(*starlark.List); ok && !enumContains(lst, value) {
 			return fmt.Errorf("value %s is not one of the enum values", value.String())
+		}
+	}
+	// pattern / format constrain STRING values only (a non-string is left to `type`).
+	if s, isStr := starlark.AsString(value); isStr {
+		if pv, found, _ := sd.Get(starlark.String("pattern")); found {
+			if pat, ok := starlark.AsString(pv); ok {
+				// pattern is ECMA-262 in JSON Schema; Go RE2 only approximates it. An uncompilable
+				// (ECMA-only) pattern is skipped; the rare RE2-vs-ECMA semantic divergence (an escape
+				// RE2 reads differently) is an accepted best-effort caveat — claude enforces the
+				// authoritative pattern on the wire via --json-schema, and this local check is a backstop
+				// (chiefly for resume re-validation), so a stray mismatch only re-runs a leaf, never wrong.
+				if re, cerr := regexp.Compile(pat); cerr == nil && !re.MatchString(s) {
+					return fmt.Errorf("value does not match pattern %q", pat)
+				}
+			}
+		}
+		if fv, found, _ := sd.Get(starlark.String("format")); found {
+			if format, ok := starlark.AsString(fv); ok {
+				if err := checkFormat(format, s); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	rv, hasRequired, _ := sd.Get(starlark.String("required"))
@@ -105,17 +157,24 @@ func validateAgainstSchema(value, schema starlark.Value, depth int) error {
 					continue // properties does NOT imply required (JSON-Schema semantics)
 				}
 				sub, _, _ := props.Get(k)
-				if err := validateAgainstSchema(cv, sub, depth+1); err != nil {
+				if err := validateAgainstSchema(cv, sub, root, depth+1); err != nil {
 					ks, _ := starlark.AsString(k)
 					return fmt.Errorf("property %q: %w", ks, err)
 				}
+			}
+		}
+		// additionalProperties governs keys NOT named in `properties`: `false` rejects any extra
+		// key; a schema validates each extra value against it; `true`/absent imposes nothing.
+		if apv, found, _ := sd.Get(starlark.String("additionalProperties")); found {
+			if err := checkAdditionalProps(d, pv, apv, root, depth); err != nil {
+				return err
 			}
 		}
 	}
 	if lst, ok := value.(*starlark.List); ok {
 		if iv, found, _ := sd.Get(starlark.String("items")); found {
 			for i := 0; i < lst.Len(); i++ {
-				if err := validateAgainstSchema(lst.Index(i), iv, depth+1); err != nil {
+				if err := validateAgainstSchema(lst.Index(i), iv, root, depth+1); err != nil {
 					return fmt.Errorf("item %d: %w", i, err)
 				}
 			}
@@ -195,4 +254,192 @@ func stripCodeFence(s string) string {
 		t = t[:i]
 	}
 	return strings.TrimSpace(t)
+}
+
+// checkComposition enforces the schema-composition keywords on value: $ref (resolve a local
+// JSON pointer into root, then validate against the target), allOf (every subschema must
+// pass), anyOf (at least one), oneOf (exactly one). Each is independent and ANDed with the
+// rest of the schema; an absent keyword is a no-op.
+func checkComposition(value starlark.Value, sd *starlark.Dict, root starlark.Value, depth int) error {
+	if rv, found, _ := sd.Get(starlark.String("$ref")); found {
+		ref, ok := starlark.AsString(rv)
+		if !ok {
+			return schemaError{fmt.Errorf("$ref must be a string")}
+		}
+		target, rerr := resolveRef(ref, root)
+		if rerr != nil {
+			return schemaError{rerr} // an unresolvable ref is a schema defect, not a value mismatch
+		}
+		if err := validateAgainstSchema(value, target, root, depth+1); err != nil {
+			return fmt.Errorf("$ref %s: %w", ref, err)
+		}
+	}
+	if av, found, _ := sd.Get(starlark.String("allOf")); found {
+		if lst, ok := av.(*starlark.List); ok {
+			var firstMismatch error
+			for i := 0; i < lst.Len(); i++ {
+				err := validateAgainstSchema(value, lst.Index(i), root, depth+1)
+				if err == nil {
+					continue
+				}
+				if isSchemaError(err) {
+					return err // a broken branch — surface ahead of any value mismatch (scan all branches)
+				}
+				if firstMismatch == nil {
+					firstMismatch = fmt.Errorf("allOf[%d]: %w", i, err)
+				}
+			}
+			if firstMismatch != nil {
+				return firstMismatch // allOf requires every branch; report the first value mismatch
+			}
+		}
+	}
+	if av, found, _ := sd.Get(starlark.String("anyOf")); found {
+		if lst, ok := av.(*starlark.List); ok { // an empty anyOf matches nothing → fails below
+			matched := false
+			for i := 0; i < lst.Len(); i++ {
+				err := validateAgainstSchema(value, lst.Index(i), root, depth+1)
+				if err == nil {
+					matched = true
+					continue // keep scanning — a LATER branch may be structurally broken
+				}
+				if isSchemaError(err) {
+					return err // a broken branch (unresolvable $ref / too deep) — surface, don't swallow
+				}
+			}
+			if !matched {
+				return fmt.Errorf("anyOf: value matches none of the %d subschemas", lst.Len())
+			}
+		}
+	}
+	if ov, found, _ := sd.Get(starlark.String("oneOf")); found {
+		if lst, ok := ov.(*starlark.List); ok { // an empty oneOf matches 0 subschemas → fails below
+			matched := 0
+			for i := 0; i < lst.Len(); i++ {
+				err := validateAgainstSchema(value, lst.Index(i), root, depth+1)
+				if err == nil {
+					matched++
+					continue
+				}
+				if isSchemaError(err) {
+					return err // a broken branch — surface, don't swallow as a non-match
+				}
+			}
+			if matched != 1 {
+				return fmt.Errorf("oneOf: value matches %d subschemas, want exactly 1", matched)
+			}
+		}
+	}
+	return nil
+}
+
+// resolveRef resolves an intra-document JSON-pointer $ref into root and returns the referenced
+// subschema. Only intra-document pointers (`#` and `#/…`) are supported; an external URI is an
+// error so an unresolvable ref FAILS validation rather than silently passing.
+func resolveRef(ref string, root starlark.Value) (starlark.Value, error) {
+	if ref == "#" {
+		return root, nil
+	}
+	if !strings.HasPrefix(ref, "#/") {
+		return nil, fmt.Errorf("unsupported $ref %q (only intra-document #/… pointers)", ref)
+	}
+	cur := root
+	for _, tok := range strings.Split(strings.TrimPrefix(ref, "#/"), "/") {
+		tok = unescapeJSONPointer(tok)
+		switch c := cur.(type) {
+		case *starlark.Dict:
+			nv, found, _ := c.Get(starlark.String(tok))
+			if !found {
+				return nil, fmt.Errorf("$ref %q: %q not found", ref, tok)
+			}
+			cur = nv
+		case *starlark.List:
+			idx, err := strconv.Atoi(tok)
+			if err != nil || idx < 0 || idx >= c.Len() {
+				return nil, fmt.Errorf("$ref %q: %q is not a valid array index", ref, tok)
+			}
+			cur = c.Index(idx)
+		default:
+			return nil, fmt.Errorf("$ref %q: %q is not an object or array", ref, tok)
+		}
+	}
+	return cur, nil
+}
+
+// unescapeJSONPointer decodes the RFC 6901 escapes ~1 → "/" then ~0 → "~" (order matters) so
+// a key containing "/" or "~" resolves correctly.
+func unescapeJSONPointer(t string) string {
+	t = strings.ReplaceAll(t, "~1", "/")
+	return strings.ReplaceAll(t, "~0", "~")
+}
+
+// checkAdditionalProps enforces additionalProperties on an object: for each key NOT named in
+// `properties`, reject it when additionalProperties is `false`, or validate its value against the
+// additionalProperties schema. `true` (or a non-bool, non-dict value) imposes nothing.
+func checkAdditionalProps(d *starlark.Dict, properties, ap, root starlark.Value, depth int) error {
+	declared := map[string]bool{}
+	if props, ok := properties.(*starlark.Dict); ok {
+		for _, k := range props.Keys() {
+			if ks, ok := starlark.AsString(k); ok {
+				declared[ks] = true
+			}
+		}
+	}
+	allowed := true
+	var apSchema starlark.Value
+	switch a := ap.(type) {
+	case starlark.Bool:
+		allowed = bool(a)
+	case *starlark.Dict:
+		apSchema = a
+	}
+	for _, k := range d.Keys() {
+		ks, ok := starlark.AsString(k)
+		if !ok || declared[ks] {
+			continue
+		}
+		if !allowed {
+			return fmt.Errorf("additional property %q is not allowed", ks)
+		}
+		if apSchema != nil {
+			cv, _, _ := d.Get(k)
+			if err := validateAgainstSchema(cv, apSchema, root, depth+1); err != nil {
+				return fmt.Errorf("additional property %q: %w", ks, err)
+			}
+		}
+	}
+	return nil
+}
+
+var (
+	formatEmail = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+	formatUUID  = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+)
+
+// checkFormat validates a string against a named `format`. Only the common set is enforced —
+// email / uri (or url) / uuid / date / date-time; an unknown format imposes nothing (per JSON
+// Schema, `format` is an annotation unless the validator opts in).
+func checkFormat(format, s string) error {
+	ok := true
+	switch format {
+	case "email":
+		ok = formatEmail.MatchString(s)
+	case "uri", "url":
+		u, err := url.Parse(s)
+		ok = err == nil && u.IsAbs()
+	case "uuid":
+		ok = formatUUID.MatchString(s)
+	case "date":
+		_, err := time.Parse("2006-01-02", s)
+		ok = err == nil
+	case "date-time":
+		_, err := time.Parse(time.RFC3339, s)
+		ok = err == nil
+	default:
+		return nil // unknown format: annotation, not a constraint
+	}
+	if !ok {
+		return fmt.Errorf("value %q is not a valid %s", s, format)
+	}
+	return nil
 }

--- a/internal/workflow/schema.go
+++ b/internal/workflow/schema.go
@@ -14,9 +14,9 @@ import (
 	"go.starlark.net/starlark"
 )
 
-// schemaError marks a structural schema defect — an unresolvable or malformed `$ref`, or nesting
-// beyond maxSchemaDepth — distinct from a value/schema MISMATCH. anyOf/oneOf must PROPAGATE it (a
-// broken branch is not "the value didn't match this branch"), never count it as a non-match.
+// schemaError marks a structural schema defect (a dangling/malformed `$ref` or nesting past
+// maxSchemaDepth), distinct from a value mismatch. anyOf/oneOf propagate it rather than count it
+// as a branch that did not match.
 type schemaError struct{ err error }
 
 func (e schemaError) Error() string { return e.err.Error() }
@@ -53,21 +53,11 @@ func encodeSchema(thread *starlark.Thread, schema starlark.Value) (string, error
 	return s, nil
 }
 
-// decodeAndValidate parses the vendor reply as JSON and recursively validates it against
-// the schema. Runs under the GIL. A parse failure or any validation failure is an error —
-// terminal for a live leaf, and on resume a cached value that no longer validates is
-// treated as a miss. The supported keywords are `type` (object/array/string/number/integer/
-// boolean/null), `required`, nested `properties`, array `items`, scalar `enum`, string `pattern`
-// (RE2 best-effort — an uncompilable ECMA pattern defers to the wire) and `format`, `additionalProperties`,
-// the composition keywords `allOf` / `anyOf` / `oneOf`, and intra-document `$ref` (`#/…` JSON
-// pointers into the root schema, e.g. `#/$defs/Address`). External `$ref` URIs are not
-// resolved (surfaced as a validation error, not silently passed).
-//
-// This is a single-pass VALUE validator, not a value-independent schema linter: an unresolvable
-// `$ref` always surfaces from a composition branch, but a structural defect buried behind a value
-// mismatch in a deeply-nested non-composition keyword may not. Recursion (a deep or cyclic `$ref`)
-// is bounded by `maxSchemaDepth`, so it terminates with a depth error rather than looping. It is
-// the backstop; claude enforces the full schema on the wire via `--json-schema`.
+// decodeAndValidate parses the reply JSON and validates it against the schema subset: `type`,
+// `required`, `properties`, `items`, `enum`, `pattern`/`format`/`additionalProperties`,
+// `allOf`/`anyOf`/`oneOf`, and intra-document `$ref` (`#/…`; an external ref is unsupported, fails).
+// It is the local backstop for claude's `--json-schema`: a live failure is terminal, a resume
+// failure is a cache miss. Single-pass over the value; `maxSchemaDepth` bounds a recursive `$ref`.
 func decodeAndValidate(thread *starlark.Thread, reply string, schema starlark.Value) (starlark.Value, error) {
 	v, err := starlark.Call(thread, jsonDecode, starlark.Tuple{starlark.String(stripCodeFence(reply))}, nil)
 	if err != nil {
@@ -112,11 +102,8 @@ func validateAgainstSchema(value, schema, root starlark.Value, depth int) error 
 	if s, isStr := starlark.AsString(value); isStr {
 		if pv, found, _ := sd.Get(starlark.String("pattern")); found {
 			if pat, ok := starlark.AsString(pv); ok {
-				// pattern is ECMA-262 in JSON Schema; Go RE2 only approximates it. An uncompilable
-				// (ECMA-only) pattern is skipped; the rare RE2-vs-ECMA semantic divergence (an escape
-				// RE2 reads differently) is an accepted best-effort caveat — claude enforces the
-				// authoritative pattern on the wire via --json-schema, and this local check is a backstop
-				// (chiefly for resume re-validation), so a stray mismatch only re-runs a leaf, never wrong.
+				// JSON Schema `pattern` is ECMA-262; Go RE2 is a best-effort local approximation. An
+				// uncompilable pattern is skipped — `--json-schema` stays authoritative on the wire.
 				if re, cerr := regexp.Compile(pat); cerr == nil && !re.MatchString(s) {
 					return fmt.Errorf("value does not match pattern %q", pat)
 				}
@@ -266,9 +253,11 @@ func checkComposition(value starlark.Value, sd *starlark.Dict, root starlark.Val
 		if !ok {
 			return schemaError{fmt.Errorf("$ref must be a string")}
 		}
+		// Only an intra-document ref resolves locally; an external URI is unsupported and fails here
+		// (claude's --json-schema is authoritative for it). A dangling intra-document ref is a defect.
 		target, rerr := resolveRef(ref, root)
 		if rerr != nil {
-			return schemaError{rerr} // an unresolvable ref is a schema defect, not a value mismatch
+			return schemaError{rerr}
 		}
 		if err := validateAgainstSchema(value, target, root, depth+1); err != nil {
 			return fmt.Errorf("$ref %s: %w", ref, err)

--- a/internal/workflow/schema_composition_test.go
+++ b/internal/workflow/schema_composition_test.go
@@ -1,0 +1,254 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"go.starlark.net/starlark"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// allOf: a payload satisfying every subschema passes and flows back.
+func TestSchemaAllOfValid(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"name":"x","employeeId":7}`)}
+	})
+	g, err := runScript(t, "co1", 1, leaf, `
+res = agent("q", vendor="v", schema={"allOf": [
+  {"type":"object","required":["name"],"properties":{"name":{"type":"string"}}},
+  {"type":"object","required":["employeeId"],"properties":{"employeeId":{"type":"integer"}}}]})
+n = res["name"]
+`)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if s, _ := starlark.AsString(g["n"]); s != "x" {
+		t.Errorf("name = %q, want x", s)
+	}
+}
+
+// allOf: violating ANY subschema fails validation terminally (one exec, no retry).
+func TestSchemaAllOfViolationTerminal(t *testing.T) {
+	rec := &recorder{}
+	leaf := fakeLeaf(rec, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"name":"x"}`)} // missing employeeId
+	})
+	if _, err := runScript(t, "co2", 1, leaf, `
+res = agent("q", vendor="v", schema={"allOf": [
+  {"type":"object","required":["name"]},
+  {"type":"object","required":["employeeId"]}]})
+`); err == nil {
+		t.Fatal("want a terminal validation error (allOf second subschema unmet)")
+	}
+	if n := len(rec.snapshot()); n != 1 {
+		t.Errorf("execs = %d, want 1 (validation failure is terminal)", n)
+	}
+}
+
+// oneOf: a payload matching MORE than one subschema fails (must match exactly one).
+func TestSchemaOneOfMatchesTwoFails(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"card":"4111","bank":"acme"}`)}
+	})
+	if _, err := runScript(t, "co3", 1, leaf, `
+res = agent("q", vendor="v", schema={"oneOf": [
+  {"type":"object","required":["card"]},
+  {"type":"object","required":["bank"]}]})
+`); err == nil {
+		t.Fatal("want an error: payload matches 2 oneOf subschemas, not exactly 1")
+	}
+}
+
+// $ref: an intra-document pointer into $defs is resolved and enforced; a conforming payload passes.
+func TestSchemaRefResolved(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"shipTo":{"zip":"10001"}}`)}
+	})
+	g, err := runScript(t, "co4", 1, leaf, `
+res = agent("q", vendor="v", schema={
+  "type":"object","required":["shipTo"],
+  "properties":{"shipTo":{"$ref":"#/$defs/addr"}},
+  "$defs":{"addr":{"type":"object","required":["zip"],"properties":{"zip":{"type":"string"}}}}})
+z = res["shipTo"]["zip"]
+`)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if s, _ := starlark.AsString(g["z"]); s != "10001" {
+		t.Errorf("zip = %q, want 10001", s)
+	}
+}
+
+// A oneOf whose other branch matches must still SURFACE a structural error (an unresolvable
+// $ref) in a sibling branch — never silently swallow it as "that branch didn't match".
+func TestSchemaOneOfSurfacesBrokenRef(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
+	})
+	if _, err := runScript(t, "co6", 1, leaf, `
+res = agent("q", vendor="v", schema={"oneOf": [
+  {"$ref":"#/missing"},
+  {"type":"string"}]})
+`); err == nil {
+		t.Fatal("want an error: oneOf has an unresolvable $ref branch (must surface, not swallow)")
+	}
+}
+
+// anyOf must surface a structural error even when an EARLIER branch already matched — it scans
+// every branch, not stopping at the first match.
+func TestSchemaAnyOfSurfacesBrokenRefAfterMatch(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
+	})
+	if _, err := runScript(t, "co8", 1, leaf, `
+res = agent("q", vendor="v", schema={"anyOf": [
+  {"type":"string"},
+  {"$ref":"#/missing"}]})
+`); err == nil {
+		t.Fatal("want an error: anyOf has a broken $ref branch after a matching branch")
+	}
+}
+
+// A structural defect surfaces even when a SIBLING keyword would short-circuit first: the broken
+// $ref in the second branch is caught before its mismatching type, so the value can't slip through.
+func TestSchemaAnyOfDefectBehindMismatch(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
+	})
+	if _, err := runScript(t, "co9", 1, leaf, `
+res = agent("q", vendor="v", schema={"anyOf": [
+  {"type":"string"},
+  {"type":"number","$ref":"#/missing"}]})
+`); err == nil {
+		t.Fatal("want an error: the broken $ref behind a type mismatch must still surface")
+	}
+}
+
+// allOf scans every branch and surfaces a structural defect (broken $ref) even when an earlier
+// branch is a plain value mismatch — so the defect isn't hidden inside an outer anyOf.
+func TestSchemaAllOfDefectBehindMismatch(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
+	})
+	if _, err := runScript(t, "co10", 1, leaf, `
+res = agent("q", vendor="v", schema={"anyOf": [
+  {"type":"string"},
+  {"allOf":[{"type":"number"}, {"$ref":"#/missing"}]}]})
+`); err == nil {
+		t.Fatal("want an error: the broken $ref in allOf[1] must surface past the allOf[0] mismatch")
+	}
+}
+
+// An empty anyOf matches nothing, and an empty oneOf matches zero subschemas — both must FAIL,
+// not silently accept every value.
+func TestSchemaEmptyAnyOfOneOfFail(t *testing.T) {
+	for i, schema := range []string{`{"anyOf":[]}`, `{"oneOf":[]}`} {
+		l := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+			return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
+		})
+		if _, err := runScript(t, "coE"+string(rune('a'+i)), 1, l,
+			"res = agent(\"q\", vendor=\"v\", schema="+schema+")"); err == nil {
+			t.Fatalf("want an error: %s must match nothing", schema)
+		}
+	}
+}
+
+// $ref resolves an array index (RFC6901 JSON pointer): #/$defs/opts/1 picks the 2nd schema.
+func TestSchemaRefArrayIndex(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"x":"hi"}`)}
+	})
+	g, err := runScript(t, "co7", 1, leaf, `
+res = agent("q", vendor="v", schema={
+  "type":"object","properties":{"x":{"$ref":"#/$defs/opts/1"}},
+  "$defs":{"opts":[{"type":"integer"},{"type":"string"}]}})
+x = res["x"]
+`)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if s, _ := starlark.AsString(g["x"]); s != "hi" {
+		t.Errorf("x = %q, want hi", s)
+	}
+}
+
+// $ref: a violation of the referenced subschema fails (zip must be a string).
+func TestSchemaRefViolation(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"shipTo":{"zip":123}}`)}
+	})
+	if _, err := runScript(t, "co5", 1, leaf, `
+res = agent("q", vendor="v", schema={
+  "type":"object","properties":{"shipTo":{"$ref":"#/$defs/addr"}},
+  "$defs":{"addr":{"type":"object","required":["zip"],"properties":{"zip":{"type":"string"}}}}})
+`); err == nil {
+		t.Fatal("want an error: $ref target requires zip:string, got integer")
+	}
+}
+
+// pattern: a string must match the regex; a mismatch fails.
+func TestSchemaPattern(t *testing.T) {
+	ok := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"code":"AB12"}`)}
+	})
+	if _, err := runScript(t, "pt1", 1, ok,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"code":{"type":"string","pattern":"^[A-Z]{2}[0-9]{2}$"}}})`); err != nil {
+		t.Fatalf("matching pattern should pass: %v", err)
+	}
+	bad := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"code":"xx"}`)}
+	})
+	if _, err := runScript(t, "pt2", 1, bad,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"code":{"type":"string","pattern":"^[A-Z]{2}[0-9]{2}$"}}})`); err == nil {
+		t.Fatal("want a pattern-mismatch error")
+	}
+}
+
+// An ECMA-only pattern (lookahead) that Go RE2 can't compile is SKIPPED locally — the leaf isn't
+// failed (claude enforced the real pattern on the wire), so a conforming value still passes.
+func TestSchemaPatternEcmaSkipped(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"p":"x1"}`)}
+	})
+	if _, err := runScript(t, "pt3", 1, leaf,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"p":{"type":"string","pattern":"(?=.*[0-9])"}}})`); err != nil {
+		t.Fatalf("an uncompilable (ECMA) pattern should be skipped, not fail: %v", err)
+	}
+}
+
+// format: a known format (email) is enforced; an invalid value fails.
+func TestSchemaFormat(t *testing.T) {
+	good := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"e":"a@b.com"}`)}
+	})
+	if _, err := runScript(t, "fm1", 1, good,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"e":{"type":"string","format":"email"}}})`); err != nil {
+		t.Fatalf("valid email should pass: %v", err)
+	}
+	bad := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"e":"nope"}`)}
+	})
+	if _, err := runScript(t, "fm2", 1, bad,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"e":{"type":"string","format":"email"}}})`); err == nil {
+		t.Fatal("want an invalid-email error")
+	}
+}
+
+// additionalProperties:false rejects a key not named in properties; a clean object passes.
+func TestSchemaAdditionalPropertiesFalse(t *testing.T) {
+	extra := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"a":1,"b":2}`)}
+	})
+	if _, err := runScript(t, "ap1", 1, extra,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"a":{"type":"integer"}},"additionalProperties":False})`); err == nil {
+		t.Fatal("want an additional-property error (b not allowed)")
+	}
+	clean := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"a":1}`)}
+	})
+	if _, err := runScript(t, "ap2", 1, clean,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"a":{"type":"integer"}},"additionalProperties":False})`); err != nil {
+		t.Fatalf("a clean object should pass: %v", err)
+	}
+}

--- a/internal/workflow/schema_composition_test.go
+++ b/internal/workflow/schema_composition_test.go
@@ -28,7 +28,7 @@ n = res["name"]
 	}
 }
 
-// allOf: violating ANY subschema fails validation terminally (one exec, no retry).
+// allOf: violating any subschema fails terminally (one exec, no retry).
 func TestSchemaAllOfViolationTerminal(t *testing.T) {
 	rec := &recorder{}
 	leaf := fakeLeaf(rec, func(leafCall) subagent.Result {
@@ -46,7 +46,7 @@ res = agent("q", vendor="v", schema={"allOf": [
 	}
 }
 
-// oneOf: a payload matching MORE than one subschema fails (must match exactly one).
+// oneOf: a payload matching more than one subschema fails (must match exactly one).
 func TestSchemaOneOfMatchesTwoFails(t *testing.T) {
 	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
 		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"card":"4111","bank":"acme"}`)}
@@ -80,8 +80,7 @@ z = res["shipTo"]["zip"]
 	}
 }
 
-// A oneOf whose other branch matches must still SURFACE a structural error (an unresolvable
-// $ref) in a sibling branch — never silently swallow it as "that branch didn't match".
+// oneOf surfaces a dangling-$ref structural error in a sibling branch even when another branch matches.
 func TestSchemaOneOfSurfacesBrokenRef(t *testing.T) {
 	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
 		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
@@ -95,8 +94,7 @@ res = agent("q", vendor="v", schema={"oneOf": [
 	}
 }
 
-// anyOf must surface a structural error even when an EARLIER branch already matched — it scans
-// every branch, not stopping at the first match.
+// anyOf scans every branch, so a structural error is not hidden by an earlier match.
 func TestSchemaAnyOfSurfacesBrokenRefAfterMatch(t *testing.T) {
 	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
 		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
@@ -110,8 +108,8 @@ res = agent("q", vendor="v", schema={"anyOf": [
 	}
 }
 
-// A structural defect surfaces even when a SIBLING keyword would short-circuit first: the broken
-// $ref in the second branch is caught before its mismatching type, so the value can't slip through.
+// A structural defect surfaces even behind a sibling keyword that would short-circuit: the $ref is
+// checked before the mismatching type, so the value can't slip through.
 func TestSchemaAnyOfDefectBehindMismatch(t *testing.T) {
 	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
 		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`"x"`)}
@@ -140,8 +138,7 @@ res = agent("q", vendor="v", schema={"anyOf": [
 	}
 }
 
-// An empty anyOf matches nothing, and an empty oneOf matches zero subschemas — both must FAIL,
-// not silently accept every value.
+// An empty anyOf matches nothing and an empty oneOf matches zero subschemas — both fail, not accept.
 func TestSchemaEmptyAnyOfOneOfFail(t *testing.T) {
 	for i, schema := range []string{`{"anyOf":[]}`, `{"oneOf":[]}`} {
 		l := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
@@ -187,6 +184,18 @@ res = agent("q", vendor="v", schema={
 	}
 }
 
+// An external (non intra-document) $ref is unsupported by the local backstop and fails validation
+// (claude's --json-schema is authoritative for it).
+func TestSchemaExternalRefFails(t *testing.T) {
+	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
+		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"a":1}`)}
+	})
+	if _, err := runScript(t, "co11", 1, leaf,
+		`res = agent("q", vendor="v", schema={"type":"object","properties":{"a":{"$ref":"https://example.com/s.json"}}})`); err == nil {
+		t.Fatal("want an error: an external $ref is unsupported by the local backstop")
+	}
+}
+
 // pattern: a string must match the regex; a mismatch fails.
 func TestSchemaPattern(t *testing.T) {
 	ok := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
@@ -205,8 +214,7 @@ func TestSchemaPattern(t *testing.T) {
 	}
 }
 
-// An ECMA-only pattern (lookahead) that Go RE2 can't compile is SKIPPED locally — the leaf isn't
-// failed (claude enforced the real pattern on the wire), so a conforming value still passes.
+// An ECMA-only pattern (lookahead) Go RE2 can't compile is skipped locally, so a conforming value passes.
 func TestSchemaPatternEcmaSkipped(t *testing.T) {
 	leaf := fakeLeaf(&recorder{}, func(leafCall) subagent.Result {
 		return subagent.Result{OK: true, StructuredOutput: json.RawMessage(`{"p":"x1"}`)}

--- a/skills/cc-fleet/references/workflow.md
+++ b/skills/cc-fleet/references/workflow.md
@@ -71,9 +71,14 @@ not JS.
 - `workflow(script_path, args=None)` — run another `.star` inline on the same engine
   (shared pool/journal/budget), **one level deep** only. Returns the child's module global
   `result` (Starlark module bodies have no top-level `return`), or `None`.
-- `budget` — `budget.total` (the `--budget-usd` cap, or `None`), `budget.spent()`,
-  `budget.remaining()` (`+inf` when uncapped). `agent()` raises once `spent() >= total`; a
-  `for`-loop guarded by `budget.remaining()` scales depth to the cap.
+- `budget` — two parallel cap surfaces. **USD:** `budget.total` (the `--budget-usd` cap in USD,
+  or `None`), `budget.spent()`, `budget.remaining()` (`+inf` when uncapped) — all USD floats (an
+  Anthropic list-price estimate). **Tokens:** `budget.tokens_total` (the `--budget-tokens` cap, or
+  `None`), `budget.tokens_spent()`, `budget.tokens_remaining()` — all ints (input+output, cache-read
+  excluded). `agent()` raises once **either** cap is reached; a `for`-loop guarded by
+  `budget.remaining()` or `budget.tokens_remaining()` scales depth to the cap. (Native's
+  `budget.total` is a token target; here it is **USD** — `--budget-usd` is the cross-vendor cap since
+  vendors price tokens differently — and tokens are the separate `tokens_*` surface.)
 - `phase(title, detail=None)` — name the current phase (tags subsequent agents lacking an
   explicit `phase=`; the detail shows on the board row). `log(msg)` — a narrator line (board
   live log + stderr).

--- a/skills/cc-fleet/references/workflow.md
+++ b/skills/cc-fleet/references/workflow.md
@@ -27,10 +27,13 @@ not JS.
   (a dict) the schema goes to the claude child via `--json-schema`: claude injects a forced
   `StructuredOutput` tool and enforces that it is CALLED (the native mechanism — no JSON
   instruction is added to the prompt); `agent()` returns the parsed structured payload.
-  Client-side validation stays as a backstop — a real (recursive) JSON-Schema subset:
+  Client-side validation stays as a backstop — a recursive JSON-Schema subset:
   `type` (object/array/string/number/integer/boolean/null; `integer` accepts `5.0`),
-  `required`, nested `properties`, array `items`, scalar `enum` (composition keywords
-  `$ref`/`allOf`/`oneOf` are NOT enforced). A validation failure — or a result envelope
+  `required`, nested `properties`, array `items`, scalar `enum`, string `pattern` (RE2 best-effort —
+  the wire enforces the authoritative ECMA regex) / `format` (email/uri/uuid/date/date-time),
+  `additionalProperties`, the composition keywords
+  `allOf`/`anyOf`/`oneOf`, and intra-document `$ref` (`#/…` pointers, e.g. `#/$defs/Addr`;
+  external URIs are not resolved). A validation failure — or a result envelope
   without a structured payload — FAILS the leaf; there is no automatic retry. The forced
   `StructuredOutput` call costs turns: give a schema'd leaf `max_turns` ≥ 3 headroom (a
   budget of 1 starves it). `schema=` needs claude ≥ 2.1.88 (the slim-profile floor); an
@@ -141,11 +144,12 @@ produce the same keys. A **failed** leaf is never journaled, so resume re-runs i
 ## Non-goals (state plainly, don't oversell)
 - **No pause.** A running `claude -p` can't be cleanly suspended; use `workflow stop` (reaps
   the run) + `run --resume` (cheap restart via the journal) instead.
-- **Client-side `schema=` validation is a practical subset** — `type`/`required`/nested
-  `properties`/array `items`/scalar `enum`, not the full JSON-Schema spec
-  (`$ref`/`allOf`/`oneOf` are ignored). claude enforces that `StructuredOutput` is called;
-  this backstop checks what it was filled with, and a failure is terminal (no retry).
-- **No deep `$ref`/composition.** Keep schemas concrete.
+- **Client-side `schema=` validation is a JSON-Schema subset** — `type`/`required`/nested
+  `properties`/array `items`/scalar `enum`/`pattern`/`format`/`additionalProperties`/`allOf`/
+  `anyOf`/`oneOf`/intra-document `$ref` (`#/…`), not the full spec (an external `$ref` URI is
+  unresolved → a validation error; an unknown `format` is an annotation, not enforced). claude
+  enforces that `StructuredOutput` is called; this backstop checks what it was filled with, and a
+  failure is terminal (no retry).
 - Key-safety is unchanged: the vendor key flows only via `apiKeyHelper`; prompts go to the
   leaf via stdin, never argv; the journal/events/board carry no key.
 

--- a/skills/cc-fleet/references/workflow.md
+++ b/skills/cc-fleet/references/workflow.md
@@ -33,7 +33,7 @@ not JS.
   the wire enforces the authoritative ECMA regex) / `format` (email/uri/uuid/date/date-time),
   `additionalProperties`, the composition keywords
   `allOf`/`anyOf`/`oneOf`, and intra-document `$ref` (`#/…` pointers, e.g. `#/$defs/Addr`;
-  external URIs are not resolved). A validation failure — or a result envelope
+  an external URI is unsupported and fails). A validation failure — or a result envelope
   without a structured payload — FAILS the leaf; there is no automatic retry. The forced
   `StructuredOutput` call costs turns: give a schema'd leaf `max_turns` ≥ 3 headroom (a
   budget of 1 starves it). `schema=` needs claude ≥ 2.1.88 (the slim-profile floor); an
@@ -147,7 +147,7 @@ produce the same keys. A **failed** leaf is never journaled, so resume re-runs i
 - **Client-side `schema=` validation is a JSON-Schema subset** — `type`/`required`/nested
   `properties`/array `items`/scalar `enum`/`pattern`/`format`/`additionalProperties`/`allOf`/
   `anyOf`/`oneOf`/intra-document `$ref` (`#/…`), not the full spec (an external `$ref` URI is
-  unresolved → a validation error; an unknown `format` is an annotation, not enforced). claude
+  unsupported and fails; an unknown `format` is an annotation, not enforced). claude
   enforces that `StructuredOutput` is called; this backstop checks what it was filled with, and a
   failure is terminal (no retry).
 - Key-safety is unchanged: the vendor key flows only via `apiKeyHelper`; prompts go to the


### PR DESCRIPTION
Two field-reported status-read bugs in the workflow runtime shared one root cause: StatusFor classified a dead detached or queued-placeholder job by passing the classifier a synthetic exit code of 0, because a Released detached job has no wait()-able exit status. That made "the process vanished without writing a terminal signal" indistinguishable from "exited 0 cleanly" — a text-mode queued placeholder that slipped past its queued branch was blessed as "done · 0 turns", and a dead background leaf with an empty capture reported the cause-erasing "claude exited 0 without a result envelope".

StatusFor now treats a job with no recorded process (PID<=0) and no cached result as queued — PID is the authority, not the Status string — so a placeholder can never reach the dead-classify path. A dead job that left no terminal signal (no JSON envelope or text answer) fails with an honest message that says the exit status is unknown rather than asserting a clean exit, and keeps any stderr clue. A one-shot confirm-delay re-read of a just-dead detached leaf's empty capture absorbs the visible-write race that made background done-detection flaky under heavy parallel test load.

The branch also closes several gaps with the native Workflow tool. The client-side schema= validator now enforces allOf/anyOf/oneOf, intra-document $ref (including array index), and pattern/format/additionalProperties — hand-rolled with no new dependency, with claude still enforcing the full schema on the wire via --json-schema. A run stopped with workflow stop finalizes its in-flight leaves as a neutral stopped rather than a red failed. The engine restamps the run manifest with its running spend as each leaf charges, so workflow status reports a live run-level total. And Usage now carries cache_creation_input_tokens, surfaced on the board when a leaf wrote the prompt cache.

The skill reference is updated to document the token budget surface (budget.tokens_total / tokens_spent() / tokens_remaining()) with both cap surfaces labeled by unit, and the widened schema keyword set.
