### PR TITLE
feat: run OpenAI-protocol endpoints and a ChatGPT subscription as Claude Code providers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) as real Claude Code agent-team teammates or one-shot subagents — driven exactly like native teammates. Your main session's own auth is untouched (OAuth subscription or API key, either works); vendor workers bill the vendor API key via apiKeyHelper (the key never enters env/argv/history). Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ day-to-day coding, not only for delegated work. `--model` overrides the default;
 / `--dangerously-skip-permissions` set the permission posture. **No tmux, no agent-teams** — just a
 terminal.
 
+### ChatGPT subscription as a provider (codex)
+
+> *Have a Codex / ChatGPT subscription? Drive gpt-5.x with it too.*
+
+```bash
+cc-fleet codex add && cc-fleet codex login
+```
+
+One `codex add` plus a device-code login turns the subscription into a regular provider —
+teammate, subagent, workflow leaf, or `cc-fleet run`, all answering through gpt-5.x. A local
+conversion daemon translates Claude's Anthropic calls to the OpenAI Responses API; the OAuth
+token stays inside the daemon (never in env, argv, or a profile), and cc-fleet keeps its own
+login so the codex CLI's auth is untouched. **Unofficial** — `codex login` asks for explicit
+confirmation; details in [the CLI guide](docs/cli.md#codex--reuse-a-chatgpt-subscription-as-a-provider).
+
 ### More example prompts
 
 - *"Spawn a glm teammate and a deepseek teammate; have each summarize its model's strengths, then compare the two."*

--- a/README_zh.md
+++ b/README_zh.md
@@ -170,6 +170,21 @@ cc-fleet run deepseek --dangerously-skip-permissions
 以用更便宜或不同司法辖区的模型，而不只是用来委派任务。`--model` 覆盖默认模型；`--permission-mode` /
 `--dangerously-skip-permissions` 设定权限模式。**无需 tmux、无需 agent-teams** —— 一个终端就够。
 
+### 用 ChatGPT 订阅当 provider（codex）
+
+> *有 Codex / ChatGPT 订阅？也能直接驱动 gpt-5.x。*
+
+```bash
+cc-fleet codex add && cc-fleet codex login
+```
+
+一次 `codex add` 加一次设备码登录，订阅就成了一个普通 provider —— teammate、subagent、
+workflow leaf、`cc-fleet run` 全部可用，由 gpt-5.x 作答。本地转换 daemon 把 Claude 的
+Anthropic 调用翻译成 OpenAI Responses API；OAuth token 只存在于 daemon 内部（绝不进
+env / argv / profile），且 cc-fleet 维护自己独立的登录，不碰 codex CLI 的认证。
+**非官方用法** —— `codex login` 会先要求明确确认；详见
+[CLI 指南](docs/cli.md#codex--reuse-a-chatgpt-subscription-as-a-provider)。
+
 ### 更多示例提示词
 
 - *"开一个 glm teammate 和一个 deepseek teammate，各自总结自己模型的强项，然后对比两者。"*

--- a/cmd/cc-fleet/codex.go
+++ b/cmd/cc-fleet/codex.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/x/term"
+	"github.com/spf13/cobra"
+
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/userops"
+)
+
+// codexRiskNotice is the consent gate shown before the device-code login:
+// subscription reuse outside the codex CLI is unofficial, and the risk lives at
+// OpenAI's account level — cc-fleet's independent token chain cannot remove it.
+const codexRiskNotice = `Reusing a ChatGPT subscription outside the codex CLI is unofficial and may
+violate OpenAI's terms of use; the account could be rate-limited or banned.
+cc-fleet keeps its own login (it never reads or writes ~/.codex auth), but that
+does not remove the account-level risk.`
+
+// newCodexCmd builds `cc-fleet codex {login,logout,status,add}` — cc-fleet's own
+// OAuth login for reusing a ChatGPT subscription, kept on an independent token
+// chain that never touches ~/.codex (so the codex CLI's own login is unaffected).
+func newCodexCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "codex",
+		Short: "Reuse a ChatGPT subscription as a cc-fleet provider",
+	}
+
+	var acceptRisk bool
+	login := &cobra.Command{
+		Use:           "login",
+		Short:         "Authorize cc-fleet against your ChatGPT subscription (device code)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !acceptRisk {
+				if err := confirmCodexRisk(cmd); err != nil {
+					return err
+				}
+			}
+			return codexproxy.Login(cmd.Context(), cmd.OutOrStdout())
+		},
+	}
+	login.Flags().BoolVar(&acceptRisk, "accept-risk", false, "skip the account-risk confirmation prompt")
+	cmd.AddCommand(login)
+
+	cmd.AddCommand(&cobra.Command{
+		Use:           "logout",
+		Short:         "Remove cc-fleet's codex login and stop the daemon",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := codexproxy.Logout(); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "logged out")
+			return nil
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "Show whether cc-fleet has a codex login",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			loggedIn, account := codexproxy.LoginStatus()
+			if loggedIn {
+				fmt.Printf("logged in (account %s)\n", account)
+			} else {
+				fmt.Println("not logged in — run: cc-fleet codex login")
+			}
+			return nil
+		},
+	})
+
+	var (
+		name  string
+		port  int
+		model string
+	)
+	add := &cobra.Command{
+		Use:           "add",
+		Short:         "Register the codex provider (auto-scans ~/.codex/config.toml for the model)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chosen, err := codexproxy.ChoosePort(port)
+			if err != nil {
+				return err
+			}
+			if model == "" {
+				model = codexproxy.ScanDefaultModel("gpt-5.5")
+			}
+			base := fmt.Sprintf("http://127.0.0.1:%d/", chosen)
+			res, err := userops.Add(userops.AddRequest{
+				Name:           name,
+				BaseURL:        base,
+				ModelsEndpoint: base + "v1/models",
+				DefaultModel:   model,
+				SecretBackend:  codexproxy.SecretBackend,
+				SecretRef:      codexproxy.SecretRef,
+				Enabled:        true,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "added provider %s (port %d, model %s)\n", res.Vendor, chosen, model)
+			if loggedIn, _ := codexproxy.LoginStatus(); !loggedIn {
+				fmt.Fprintln(cmd.OutOrStdout(), "next: cc-fleet codex login")
+			}
+			return nil
+		},
+	}
+	add.Flags().StringVar(&name, "name", "codex", "provider name to register")
+	add.Flags().IntVar(&port, "port", 0, "loopback port for the conversion daemon (default: first free in the reserved range)")
+	add.Flags().StringVar(&model, "model", "", "default model (default: ~/.codex/config.toml, else gpt-5.5)")
+	cmd.AddCommand(add)
+
+	return cmd
+}
+
+// confirmCodexRisk prints the risk notice and asks for explicit confirmation.
+// Non-interactive callers must pass --accept-risk (no silent opt-in).
+func confirmCodexRisk(cmd *cobra.Command) error {
+	fmt.Fprintln(cmd.OutOrStdout(), codexRiskNotice)
+	if !term.IsTerminal(os.Stdin.Fd()) {
+		return errors.New("non-interactive session: pass --accept-risk to confirm")
+	}
+	fmt.Fprint(cmd.OutOrStdout(), "Continue? [y/N] ")
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil {
+		return errors.New("aborted")
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return errors.New("aborted")
+	}
+}

--- a/cmd/cc-fleet/codex.go
+++ b/cmd/cc-fleet/codex.go
@@ -14,14 +14,6 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
 
-// codexRiskNotice is the consent gate shown before the device-code login:
-// subscription reuse outside the codex CLI is unofficial, and the risk lives at
-// OpenAI's account level — cc-fleet's independent token chain cannot remove it.
-const codexRiskNotice = `Reusing a ChatGPT subscription outside the codex CLI is unofficial and may
-violate OpenAI's terms of use; the account could be rate-limited or banned.
-cc-fleet keeps its own login (it never reads or writes ~/.codex auth), but that
-does not remove the account-level risk.`
-
 // newCodexCmd builds `cc-fleet codex {login,logout,status,add}` — cc-fleet's own
 // OAuth login for reusing a ChatGPT subscription, kept on an independent token
 // chain that never touches ~/.codex (so the codex CLI's own login is unaffected).
@@ -65,13 +57,24 @@ func newCodexCmd() *cobra.Command {
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "status",
-		Short: "Show whether cc-fleet has a codex login",
+		Short: "Show codex credential sources (the codex CLI login and cc-fleet's own)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loggedIn, account := codexproxy.LoginStatus()
-			if loggedIn {
-				fmt.Printf("logged in (account %s)\n", account)
+			st := codexproxy.StatusReport()
+			out := cmd.OutOrStdout()
+			ride := "unavailable"
+			if st.CLIRide {
+				ride = "available"
+			}
+			own := "absent"
+			if st.OwnLogin {
+				own = "present"
+			}
+			fmt.Fprintf(out, "cli-ride:  %s\n", ride)
+			fmt.Fprintf(out, "own-login: %s\n", own)
+			if st.Active == "none" {
+				fmt.Fprintln(out, "active:    none — log in with the codex CLI, or run: cc-fleet codex login")
 			} else {
-				fmt.Println("not logged in — run: cc-fleet codex login")
+				fmt.Fprintf(out, "active:    %s (account %s)\n", st.Active, st.Account)
 			}
 			return nil
 		},
@@ -126,7 +129,7 @@ func newCodexCmd() *cobra.Command {
 // confirmCodexRisk prints the risk notice and asks for explicit confirmation.
 // Non-interactive callers must pass --accept-risk (no silent opt-in).
 func confirmCodexRisk(cmd *cobra.Command) error {
-	fmt.Fprintln(cmd.OutOrStdout(), codexRiskNotice)
+	fmt.Fprintln(cmd.OutOrStdout(), codexproxy.RiskNotice)
 	if !term.IsTerminal(os.Stdin.Fd()) {
 		return errors.New("non-interactive session: pass --accept-risk to confirm")
 	}

--- a/cmd/cc-fleet/codexproxy.go
+++ b/cmd/cc-fleet/codexproxy.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+)
+
+// newCodexProxyCmd builds `cc-fleet codex-proxy {serve,stop,status}` — the local
+// Anthropic<->OpenAI conversion daemon. `serve` is started detached by the run
+// modes; users normally only touch `stop`/`status`.
+func newCodexProxyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "codex-proxy",
+		Short: "Manage the codex conversion daemon",
+	}
+	var port int
+	serve := &cobra.Command{
+		Use:           "serve",
+		Short:         "Run the codex conversion daemon (loopback only)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if port <= 0 {
+				return fmt.Errorf("--port is required")
+			}
+			return codexproxy.Serve(port)
+		},
+	}
+	serve.Flags().IntVar(&port, "port", 0, "loopback port to bind")
+	cmd.AddCommand(serve)
+	cmd.AddCommand(&cobra.Command{
+		Use:   "stop",
+		Short: "Stop the codex conversion daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return codexproxy.StopDaemon()
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "Show the codex conversion daemon status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			running, p := codexproxy.Status()
+			if running {
+				fmt.Printf("running on 127.0.0.1:%d\n", p)
+			} else {
+				fmt.Println("not running")
+			}
+			return nil
+		},
+	})
+	return cmd
+}

--- a/cmd/cc-fleet/codexproxy.go
+++ b/cmd/cc-fleet/codexproxy.go
@@ -16,20 +16,26 @@ func newCodexProxyCmd() *cobra.Command {
 		Use:   "codex-proxy",
 		Short: "Manage the codex conversion daemon",
 	}
-	var port int
+	var (
+		port        int
+		protocol    string
+		upstreamURL string
+	)
 	serve := &cobra.Command{
 		Use:           "serve",
-		Short:         "Run the codex conversion daemon (loopback only)",
+		Short:         "Run the conversion daemon (loopback only)",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if port <= 0 {
 				return fmt.Errorf("--port is required")
 			}
-			return codexproxy.Serve(port)
+			return codexproxy.Serve(port, protocol, upstreamURL)
 		},
 	}
 	serve.Flags().IntVar(&port, "port", 0, "loopback port to bind")
+	serve.Flags().StringVar(&protocol, "protocol", "", "wire protocol (default: codex-oauth)")
+	serve.Flags().StringVar(&upstreamURL, "upstream-url", "", "real upstream base URL (openai-* protocols)")
 	cmd.AddCommand(serve)
 	cmd.AddCommand(&cobra.Command{
 		Use:   "stop",
@@ -40,13 +46,15 @@ func newCodexProxyCmd() *cobra.Command {
 	})
 	cmd.AddCommand(&cobra.Command{
 		Use:   "status",
-		Short: "Show the codex conversion daemon status",
+		Short: "Show the conversion daemon status",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			running, p := codexproxy.Status()
-			if running {
-				fmt.Printf("running on 127.0.0.1:%d\n", p)
-			} else {
+			daemons := codexproxy.RunningDaemons()
+			if len(daemons) == 0 {
 				fmt.Println("not running")
+				return nil
+			}
+			for _, d := range daemons {
+				fmt.Printf("running on 127.0.0.1:%d (%s)\n", d.Port, d.Protocol)
 			}
 			return nil
 		},

--- a/cmd/cc-fleet/main.go
+++ b/cmd/cc-fleet/main.go
@@ -46,6 +46,8 @@ teammate Claude Code sessions inside tmux windows.`,
 	root.AddCommand(newSubagentGCCmd())
 	root.AddCommand(newWorkflowCmd())
 	root.AddCommand(newRunCmd())
+	root.AddCommand(newCodexCmd())
+	root.AddCommand(newCodexProxyCmd())
 	root.AddCommand(newTeardownCmd())
 	root.AddCommand(newHideCmd())
 	root.AddCommand(newShowCmd())

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,8 @@ drive it through plain language, but every command also works directly. Run `cc-
 | `spawn <vendor>` | Spawn a vendor teammate as a tmux pane (Claude layer). |
 | `subagent <vendor>` | Run a one-shot headless vendor subagent. |
 | `run <vendor>` | Launch an interactive vendor-backed `claude` session (foreground; you drive it). |
+| `codex add` / `login` / `logout` / `status` | Register the ChatGPT-subscription provider + manage cc-fleet's own codex login. |
+| `codex-proxy status` / `stop` | Inspect / stop the local codex conversion daemon. |
 | `ps` | List live cc-fleet teammates (`--json`, `--check` for health). |
 | `hide` / `show` | Hide / restore a teammate's tmux pane without killing it. |
 | `teardown <team\|%pane>` | Kill teammate panes and clean up team state. |
@@ -121,6 +123,28 @@ Disabled keys are filtered out before selection. Keys are shown masked everywher
 `~/.config/cc-fleet/secrets/`), or an external manager referenced by `--secret-ref`
 (1Password, Vault, keyring). For non-file backends you provision the secret through that
 backend's own CLI; cc-fleet only resolves it at `keyget` time.
+
+## Codex — reuse a ChatGPT subscription as a provider
+
+A `codex` provider drives OpenAI gpt-5.x through your existing ChatGPT/Codex
+subscription — as a teammate, subagent, workflow leaf, or `cc-fleet run` session:
+
+```bash
+cc-fleet codex add      # register the provider (port + default model auto-picked)
+cc-fleet codex login    # one-time device-code OAuth (prints a URL + code)
+```
+
+The `claude` process speaks the Anthropic API to a loopback conversion daemon
+(`codex-proxy`, started lazily, self-exits when idle with no codex worker left);
+the daemon translates to the OpenAI Responses API and calls the ChatGPT backend.
+The OAuth bearer lives only inside the daemon — `keyget` hands claude a low-value
+loopback handshake secret, and the token never enters env, argv, or any profile.
+cc-fleet keeps its **own** token chain (`codex login`), never reading or writing
+`~/.codex` auth, so the codex CLI's login is unaffected.
+
+> **Unofficial:** reusing a subscription outside the codex CLI may violate
+> OpenAI's terms; the account could be rate-limited or banned. `codex login`
+> asks for explicit confirmation, and quota errors surface with their reset time.
 
 ## Health & repair
 

--- a/internal/codexproxy/cliride.go
+++ b/internal/codexproxy/cliride.go
@@ -1,0 +1,133 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// codexCLIAuth is the subset of ~/.codex/auth.json that cc-fleet reads. The
+// refresh_token is deliberately absent from this struct so it is never even
+// deserialized into memory: cc-fleet rides the codex CLI's access token but
+// never rotates its chain, so it cannot trip OpenAI's reuse detection.
+type codexCLIAuth struct {
+	Tokens struct {
+		AccessToken string `json:"access_token"`
+		AccountID   string `json:"account_id"`
+		IDToken     string `json:"id_token"`
+	} `json:"tokens"`
+}
+
+// codexCLIAuthPath is the codex CLI's own credential file, opened READ-ONLY.
+func codexCLIAuthPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "auth.json"), nil
+}
+
+// cliRideStore is the composite codex credential source. It prefers cc-fleet's own
+// login (an explicit `cc-fleet codex login` on the ownStore device-code chain) and
+// rides the codex CLI's existing login (~/.codex/auth.json, read-only) only when
+// there is no own login. Re-reading ~/.codex on every ride serves the codex CLI's
+// latest token for free, without cc-fleet ever refreshing that chain itself.
+type cliRideStore struct {
+	own *ownStore
+}
+
+func newCLIRideStore() (*cliRideStore, error) {
+	own, err := newOwnStore()
+	if err != nil {
+		return nil, err
+	}
+	return &cliRideStore{own: own}, nil
+}
+
+func (s *cliRideStore) token(ctx context.Context) (bearer, error) {
+	// cc-fleet's own login is authoritative: an explicit `cc-fleet codex login`
+	// wins. Ride the codex CLI's ~/.codex only when there is no own login; with
+	// neither, the own store returns ErrReauth.
+	if s.own.loggedIn() {
+		return s.own.token(ctx)
+	}
+	if b, ok := readCLIRideToken(); ok {
+		return b, nil
+	}
+	return s.own.token(ctx)
+}
+
+// invalidate forwards only to the own chain: a CLI-ride token is generation 0 and
+// cc-fleet cannot refresh it (that is the codex CLI's job), so a 401 on it is
+// terminal here — the next token() re-reads ~/.codex and falls back if it is gone.
+func (s *cliRideStore) invalidate(gen uint64) {
+	if gen != 0 {
+		s.own.invalidate(gen)
+	}
+}
+
+// readCLIRideToken reads a still-valid access token from ~/.codex/auth.json
+// read-only and returns it as a generation-0 bearer. A missing/corrupt file or an
+// expired/near-expiry token returns ok=false so the caller falls back to the own
+// chain. The file is never written and the refresh_token is never read.
+func readCLIRideToken() (bearer, bool) {
+	p, err := codexCLIAuthPath()
+	if err != nil {
+		return bearer{}, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return bearer{}, false
+	}
+	var a codexCLIAuth
+	if err := json.Unmarshal(b, &a); err != nil {
+		return bearer{}, false // partial/corrupt (codex CLI mid-rotation): unavailable
+	}
+	access := a.Tokens.AccessToken
+	if access == "" {
+		return bearer{}, false
+	}
+	exp, ok := tokenExpiry(access)
+	if !ok || !time.Now().Before(exp.Add(-refreshSkew)) {
+		return bearer{}, false // expired or near expiry: fall back to the own chain
+	}
+	account := accountIDFromTokens(&tokens{
+		AccessToken: access,
+		AccountID:   a.Tokens.AccountID,
+		IDToken:     a.Tokens.IDToken,
+	})
+	return bearer{accessToken: access, accountID: account, generation: 0}, true
+}
+
+// CredStatus reports the state of both codex credential sources for
+// `cc-fleet codex status` and the TUI's CLI-auth flow.
+type CredStatus struct {
+	CLIRide  bool   // an unexpired ~/.codex access token is present
+	OwnLogin bool   // cc-fleet's own refresh chain is present
+	Active   string // the source token() would serve now: "cli-ride", "own", or "none"
+	Account  string // masked account id of the active source, if any
+}
+
+// StatusReport summarizes both codex credential sources without any refresh or
+// network call (it only reads what is already on disk).
+func StatusReport() CredStatus {
+	var st CredStatus
+	if loggedIn, account := LoginStatus(); loggedIn {
+		st.OwnLogin = true
+		st.Active = "own"
+		st.Account = account
+	}
+	if b, ok := readCLIRideToken(); ok {
+		st.CLIRide = true
+		if st.Active == "" {
+			st.Active = "cli-ride"
+			st.Account = redactAccount(b.accountID)
+		}
+	}
+	if st.Active == "" {
+		st.Active = "none"
+	}
+	return st
+}

--- a/internal/codexproxy/cliride_test.go
+++ b/internal/codexproxy/cliride_test.go
@@ -1,0 +1,268 @@
+package codexproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// recordRT fails any request and counts it, so a test can assert the ride path
+// reaches the network zero times.
+type recordRT struct{ calls int }
+
+func (r *recordRT) RoundTrip(*http.Request) (*http.Response, error) {
+	r.calls++
+	return nil, errors.New("no network expected on the ride path")
+}
+
+// writeCLIAuth writes a ~/.codex/auth.json carrying the given access token plus a
+// refresh_token that cc-fleet must never read, and returns the exact bytes.
+func writeCLIAuth(t *testing.T, home, access string) []byte {
+	t.Helper()
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"OPENAI_API_KEY": nil,
+		"tokens": map[string]any{
+			"id_token":      "idt",
+			"access_token":  access,
+			"refresh_token": "SECRET-RT-DO-NOT-READ",
+			"account_id":    "acc-stored",
+		},
+		"last_refresh": "2026-06-08T00:00:00Z",
+	})
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func rideStore(t *testing.T, rec *recordRT) *cliRideStore {
+	t.Helper()
+	own, err := newOwnStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	own.oauth = &oauthClient{http: &http.Client{Transport: rec}}
+	return &cliRideStore{own: own}
+}
+
+func authBytes(t *testing.T, home string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// An unexpired ~/.codex token is served read-only as a generation-0 bearer
+// without any network call, and the auth file is left byte-identical.
+func TestCLIRide_ServesUnexpiredTokenReadOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	access := fakeJWT(map[string]any{"exp": float64(time.Now().Add(time.Hour).Unix())})
+	before := writeCLIAuth(t, home, access)
+
+	rec := &recordRT{}
+	b, err := rideStore(t, rec).token(context.Background())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if b.accessToken != access || b.generation != 0 {
+		t.Fatalf("ride bearer = {gen %d}, want the CLI access token at gen 0", b.generation)
+	}
+	if b.accountID != "acc-stored" {
+		t.Fatalf("account id = %q, want acc-stored", b.accountID)
+	}
+	if rec.calls != 0 {
+		t.Fatalf("ride path made %d network calls, want 0", rec.calls)
+	}
+	if !bytes.Equal(before, authBytes(t, home)) {
+		t.Fatal("~/.codex/auth.json was modified")
+	}
+}
+
+// An expired CLI token falls back to the own chain (here absent → ErrReauth),
+// and the auth file is still left byte-identical.
+func TestCLIRide_FallsBackWhenExpired(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	access := fakeJWT(map[string]any{"exp": float64(time.Now().Add(-time.Hour).Unix())})
+	before := writeCLIAuth(t, home, access)
+
+	rec := &recordRT{}
+	if _, err := rideStore(t, rec).token(context.Background()); !errors.Is(err, ErrReauth) {
+		t.Fatalf("expired ride + no own login: err = %v, want ErrReauth", err)
+	}
+	if !bytes.Equal(before, authBytes(t, home)) {
+		t.Fatal("~/.codex/auth.json was modified on the fallback path")
+	}
+}
+
+// With no ~/.codex at all, token() falls straight through to the own chain.
+func TestCLIRide_FallsBackWhenAbsent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	rec := &recordRT{}
+	if _, err := rideStore(t, rec).token(context.Background()); !errors.Is(err, ErrReauth) {
+		t.Fatalf("absent ride + no own login: err = %v, want ErrReauth", err)
+	}
+}
+
+// With both an own login and a valid ride token present, token() serves the own
+// login (its bearer is generation != 0; the ride's is 0).
+func TestCLIRide_OwnLoginTakesPriority(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeCLIAuth(t, home, fakeJWT(map[string]any{"exp": float64(time.Now().Add(time.Hour).Unix())}))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  fakeJWT(map[string]any{"exp": float64(time.Now().Add(time.Hour).Unix())}),
+			"refresh_token": "rt-next",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	target, _ := url.Parse(srv.URL)
+
+	p, err := storePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"refresh_token":"rt-0","account_id":"own-acc"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	own, err := newOwnStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	own.oauth = &oauthClient{http: &http.Client{Transport: rewriteRT{target}}}
+	s := &cliRideStore{own: own}
+
+	b, err := s.token(context.Background())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if b.generation == 0 {
+		t.Fatal("own login must take priority over the ride (own bearer is gen != 0)")
+	}
+}
+
+// invalidate(0) is a no-op (the CLI-ride token cannot be refreshed); a non-zero
+// generation forwards to the own chain.
+func TestCLIRide_InvalidateGenDomain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	own, err := newOwnStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	own.gen = 5
+	own.expiry = time.Now().Add(time.Hour)
+	s := &cliRideStore{own: own}
+
+	s.invalidate(0)
+	if own.expiry.IsZero() {
+		t.Fatal("invalidate(0) must not disturb the own chain")
+	}
+	s.invalidate(5)
+	if !own.expiry.IsZero() {
+		t.Fatal("invalidate(own gen) must force the own chain to refresh")
+	}
+}
+
+func TestStatusReport(t *testing.T) {
+	unexpired := func() string {
+		return fakeJWT(map[string]any{"exp": float64(time.Now().Add(time.Hour).Unix())})
+	}
+	writeOwn := func(t *testing.T) {
+		t.Helper()
+		p, err := storePath()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(`{"refresh_token":"rt","account_id":"own-acc"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("none", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		st := StatusReport()
+		if st.CLIRide || st.OwnLogin || st.Active != "none" {
+			t.Fatalf("none: %+v", st)
+		}
+	})
+	t.Run("ride only", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		writeCLIAuth(t, home, unexpired())
+		st := StatusReport()
+		if !st.CLIRide || st.OwnLogin || st.Active != "cli-ride" || st.Account == "" {
+			t.Fatalf("ride only: %+v", st)
+		}
+	})
+	t.Run("own only", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		writeOwn(t)
+		st := StatusReport()
+		if st.CLIRide || !st.OwnLogin || st.Active != "own" {
+			t.Fatalf("own only: %+v", st)
+		}
+	})
+	t.Run("both prefer own", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		writeCLIAuth(t, home, unexpired())
+		writeOwn(t)
+		st := StatusReport()
+		if !st.CLIRide || !st.OwnLogin || st.Active != "own" {
+			t.Fatalf("both: %+v", st)
+		}
+	})
+}
+
+func TestAccountIDOrganizationsRung(t *testing.T) {
+	// organizations[0].id is the last-resort rung under the auth namespace.
+	orgClaim := map[string]any{jwtAuthClaim: map[string]any{
+		"organizations": []any{map[string]any{"id": "org-7"}},
+	}}
+	if got := accountIDFromTokens(&tokens{IDToken: fakeJWT(orgClaim)}); got != "org-7" {
+		t.Fatalf("organizations rung: %q", got)
+	}
+	// a top-level chatgpt_account_id wins over the namespaced claim.
+	top := map[string]any{
+		"chatgpt_account_id": "top-1",
+		jwtAuthClaim:         map[string]any{"chatgpt_account_id": "nested"},
+	}
+	if got := accountIDFromTokens(&tokens{AccessToken: fakeJWT(top)}); got != "top-1" {
+		t.Fatalf("top-level account id: %q", got)
+	}
+}

--- a/internal/codexproxy/daemon.go
+++ b/internal/codexproxy/daemon.go
@@ -28,11 +28,21 @@ const (
 	readyTimeout = 10 * time.Second
 )
 
-func stateDir() (string, error)   { return config.ConfigDir() }
-func statePath() (string, error)  { return joinConfig("codex-proxy.json") }
-func secretPath() (string, error) { return joinConfig("codex-proxy-secret") }
-func lockPath() (string, error)   { return joinConfig(".cc-fleet-codex-proxy.lock") }
-func leasesDir() (string, error)  { return joinConfig("codex-proxy-leases") }
+// Daemon state is per-port: a state file, a start/exit lock, and a lease dir keyed
+// by port, so a codex daemon and an openai daemon (or two openai daemons) coexist
+// without overwriting each other. The handshake secret + its create-once lock and
+// the token lock stay GLOBAL (one per install), shared by all codex daemons.
+func statePath(port int) (string, error) {
+	return joinConfig(fmt.Sprintf("codex-proxy-%d.json", port))
+}
+func lockPath(port int) (string, error) {
+	return joinConfig(fmt.Sprintf(".cc-fleet-codex-proxy-%d.lock", port))
+}
+func leasesDir(port int) (string, error) {
+	return joinConfig(fmt.Sprintf("codex-proxy-leases-%d", port))
+}
+func secretPath() (string, error)     { return joinConfig("codex-proxy-secret") }
+func secretLockPath() (string, error) { return joinConfig(".cc-fleet-codex-secret.lock") }
 
 func joinConfig(name string) (string, error) {
 	dir, err := config.ConfigDir()
@@ -42,30 +52,47 @@ func joinConfig(name string) (string, error) {
 	return filepath.Join(dir, name), nil
 }
 
-// proxyState is the persisted daemon descriptor (pid + procStart guard against PID
-// reuse; the port the daemon is bound to).
+// proxyState is the persisted daemon descriptor: pid + procStart guard against PID
+// reuse; the bound port; and the identity (protocol + upstream URL) a reuse check
+// matches against so a daemon left from a different vendor is never reused.
 type proxyState struct {
-	Port      int    `json:"port"`
-	PID       int    `json:"pid"`
-	ProcStart string `json:"proc_start"`
+	Port        int    `json:"port"`
+	PID         int    `json:"pid"`
+	ProcStart   string `json:"proc_start"`
+	Protocol    string `json:"protocol"`
+	UpstreamURL string `json:"upstream_url,omitempty"`
 }
 
-// withProxyLock serializes daemon start / exit decisions. It is the FIFTH flock
-// scope and is held with NONE of the other four (vendors / team / server / run),
-// so it cannot form a lock-order cycle.
-func withProxyLock(fn func() error) error {
-	p, err := lockPath()
+// withProxyLock serializes a single port's daemon start / exit decisions. It is a
+// standalone flock scope, held with none of the others (vendors / team / server /
+// run / secret / token), so it cannot form a lock-order cycle.
+func withProxyLock(port int, fn func() error) error {
+	p, err := lockPath(port)
 	if err != nil {
 		return err
 	}
 	return config.WithFlock(p, fn)
 }
 
-// SecretForKeyget returns the stable loopback handshake secret, creating it once.
-// keyget hands this (not the upstream token) to the claude process.
+// withSecretLock serializes the handshake secret's create-once. It is global (the
+// secret is per-install), so two first-time daemons on different ports never
+// race-overwrite it (which would desync keyget from a running daemon). Standalone
+// — acquired and released before the per-port proxy lock in EnsureDaemon, never
+// nested with it, so no ordering cycle.
+func withSecretLock(fn func() error) error {
+	p, err := secretLockPath()
+	if err != nil {
+		return err
+	}
+	return config.WithFlock(p, fn)
+}
+
+// SecretForKeyget returns the stable loopback handshake secret, creating it once
+// under the global secret lock. keyget hands this (not the upstream token) to the
+// claude process.
 func SecretForKeyget() (string, error) {
 	var secret string
-	err := withProxyLock(func() error {
+	err := withSecretLock(func() error {
 		s, e := loadOrCreateSecret()
 		secret = s
 		return e
@@ -92,17 +119,17 @@ func loadOrCreateSecret() (string, error) {
 	return secret, nil
 }
 
-// PortFromBaseURL extracts the loopback port from a codex vendor's base_url,
-// validating it is a plain loopback http URL first (config.ParseLoopbackURL is
-// the shared definition, also used at config load/validate time).
+// PortFromBaseURL extracts the loopback port from a daemon-backed vendor's
+// base_url, validating it is a plain loopback http URL first (config.ParseLoopbackURL
+// is the shared definition, also used at config load/validate time).
 func PortFromBaseURL(baseURL string) (int, error) {
 	u, err := config.ParseLoopbackURL(baseURL)
 	if err != nil {
-		return 0, fmt.Errorf("codex base_url %w", err)
+		return 0, fmt.Errorf("base_url %w", err)
 	}
 	port, err := strconv.Atoi(u.Port())
 	if err != nil || port <= 0 {
-		return 0, fmt.Errorf("codex base_url %q has no valid port", baseURL)
+		return 0, fmt.Errorf("base_url %q has no valid port", baseURL)
 	}
 	return port, nil
 }
@@ -119,58 +146,92 @@ func EnsureForVendorName(name string) error {
 	return EnsureForVendor(cfg.Vendors[name])
 }
 
-// EnsureForVendor ensures the proxy daemon is up for a codex provider (a no-op for
-// any other vendor). Call it after the fingerprint gate and before the profile write.
+// EnsureForVendor ensures the proxy daemon is up for a daemon-backed provider (a
+// no-op for an Anthropic-native vendor). Call it after the fingerprint gate and
+// before the profile write. Keys on the normalized protocol so a codex row
+// predating the protocol field (codex-oauth backend, no protocol) is recognized.
 func EnsureForVendor(v *config.Vendor) error {
-	if v == nil || v.SecretBackend != SecretBackend {
+	if v == nil || !v.DaemonBacked() {
 		return nil
-	}
-	// models_endpoint must also stay loopback — a probe sends the handshake secret
-	// there, so a remote one would leak it off-host.
-	if v.ModelsEndpoint != "" {
-		if _, err := config.ParseLoopbackURL(v.ModelsEndpoint); err != nil {
-			return fmt.Errorf("codex models_endpoint %w", err)
-		}
 	}
 	port, err := PortFromBaseURL(v.BaseURL)
 	if err != nil {
 		return err
 	}
-	return EnsureDaemon(port)
+	// codex also serves its models_endpoint from the daemon, and a probe sends the
+	// handshake secret there, so it too must stay loopback.
+	if v.EffectiveProtocol() == config.ProtocolCodexOAuth && v.ModelsEndpoint != "" {
+		if _, err := config.ParseLoopbackURL(v.ModelsEndpoint); err != nil {
+			return fmt.Errorf("codex models_endpoint %w", err)
+		}
+	}
+	return EnsureDaemon(port, v.EffectiveProtocol(), v.UpstreamURL)
 }
 
-// EnsureDaemon makes the codex proxy daemon reachable on port, lazily and
-// single-flight under the proxy lock, and registers a launch lease that keeps the
-// daemon alive across the window before the launched claude is visible. Slot it
-// after the fingerprint gate and before the profile-write side effect.
-func EnsureDaemon(port int) error {
-	return withProxyLock(func() error {
-		if _, err := loadOrCreateSecret(); err != nil {
+// EnsureDaemon makes the proxy daemon for (port, protocol, upstreamURL) reachable,
+// lazily and single-flight under that port's proxy lock, and registers a launch
+// lease that keeps it alive across the window before the launched claude is
+// visible. A live daemon is reused only if its persisted identity matches; a
+// mismatch is torn down and restarted. Slot it after the fingerprint gate and
+// before the profile-write side effect.
+func EnsureDaemon(port int, protocol, upstreamURL string) error {
+	if protocol == config.ProtocolCodexOAuth {
+		if err := withSecretLock(func() error { _, e := loadOrCreateSecret(); return e }); err != nil {
 			return err
 		}
-		if !healthy(port) {
-			if err := startDetached(port); err != nil {
+	}
+	return withProxyLock(port, func() error {
+		if !healthy(port, protocol, upstreamURL) {
+			stopStaleDaemon(port)
+			if err := startDetached(port, protocol, upstreamURL); err != nil {
 				return err
 			}
 			if err := waitReady(port); err != nil {
 				return err
 			}
 		}
-		return registerLease()
+		return registerLease(port)
 	})
 }
 
-func healthy(port int) bool {
-	st, err := readState()
+// healthy reports whether a live daemon on port already serves this exact identity.
+// A dead pid, a different protocol/upstream (port reuse or an edited vendor), or an
+// unresponsive port all return false. Readiness is the upstream-independent
+// /healthz: an openai daemon's /v1/models returns an empty list (its models come
+// from the real upstream), so it is no readiness signal.
+func healthy(port int, protocol, upstreamURL string) bool {
+	st, err := readState(port)
 	if err != nil || st.Port != port || st.PID <= 0 || !pidAlive(st.PID, st.ProcStart) {
+		return false
+	}
+	if st.Protocol != protocol || st.UpstreamURL != upstreamURL {
 		return false
 	}
 	return portResponds(port)
 }
 
+// stopStaleDaemon interrupts a live daemon whose identity no longer matches and
+// waits briefly for it to free the port, so EnsureDaemon can rebind it. A no-op
+// when no daemon (or a dead one) holds the port.
+func stopStaleDaemon(port int) {
+	st, err := readState(port)
+	if err != nil {
+		return
+	}
+	if st.PID > 0 && pidAlive(st.PID, st.ProcStart) {
+		if proc, e := os.FindProcess(st.PID); e == nil {
+			_ = proc.Signal(os.Interrupt)
+		}
+		for i := 0; i < 20 && whoHoldsPort(port); i++ {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	clearState(port)
+}
+
 func portResponds(port int) bool {
 	c := &http.Client{Timeout: 1500 * time.Millisecond}
-	resp, err := c.Get(fmt.Sprintf("http://127.0.0.1:%d/v1/models", port))
+	resp, err := c.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", port))
 	if err != nil {
 		return false
 	}
@@ -178,18 +239,23 @@ func portResponds(port int) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-func startDetached(port int) error {
+func startDetached(port int, protocol, upstreamURL string) error {
 	if held := whoHoldsPort(port); held {
-		return fmt.Errorf("port %d is held by another process; free it or set a different codex base_url port", port)
+		return fmt.Errorf("port %d is held by another process; free it or set a different base_url port", port)
 	}
 	bin, err := os.Executable()
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(bin, "codex-proxy", "serve", "--port", strconv.Itoa(port))
+	args := []string{"codex-proxy", "serve", "--port", strconv.Itoa(port), "--protocol", protocol}
+	if upstreamURL != "" {
+		args = append(args, "--upstream-url", upstreamURL)
+	}
+	cmd := exec.Command(bin, args...)
 	cmd.Stdout, cmd.Stderr = nil, nil
 	// Scrub the launcher's creds + nested-CC/teams markers from the long-lived
-	// daemon (it authenticates via its own OAuth chain, never the lead's env).
+	// daemon (codex authenticates via its own OAuth chain; an openai daemon takes
+	// the key per request, never from the lead's env).
 	cmd.Env = childenv.Clean(os.Environ())
 	detach(cmd)
 	if err := cmd.Start(); err != nil {
@@ -222,9 +288,9 @@ func waitReady(port int) error {
 	return fmt.Errorf("codex proxy did not become ready on port %d", port)
 }
 
-func readState() (proxyState, error) {
+func readState(port int) (proxyState, error) {
 	var st proxyState
-	p, err := statePath()
+	p, err := statePath(port)
 	if err != nil {
 		return st, err
 	}
@@ -236,12 +302,40 @@ func readState() (proxyState, error) {
 }
 
 func writeState(st proxyState) error {
-	p, err := statePath()
+	p, err := statePath(st.Port)
 	if err != nil {
 		return err
 	}
 	b, _ := json.MarshalIndent(st, "", "  ")
 	return fileutil.AtomicWrite(p, b, 0o600)
+}
+
+// listStates returns every persisted per-port daemon descriptor.
+func listStates() []proxyState {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []proxyState
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "codex-proxy-") || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		var st proxyState
+		if json.Unmarshal(b, &st) == nil && st.Port > 0 {
+			out = append(out, st)
+		}
+	}
+	return out
 }
 
 func pidAlive(pid int, procStart string) bool {
@@ -253,8 +347,8 @@ func pidAlive(pid int, procStart string) bool {
 
 // registerLease writes a short-TTL lease so the daemon won't exit during the window
 // between ensureDaemon returning and the launched claude appearing in the table.
-func registerLease() error {
-	dir, err := leasesDir()
+func registerLease(port int) error {
+	dir, err := leasesDir(port)
 	if err != nil {
 		return err
 	}
@@ -268,9 +362,9 @@ func registerLease() error {
 	return fileutil.AtomicWrite(filepath.Join(dir, name), []byte(strconv.FormatInt(expires, 10)), 0o600)
 }
 
-// activeLeases counts unexpired leases and prunes expired ones.
-func activeLeases() int {
-	dir, err := leasesDir()
+// activeLeases counts unexpired leases for a port and prunes expired ones.
+func activeLeases(port int) int {
+	dir, err := leasesDir(port)
 	if err != nil {
 		return 0
 	}
@@ -296,9 +390,9 @@ func activeLeases() int {
 	return active
 }
 
-// liveCodexWorkers counts running claude processes whose --settings profile points
-// at this proxy's port. A scan error returns -1 ("unknown" -> daemon stays alive).
-func liveCodexWorkers(port int) int {
+// liveWorkers counts running claude processes whose --settings profile points at
+// this proxy's port. A scan error returns -1 ("unknown" -> daemon stays alive).
+func liveWorkers(port int) int {
 	table, err := procintrospect.ProcessTable()
 	if err != nil {
 		return -1

--- a/internal/codexproxy/daemon.go
+++ b/internal/codexproxy/daemon.go
@@ -1,0 +1,343 @@
+package codexproxy
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/childenv"
+	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/fileutil"
+	"github.com/ethanhq/cc-fleet/internal/procintrospect"
+)
+
+// Daemon timing. leaseTTL must comfortably exceed the gap between ensureDaemon
+// returning and the launched claude appearing in the process table.
+const (
+	leaseTTL     = 90 * time.Second
+	idleGrace    = 5 * time.Minute
+	readyTimeout = 10 * time.Second
+)
+
+func stateDir() (string, error)   { return config.ConfigDir() }
+func statePath() (string, error)  { return joinConfig("codex-proxy.json") }
+func secretPath() (string, error) { return joinConfig("codex-proxy-secret") }
+func lockPath() (string, error)   { return joinConfig(".cc-fleet-codex-proxy.lock") }
+func leasesDir() (string, error)  { return joinConfig("codex-proxy-leases") }
+
+func joinConfig(name string) (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
+}
+
+// proxyState is the persisted daemon descriptor (pid + procStart guard against PID
+// reuse; the port the daemon is bound to).
+type proxyState struct {
+	Port      int    `json:"port"`
+	PID       int    `json:"pid"`
+	ProcStart string `json:"proc_start"`
+}
+
+// withProxyLock serializes daemon start / exit decisions. It is the FIFTH flock
+// scope and is held with NONE of the other four (vendors / team / server / run),
+// so it cannot form a lock-order cycle.
+func withProxyLock(fn func() error) error {
+	p, err := lockPath()
+	if err != nil {
+		return err
+	}
+	return config.WithFlock(p, fn)
+}
+
+// SecretForKeyget returns the stable loopback handshake secret, creating it once.
+// keyget hands this (not the upstream token) to the claude process.
+func SecretForKeyget() (string, error) {
+	var secret string
+	err := withProxyLock(func() error {
+		s, e := loadOrCreateSecret()
+		secret = s
+		return e
+	})
+	return secret, err
+}
+
+func loadOrCreateSecret() (string, error) {
+	p, err := secretPath()
+	if err != nil {
+		return "", err
+	}
+	if b, err := os.ReadFile(p); err == nil && len(b) > 0 {
+		return strings.TrimSpace(string(b)), nil
+	}
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	secret := hex.EncodeToString(buf)
+	if err := fileutil.AtomicWrite(p, []byte(secret), 0o600); err != nil {
+		return "", err
+	}
+	return secret, nil
+}
+
+// PortFromBaseURL extracts the loopback port from a codex vendor's base_url,
+// validating it is a plain loopback http URL first (config.ParseLoopbackURL is
+// the shared definition, also used at config load/validate time).
+func PortFromBaseURL(baseURL string) (int, error) {
+	u, err := config.ParseLoopbackURL(baseURL)
+	if err != nil {
+		return 0, fmt.Errorf("codex base_url %w", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil || port <= 0 {
+		return 0, fmt.Errorf("codex base_url %q has no valid port", baseURL)
+	}
+	return port, nil
+}
+
+// EnsureForVendorName loads the named vendor and ensures the proxy for it. The
+// workflow engine uses this (it has only the vendor name) to ensure the daemon
+// before minting a queued leaf. An unknown vendor is a no-op here — the leaf's own
+// path surfaces it.
+func EnsureForVendorName(name string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	return EnsureForVendor(cfg.Vendors[name])
+}
+
+// EnsureForVendor ensures the proxy daemon is up for a codex provider (a no-op for
+// any other vendor). Call it after the fingerprint gate and before the profile write.
+func EnsureForVendor(v *config.Vendor) error {
+	if v == nil || v.SecretBackend != SecretBackend {
+		return nil
+	}
+	// models_endpoint must also stay loopback — a probe sends the handshake secret
+	// there, so a remote one would leak it off-host.
+	if v.ModelsEndpoint != "" {
+		if _, err := config.ParseLoopbackURL(v.ModelsEndpoint); err != nil {
+			return fmt.Errorf("codex models_endpoint %w", err)
+		}
+	}
+	port, err := PortFromBaseURL(v.BaseURL)
+	if err != nil {
+		return err
+	}
+	return EnsureDaemon(port)
+}
+
+// EnsureDaemon makes the codex proxy daemon reachable on port, lazily and
+// single-flight under the proxy lock, and registers a launch lease that keeps the
+// daemon alive across the window before the launched claude is visible. Slot it
+// after the fingerprint gate and before the profile-write side effect.
+func EnsureDaemon(port int) error {
+	return withProxyLock(func() error {
+		if _, err := loadOrCreateSecret(); err != nil {
+			return err
+		}
+		if !healthy(port) {
+			if err := startDetached(port); err != nil {
+				return err
+			}
+			if err := waitReady(port); err != nil {
+				return err
+			}
+		}
+		return registerLease()
+	})
+}
+
+func healthy(port int) bool {
+	st, err := readState()
+	if err != nil || st.Port != port || st.PID <= 0 || !pidAlive(st.PID, st.ProcStart) {
+		return false
+	}
+	return portResponds(port)
+}
+
+func portResponds(port int) bool {
+	c := &http.Client{Timeout: 1500 * time.Millisecond}
+	resp, err := c.Get(fmt.Sprintf("http://127.0.0.1:%d/v1/models", port))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func startDetached(port int) error {
+	if held := whoHoldsPort(port); held {
+		return fmt.Errorf("port %d is held by another process; free it or set a different codex base_url port", port)
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(bin, "codex-proxy", "serve", "--port", strconv.Itoa(port))
+	cmd.Stdout, cmd.Stderr = nil, nil
+	// Scrub the launcher's creds + nested-CC/teams markers from the long-lived
+	// daemon (it authenticates via its own OAuth chain, never the lead's env).
+	cmd.Env = childenv.Clean(os.Environ())
+	detach(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// The daemon owns its own lifecycle (self-exits when idle), so release the
+	// handle rather than leak it or leave a zombie when it eventually exits.
+	return cmd.Process.Release()
+}
+
+// whoHoldsPort reports whether the loopback port is already bound (by anyone). A
+// just-started daemon of ours will be caught by healthy()/waitReady() instead.
+func whoHoldsPort(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return true
+	}
+	ln.Close()
+	return false
+}
+
+func waitReady(port int) error {
+	deadline := time.Now().Add(readyTimeout)
+	for time.Now().Before(deadline) {
+		if portResponds(port) {
+			return nil
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return fmt.Errorf("codex proxy did not become ready on port %d", port)
+}
+
+func readState() (proxyState, error) {
+	var st proxyState
+	p, err := statePath()
+	if err != nil {
+		return st, err
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return st, err
+	}
+	return st, json.Unmarshal(b, &st)
+}
+
+func writeState(st proxyState) error {
+	p, err := statePath()
+	if err != nil {
+		return err
+	}
+	b, _ := json.MarshalIndent(st, "", "  ")
+	return fileutil.AtomicWrite(p, b, 0o600)
+}
+
+func pidAlive(pid int, procStart string) bool {
+	if start, ok := procintrospect.ProcStart(pid); ok {
+		return start == procStart
+	}
+	return false
+}
+
+// registerLease writes a short-TTL lease so the daemon won't exit during the window
+// between ensureDaemon returning and the launched claude appearing in the table.
+func registerLease() error {
+	dir, err := leasesDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	buf := make([]byte, 8)
+	_, _ = rand.Read(buf)
+	name := fmt.Sprintf("%d-%s", os.Getpid(), hex.EncodeToString(buf))
+	expires := time.Now().Add(leaseTTL).UnixNano()
+	return fileutil.AtomicWrite(filepath.Join(dir, name), []byte(strconv.FormatInt(expires, 10)), 0o600)
+}
+
+// activeLeases counts unexpired leases and prunes expired ones.
+func activeLeases() int {
+	dir, err := leasesDir()
+	if err != nil {
+		return 0
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	now := time.Now().UnixNano()
+	active := 0
+	for _, e := range entries {
+		full := filepath.Join(dir, e.Name())
+		b, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		exp, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+		if err != nil || exp < now {
+			os.Remove(full)
+			continue
+		}
+		active++
+	}
+	return active
+}
+
+// liveCodexWorkers counts running claude processes whose --settings profile points
+// at this proxy's port. A scan error returns -1 ("unknown" -> daemon stays alive).
+func liveCodexWorkers(port int) int {
+	table, err := procintrospect.ProcessTable()
+	if err != nil {
+		return -1
+	}
+	n := 0
+	for _, p := range table {
+		if profileTargetsPort(p.Argv, port) {
+			n++
+		}
+	}
+	return n
+}
+
+func profileTargetsPort(argv []string, port int) bool {
+	settings := settingsPath(argv)
+	if settings == "" {
+		return false
+	}
+	b, err := os.ReadFile(settings)
+	if err != nil {
+		return false
+	}
+	var prof struct {
+		Env map[string]string `json:"env"`
+	}
+	if json.Unmarshal(b, &prof) != nil {
+		return false
+	}
+	return strings.Contains(prof.Env["ANTHROPIC_BASE_URL"], fmt.Sprintf(":%d", port))
+}
+
+func settingsPath(argv []string) string {
+	for i, a := range argv {
+		if a == "--settings" && i+1 < len(argv) {
+			return argv[i+1]
+		}
+		if strings.HasPrefix(a, "--settings=") {
+			return strings.TrimPrefix(a, "--settings=")
+		}
+	}
+	return ""
+}

--- a/internal/codexproxy/detach_unix.go
+++ b/internal/codexproxy/detach_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package codexproxy
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detach makes the spawned daemon its own process-group leader so it outlives the
+// cc-fleet process that started it (mirrors subagent's Setpgid detach).
+func detach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/codexproxy/detach_windows.go
+++ b/internal/codexproxy/detach_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package codexproxy
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// detach starts the daemon in a new process group so it outlives the launcher and
+// no console Ctrl event leaks from the parent (mirrors subagent's windows detach).
+func detach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+}

--- a/internal/codexproxy/doc.go
+++ b/internal/codexproxy/doc.go
@@ -1,0 +1,13 @@
+// Package codexproxy hosts the local Anthropic-Messages <-> OpenAI-Responses
+// conversion daemon that lets a Codex/ChatGPT subscription drive OpenAI models as
+// a cc-fleet provider. A launched claude process speaks the Anthropic Messages API
+// to a loopback HTTP server here; the server translates each request to the OpenAI
+// Responses API, calls the ChatGPT backend with a reused OAuth bearer, and
+// translates the streamed reply back to Anthropic SSE.
+//
+// The OAuth bearer lives only inside this daemon: cc-fleet runs its own OAuth
+// device-code login and keeps an independent token chain (it never reads or writes
+// ~/.codex/auth.json), so reusing the subscription cannot disturb the codex CLI's
+// own login. The claude->proxy hop carries only a low-value loopback handshake
+// secret, never the upstream token.
+package codexproxy

--- a/internal/codexproxy/fixture_test.go
+++ b/internal/codexproxy/fixture_test.go
@@ -1,0 +1,147 @@
+package codexproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Fixture replay: live-captured (sanitized) Responses SSE streams from the
+// ChatGPT codex backend, run through the converter and held to the full
+// Anthropic stream grammar. These pin the converter against the real wire
+// shape, not a hand-written approximation.
+
+func replayFixture(t *testing.T, name string) *recSink {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name+".sse"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recSink{}
+	c := newStreamConverter(sink, "gpt-5.5")
+	if err := c.Convert(bytes.NewReader(b)); err != nil {
+		t.Fatalf("convert %s: %v", name, err)
+	}
+	return sink
+}
+
+// assertGrammar checks the Anthropic stream invariants: one message_start
+// first, every opened block closed before message_delta, one message_delta,
+// message_stop last, deltas only on open blocks.
+func assertGrammar(t *testing.T, sink *recSink) {
+	t.Helper()
+	if len(sink.events) == 0 || sink.events[0] != "message_start" {
+		t.Fatalf("stream must open with message_start: %s", sink.seq())
+	}
+	if sink.events[len(sink.events)-1] != "message_stop" {
+		t.Fatalf("stream must end with message_stop: %s", sink.seq())
+	}
+	open := map[any]bool{}
+	deltaSeen := false
+	for i, ev := range sink.events {
+		p, _ := sink.payloads[i].(map[string]any)
+		switch ev {
+		case "content_block_start":
+			idx := p["index"]
+			if open[idx] {
+				t.Fatalf("block %v opened twice", idx)
+			}
+			open[idx] = true
+		case "content_block_delta":
+			if !open[p["index"]] {
+				t.Fatalf("delta on closed/unopened block %v", p["index"])
+			}
+		case "content_block_stop":
+			if !open[p["index"]] {
+				t.Fatalf("stop on unopened block %v", p["index"])
+			}
+			delete(open, p["index"])
+		case "message_delta":
+			if len(open) != 0 {
+				t.Fatalf("message_delta with %d block(s) still open", len(open))
+			}
+			deltaSeen = true
+		}
+	}
+	if !deltaSeen {
+		t.Fatal("no message_delta emitted")
+	}
+}
+
+// collectDeltas concatenates every delta value of the given delta type/field.
+func collectDeltas(sink *recSink, deltaType, field string) string {
+	var sb strings.Builder
+	for i, ev := range sink.events {
+		if ev != "content_block_delta" {
+			continue
+		}
+		p, _ := sink.payloads[i].(map[string]any)
+		d, _ := p["delta"].(map[string]any)
+		if d["type"] == deltaType {
+			s, _ := d[field].(string)
+			sb.WriteString(s)
+		}
+	}
+	return sb.String()
+}
+
+func stopReason(t *testing.T, sink *recSink) string {
+	t.Helper()
+	p := sink.payload("message_delta", 0)
+	d, _ := p["delta"].(map[string]any)
+	s, _ := d["stop_reason"].(string)
+	return s
+}
+
+func TestFixture_Text(t *testing.T) {
+	sink := replayFixture(t, "text")
+	assertGrammar(t, sink)
+	if got := collectDeltas(sink, "text_delta", "text"); got != "pong" {
+		t.Fatalf("text = %q", got)
+	}
+	if sr := stopReason(t, sink); sr != "end_turn" {
+		t.Fatalf("stop_reason = %q", sr)
+	}
+}
+
+func TestFixture_ForcedTool(t *testing.T) {
+	sink := replayFixture(t, "forced_tool")
+	assertGrammar(t, sink)
+	// The tool_use block carries the captured call id + name.
+	var toolBlock map[string]any
+	for i, ev := range sink.events {
+		if ev != "content_block_start" {
+			continue
+		}
+		p, _ := sink.payloads[i].(map[string]any)
+		cb, _ := p["content_block"].(map[string]any)
+		if cb["type"] == "tool_use" {
+			toolBlock = cb
+		}
+	}
+	if toolBlock == nil || toolBlock["name"] != "lookup" {
+		t.Fatalf("tool_use block = %v", toolBlock)
+	}
+	args := collectDeltas(sink, "input_json_delta", "partial_json")
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(args), &parsed); err != nil || parsed["key"] != "alpha" {
+		t.Fatalf("streamed tool args %q: %v", args, err)
+	}
+	if sr := stopReason(t, sink); sr != "tool_use" {
+		t.Fatalf("stop_reason = %q", sr)
+	}
+}
+
+func TestFixture_Thinking(t *testing.T) {
+	sink := replayFixture(t, "thinking")
+	assertGrammar(t, sink)
+	if got := collectDeltas(sink, "signature_delta", "signature"); !strings.Contains(got, "gAAAAA-fixture-stub") {
+		t.Fatalf("reasoning encrypted_content not surfaced as a signature: %q", got)
+	}
+	if got := collectDeltas(sink, "text_delta", "text"); got != "391" {
+		t.Fatalf("answer text = %q", got)
+	}
+}

--- a/internal/codexproxy/login.go
+++ b/internal/codexproxy/login.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+// RiskNotice is the consent text shown before a device-code login (CLI and TUI):
+// reusing a ChatGPT subscription outside the codex CLI is unofficial, and the risk
+// lives at OpenAI's account level — cc-fleet's independent token chain can't remove it.
+const RiskNotice = `Reusing a ChatGPT subscription outside the codex CLI is unofficial and may
+violate OpenAI's terms of use; the account could be rate-limited or banned.
+cc-fleet keeps its own login and never writes or refreshes ~/.codex (it only reads
+the codex CLI's token), but that does not remove the account-level risk.`
+
 // Login runs an interactive OAuth device-code login and persists an independent
 // token chain to cc-fleet's own store (never touching ~/.codex). It prints the
 // verification URL + user code to out and polls until the user authorizes.
@@ -46,6 +54,57 @@ func Login(ctx context.Context, out io.Writer) error {
 	}
 	return errors.New("device code expired before authorization")
 }
+
+// LoginSession is a two-phase device-code login an interactive caller (the TUI)
+// drives: Begin returns the URL + user code to display, then Poll is called on an
+// interval until it reports done. Like Login it only ever touches cc-fleet's own
+// token chain, never ~/.codex.
+type LoginSession struct {
+	VerifyURL string
+	UserCode  string
+
+	dc    *deviceCode
+	store *ownStore
+	oc    *oauthClient
+}
+
+// BeginDeviceLogin starts a device-code flow and returns the session to display +
+// poll. The caller must have already obtained consent (subscription reuse risk).
+func BeginDeviceLogin(ctx context.Context) (*LoginSession, error) {
+	store, err := newOwnStore()
+	if err != nil {
+		return nil, err
+	}
+	oc := newOAuthClient()
+	dc, err := oc.startDeviceLogin(ctx, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	return &LoginSession{VerifyURL: dc.verifyURL, UserCode: dc.userCode, dc: dc, store: store, oc: oc}, nil
+}
+
+// Poll performs one authorization poll. done=false with a nil error means the
+// user has not authorized yet (poll again after Interval); done=true persists the
+// new login. An expired code or a hard failure returns an error.
+func (s *LoginSession) Poll(ctx context.Context) (done bool, err error) {
+	if time.Now().After(s.dc.expiresAt) {
+		return false, errors.New("device code expired; restart login")
+	}
+	tk, err := s.oc.pollDeviceLogin(ctx, s.dc)
+	if errors.Is(err, errAuthPending) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := s.store.setLogin(tk); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Interval is the minimum delay between Poll calls.
+func (s *LoginSession) Interval() time.Duration { return s.dc.interval }
 
 // LoginStatus reports whether cc-fleet has an independent codex login.
 func LoginStatus() (loggedIn bool, account string) {

--- a/internal/codexproxy/login.go
+++ b/internal/codexproxy/login.go
@@ -1,0 +1,84 @@
+package codexproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// Login runs an interactive OAuth device-code login and persists an independent
+// token chain to cc-fleet's own store (never touching ~/.codex). It prints the
+// verification URL + user code to out and polls until the user authorizes.
+func Login(ctx context.Context, out io.Writer) error {
+	store, err := newOwnStore()
+	if err != nil {
+		return err
+	}
+	oc := newOAuthClient()
+	dc, err := oc.startDeviceLogin(ctx, time.Now())
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Open %s and enter code: %s\n", dc.verifyURL, dc.userCode)
+	fmt.Fprintln(out, "Waiting for authorization...")
+
+	for time.Now().Before(dc.expiresAt) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(dc.interval):
+		}
+		tk, err := oc.pollDeviceLogin(ctx, dc)
+		if errors.Is(err, errAuthPending) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if err := store.setLogin(tk); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "Logged in (account %s).\n", redactAccount(tk.AccountID))
+		return nil
+	}
+	return errors.New("device code expired before authorization")
+}
+
+// LoginStatus reports whether cc-fleet has an independent codex login.
+func LoginStatus() (loggedIn bool, account string) {
+	store, err := newOwnStore()
+	if err != nil {
+		return false, ""
+	}
+	return store.loggedIn(), redactAccount(store.data.AccountID)
+}
+
+// Logout removes cc-fleet's own token chain and stops the daemon (whose
+// in-memory access token dies with it). ~/.codex is untouched.
+func Logout() error {
+	if err := withTokenLock(func() error {
+		p, err := storePath()
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return StopDaemon()
+}
+
+// redactAccount masks an account id for display (it is an identifier, not a secret,
+// but full-value display is avoided in logs/UI for consistency).
+func redactAccount(id string) string {
+	if len(id) <= 6 {
+		return id
+	}
+	return "…" + id[len(id)-6:]
+}

--- a/internal/codexproxy/misc_test.go
+++ b/internal/codexproxy/misc_test.go
@@ -1,0 +1,160 @@
+package codexproxy
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// fakeJWT builds an unsigned JWT whose payload is the given claims map.
+func fakeJWT(claims map[string]any) string {
+	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	pb, _ := json.Marshal(claims)
+	return hdr + "." + base64.RawURLEncoding.EncodeToString(pb) + "."
+}
+
+func TestAccountIDFallbackChain(t *testing.T) {
+	authClaim := map[string]any{jwtAuthClaim: map[string]any{"chatgpt_account_id": "acc-id"}}
+
+	// 1) explicit field wins.
+	if got := accountIDFromTokens(&tokens{AccountID: "explicit"}); got != "explicit" {
+		t.Fatalf("explicit account id: %q", got)
+	}
+	// 2) id_token claim is used before the access token.
+	tk := &tokens{IDToken: fakeJWT(authClaim)}
+	if got := accountIDFromTokens(tk); got != "acc-id" {
+		t.Fatalf("id_token account id: %q", got)
+	}
+	// 3) access_token claim is the last resort.
+	tk = &tokens{AccessToken: fakeJWT(authClaim)}
+	if got := accountIDFromTokens(tk); got != "acc-id" {
+		t.Fatalf("access_token account id: %q", got)
+	}
+	// 4) none present.
+	if got := accountIDFromTokens(&tokens{}); got != "" {
+		t.Fatalf("want empty, got %q", got)
+	}
+}
+
+func TestTokenExpiry(t *testing.T) {
+	jwt := fakeJWT(map[string]any{"exp": float64(1781542266)})
+	exp, ok := tokenExpiry(jwt)
+	if !ok || exp.Unix() != 1781542266 {
+		t.Fatalf("tokenExpiry=%v ok=%v", exp, ok)
+	}
+	if _, ok := tokenExpiry("not-a-jwt"); ok {
+		t.Fatal("expected !ok for a non-JWT")
+	}
+}
+
+func TestParseInterval(t *testing.T) {
+	if d := parseInterval(json.RawMessage(`5`)); d.Seconds() != 8 { // 5 + 3 safety
+		t.Fatalf("numeric interval=%v", d)
+	}
+	if d := parseInterval(nil); d.Seconds() != 8 {
+		t.Fatalf("default interval=%v", d)
+	}
+}
+
+func TestPortFromBaseURL(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"http://127.0.0.1:8765/", 8765, true},
+		{"http://127.0.0.1:9000", 9000, true},
+		{"http://127.0.0.1/", 0, false},
+	} {
+		got, err := PortFromBaseURL(c.in)
+		if c.ok && (err != nil || got != c.want) {
+			t.Fatalf("PortFromBaseURL(%q)=%d,%v", c.in, got, err)
+		}
+		if !c.ok && err == nil {
+			t.Fatalf("PortFromBaseURL(%q) expected error", c.in)
+		}
+	}
+}
+
+func TestIsCloudflareChallenge(t *testing.T) {
+	h := http.Header{}
+	h.Set("cf-mitigated", "challenge")
+	if !isCloudflareChallenge(h, "") {
+		t.Fatal("cf-mitigated header should be detected")
+	}
+	h2 := http.Header{}
+	h2.Set("Server", "cloudflare")
+	if !isCloudflareChallenge(h2, "Just a moment...") {
+		t.Fatal("cloudflare challenge body should be detected")
+	}
+	if isCloudflareChallenge(http.Header{}, "ordinary 403 body") {
+		t.Fatal("ordinary 403 must not be a cloudflare challenge")
+	}
+}
+
+func TestQuotaMessage(t *testing.T) {
+	got := quotaMessage(`{"error":{"code":"usage_limit_reached","resets_at":1781542266}}`)
+	want := "codex usage_limit_reached (resets at 2026-06-15T16:51:06Z)"
+	if got != want {
+		t.Fatalf("quotaMessage = %q, want %q", got, want)
+	}
+	if got := quotaMessage("plain throttling text"); got != "codex usage limit reached: plain throttling text" {
+		t.Fatalf("fallback = %q", got)
+	}
+}
+
+func TestEnsureForVendor_RejectsNonLoopback(t *testing.T) {
+	for _, c := range []struct {
+		name, base, models string
+		wantErr            bool
+	}{
+		{"remote base", "https://evil.example.com/", "http://127.0.0.1:17222/v1/models", true},
+		{"http remote base", "http://evil.example.com:17222/", "http://127.0.0.1:17222/v1/models", true},
+		{"userinfo base", "http://x@127.0.0.1:17222/", "http://127.0.0.1:17222/v1/models", true},
+		{"remote models", "http://127.0.0.1:17222/", "https://evil.example.com/v1/models", true},
+		{"no port", "http://127.0.0.1/", "http://127.0.0.1/v1/models", true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			v := &config.Vendor{SecretBackend: SecretBackend, BaseURL: c.base, ModelsEndpoint: c.models}
+			if err := EnsureForVendor(v); (err != nil) != c.wantErr {
+				t.Fatalf("EnsureForVendor err=%v, wantErr=%v", err, c.wantErr)
+			}
+		})
+	}
+	// A non-codex vendor is always a no-op, even with a remote base_url.
+	if err := EnsureForVendor(&config.Vendor{SecretBackend: "file", BaseURL: "https://api.example.com/"}); err != nil {
+		t.Fatalf("non-codex vendor must be a no-op, got %v", err)
+	}
+}
+
+func TestStaticModels(t *testing.T) {
+	m := StaticModels()
+	if len(m) == 0 || m[0] != "gpt-5.5" {
+		t.Fatalf("StaticModels = %v", m)
+	}
+	m[0] = "mutated" // must not affect the package list
+	if StaticModels()[0] != "gpt-5.5" {
+		t.Fatal("StaticModels returned a shared backing array")
+	}
+}
+
+func TestAnthropicErrorFor(t *testing.T) {
+	for _, c := range []struct {
+		kind   upstreamKind
+		status int
+		etype  string
+	}{
+		{upQuota, http.StatusTooManyRequests, "rate_limit_error"},
+		{upCloudflare, http.StatusForbidden, "api_error"},
+		{upAuth, http.StatusUnauthorized, "authentication_error"},
+		{upBadRequest, http.StatusBadRequest, "invalid_request_error"},
+	} {
+		status, etype, _ := anthropicErrorFor(&upstreamError{kind: c.kind, status: c.status, message: "m"})
+		if status != c.status || etype != c.etype {
+			t.Fatalf("anthropicErrorFor(%d)=%d,%s want %d,%s", c.kind, status, etype, c.status, c.etype)
+		}
+	}
+}

--- a/internal/codexproxy/oauth.go
+++ b/internal/codexproxy/oauth.go
@@ -1,0 +1,264 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// refreshSkew refreshes the access token this long before its JWT exp.
+const refreshSkew = 120 * time.Second
+
+// ErrReauth means the stored refresh token is dead (or absent); the caller must
+// run `cc-fleet codex login` again. It never means a transient network failure.
+var ErrReauth = errors.New("codexproxy: codex login required")
+
+// tokens is the persisted credential chain. The access token is cached in memory
+// only; refresh_token + account_id are durable (see tokenStore).
+type tokens struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+}
+
+// oauthClient performs the device-code login and refresh grants. It owns no state;
+// the tokenStore holds the durable chain.
+type oauthClient struct {
+	http *http.Client
+}
+
+func newOAuthClient() *oauthClient {
+	return &oauthClient{http: &http.Client{Timeout: 45 * time.Second}}
+}
+
+// deviceCode is the start-of-login handle shown to the user.
+type deviceCode struct {
+	deviceAuthID string
+	userCode     string
+	verifyURL    string
+	interval     time.Duration
+	expiresAt    time.Time
+}
+
+type deviceCodeResp struct {
+	DeviceAuthID string          `json:"device_auth_id"`
+	UserCode     string          `json:"user_code"`
+	Interval     json.RawMessage `json:"interval"`
+	ExpiresIn    int             `json:"expires_in"`
+}
+
+// startDeviceLogin begins an OAuth device-code flow; the user authorizes deviceVerifyURL
+// with the returned user code, then the caller polls pollDeviceLogin.
+func (c *oauthClient) startDeviceLogin(ctx context.Context, now time.Time) (*deviceCode, error) {
+	body, _ := json.Marshal(map[string]string{"client_id": oauthClientID})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, deviceUserCodeURL, strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgentValue)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device start: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("device start: http %d", resp.StatusCode)
+	}
+	var dr deviceCodeResp
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return nil, fmt.Errorf("device start decode: %w", err)
+	}
+	expiresIn := dr.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 900
+	}
+	return &deviceCode{
+		deviceAuthID: dr.DeviceAuthID,
+		userCode:     dr.UserCode,
+		verifyURL:    deviceVerifyURL,
+		interval:     parseInterval(dr.Interval),
+		expiresAt:    now.Add(time.Duration(expiresIn) * time.Second),
+	}, nil
+}
+
+// errAuthPending is returned by a poll while the user has not yet authorized.
+var errAuthPending = errors.New("authorization pending")
+
+type devicePollResp struct {
+	AuthorizationCode string `json:"authorization_code"`
+	CodeVerifier      string `json:"code_verifier"`
+}
+
+type tokenResp struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+// pollDeviceLogin polls once; it returns errAuthPending until the user authorizes,
+// then exchanges the authorization code for the token chain.
+func (c *oauthClient) pollDeviceLogin(ctx context.Context, dc *deviceCode) (*tokens, error) {
+	body, _ := json.Marshal(map[string]string{"device_auth_id": dc.deviceAuthID, "user_code": dc.userCode})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, deviceTokenURL, strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgentValue)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device poll: %w", err)
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusForbidden, resp.StatusCode == http.StatusNotFound:
+		return nil, errAuthPending
+	case resp.StatusCode == http.StatusGone:
+		return nil, errors.New("device code expired; restart login")
+	case resp.StatusCode/100 != 2:
+		return nil, fmt.Errorf("device poll: http %d", resp.StatusCode)
+	}
+	var pr devicePollResp
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, fmt.Errorf("device poll decode: %w", err)
+	}
+	return c.exchangeCode(ctx, pr.AuthorizationCode, pr.CodeVerifier)
+}
+
+func (c *oauthClient) exchangeCode(ctx context.Context, code, verifier string) (*tokens, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {deviceRedirectURI},
+		"client_id":     {oauthClientID},
+		"code_verifier": {verifier},
+	}
+	tr, err := c.postToken(ctx, form)
+	if err != nil {
+		return nil, err
+	}
+	tk := &tokens{AccessToken: tr.AccessToken, RefreshToken: tr.RefreshToken, IDToken: tr.IDToken}
+	tk.AccountID = accountIDFromTokens(tk)
+	return tk, nil
+}
+
+// refresh exchanges the refresh token for a new access token (and possibly a
+// rotated refresh token). A 401/403 means the chain is dead -> ErrReauth.
+func (c *oauthClient) refresh(ctx context.Context, refreshToken string) (*tokens, error) {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {oauthClientID},
+		"scope":         {"openid profile email"},
+	}
+	tr, err := c.postToken(ctx, form)
+	if err != nil {
+		return nil, err
+	}
+	rt := tr.RefreshToken
+	if rt == "" {
+		rt = refreshToken // server omitted a rotation; keep the current one
+	}
+	tk := &tokens{AccessToken: tr.AccessToken, RefreshToken: rt, IDToken: tr.IDToken}
+	tk.AccountID = accountIDFromTokens(tk)
+	return tk, nil
+}
+
+func (c *oauthClient) postToken(ctx context.Context, form url.Values) (*tokenResp, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, oauthTokenURL, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgentValue)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token grant: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, ErrReauth
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("token grant: http %d", resp.StatusCode)
+	}
+	var tr tokenResp
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("token grant decode: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return nil, errors.New("token grant: empty access_token")
+	}
+	return &tr, nil
+}
+
+func parseInterval(raw json.RawMessage) time.Duration {
+	secs := 5
+	if len(raw) > 0 {
+		var n int
+		if json.Unmarshal(raw, &n) == nil && n > 0 {
+			secs = n
+		} else {
+			var s string
+			if json.Unmarshal(raw, &s) == nil {
+				if v, err := time.ParseDuration(s + "s"); err == nil && v > 0 {
+					secs = int(v.Seconds())
+				}
+			}
+		}
+	}
+	return time.Duration(secs+3) * time.Second
+}
+
+// jwtClaims base64url-decodes a JWT payload to a claims map. Decode-only; never
+// verifies a signature (we only read identity claims from our own tokens).
+func jwtClaims(jwt string) map[string]any {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	var m map[string]any
+	if json.Unmarshal(payload, &m) != nil {
+		return nil
+	}
+	return m
+}
+
+// accountIDFromTokens derives chatgpt_account_id via the fallback chain
+// id_token claim -> access_token claim. After a refresh the access_token can omit
+// the claim, so the id_token is tried first.
+func accountIDFromTokens(tk *tokens) string {
+	if tk.AccountID != "" {
+		return tk.AccountID
+	}
+	for _, jwt := range []string{tk.IDToken, tk.AccessToken} {
+		if claimAccount := accountIDFromClaim(jwtClaims(jwt)); claimAccount != "" {
+			return claimAccount
+		}
+	}
+	return ""
+}
+
+func accountIDFromClaim(claims map[string]any) string {
+	auth, ok := claims[jwtAuthClaim].(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := auth["chatgpt_account_id"].(string)
+	return id
+}
+
+// tokenExpiry reads the exp claim (unix seconds) from an access token JWT.
+func tokenExpiry(accessToken string) (time.Time, bool) {
+	claims := jwtClaims(accessToken)
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return time.Time{}, false
+	}
+	return time.Unix(int64(exp), 0), true
+}

--- a/internal/codexproxy/oauth.go
+++ b/internal/codexproxy/oauth.go
@@ -244,13 +244,27 @@ func accountIDFromTokens(tk *tokens) string {
 	return ""
 }
 
+// accountIDFromClaim derives chatgpt_account_id from one JWT's claims, trying the
+// top-level claim, the namespaced auth claim, then the first organization id.
 func accountIDFromClaim(claims map[string]any) string {
+	if id, _ := claims["chatgpt_account_id"].(string); id != "" {
+		return id
+	}
 	auth, ok := claims[jwtAuthClaim].(map[string]any)
 	if !ok {
 		return ""
 	}
-	id, _ := auth["chatgpt_account_id"].(string)
-	return id
+	if id, _ := auth["chatgpt_account_id"].(string); id != "" {
+		return id
+	}
+	if orgs, ok := auth["organizations"].([]any); ok && len(orgs) > 0 {
+		if org0, ok := orgs[0].(map[string]any); ok {
+			if id, _ := org0["id"].(string); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
 }
 
 // tokenExpiry reads the exp claim (unix seconds) from an access token JWT.

--- a/internal/codexproxy/openai_chat.go
+++ b/internal/codexproxy/openai_chat.go
@@ -1,0 +1,256 @@
+package codexproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ethanhq/cc-fleet/internal/redact"
+)
+
+// openaiChatUpstream speaks the OpenAI Chat Completions API
+// (POST <upstream>/chat/completions) with a per-request Bearer key. It is the
+// upstream for the openai-chat protocol and the only one with a hand-written
+// translator + converter (the Responses path reuses codex's).
+type openaiChatUpstream struct {
+	http    *http.Client
+	baseURL string
+}
+
+func newOpenAIChatUpstream(baseURL string) *openaiChatUpstream {
+	return &openaiChatUpstream{http: &http.Client{Timeout: 0}, baseURL: baseURL}
+}
+
+// models is empty: an openai-* provider's model list comes from the real upstream
+// models_endpoint (probed directly with the key), never from this daemon.
+func (u *openaiChatUpstream) models() []string { return nil }
+
+func (u *openaiChatUpstream) convert(body io.Reader, sink sseSink, model, apiKey string) error {
+	c := newChatStreamConverter(sink, model)
+	c.redact = func(s string) string { return redactKey(s, apiKey) }
+	return c.Convert(body)
+}
+
+// call translates the Anthropic request to a Chat Completions request, sends it
+// with Authorization: Bearer <apiKey>, and returns the streaming body. On a
+// non-2xx the response body is redacted (an arbitrary endpoint may echo the key)
+// before it becomes a classified *upstreamError.
+func (u *openaiChatUpstream) call(ctx context.Context, areq *anthropicRequest, apiKey string) (io.ReadCloser, error) {
+	creq, err := translateChatRequest(areq)
+	if err != nil {
+		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, err.Error()}
+	}
+	body, _ := json.Marshal(creq)
+	endpoint, err := url.JoinPath(u.baseURL, "chat", "completions")
+	if err != nil {
+		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, "invalid upstream url"}
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := u.http.Do(req)
+	if err != nil {
+		return nil, &upstreamError{upTransient, http.StatusBadGateway, "openai upstream: " + redactKey(err.Error(), apiKey)}
+	}
+	if resp.StatusCode/100 == 2 {
+		return resp.Body, nil
+	}
+	return nil, classifyOpenAI(resp, apiKey)
+}
+
+// classifyOpenAI maps a non-2xx Chat/Responses status to an upstreamError. Unlike
+// the codex backend it has no Cloudflare path and no OAuth-refresh: 401/403 is a
+// terminal auth failure, 429 a standard rate limit. The body is redacted first.
+func classifyOpenAI(resp *http.Response, apiKey string) *upstreamError {
+	body := redactKey(drain(resp), apiKey)
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &upstreamError{upQuota, http.StatusTooManyRequests, "openai rate limited: " + body}
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &upstreamError{upAuth, resp.StatusCode, "openai auth rejected: " + body}
+	case resp.StatusCode/100 == 5:
+		return &upstreamError{upTransient, resp.StatusCode, fmt.Sprintf("openai upstream http %d", resp.StatusCode)}
+	default:
+		return &upstreamError{upBadRequest, resp.StatusCode, fmt.Sprintf("openai upstream http %d: %s", resp.StatusCode, body)}
+	}
+}
+
+// redactKey masks the exact presented key AND any key-shaped token, so an upstream
+// that echoes the Authorization/x-api-key bytes can never reach the client.
+func redactKey(s, apiKey string) string {
+	if apiKey != "" {
+		s = strings.ReplaceAll(s, apiKey, "sk-[REDACTED]")
+	}
+	return redact.MaskKeyLikeString(s)
+}
+
+// ---- Anthropic -> Chat Completions request ---------------------------------
+
+type chatRequest struct {
+	Model             string         `json:"model"`
+	Messages          []any          `json:"messages"`
+	MaxTokens         int            `json:"max_tokens,omitempty"`
+	Tools             []chatTool     `json:"tools,omitempty"`
+	ToolChoice        any            `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool          `json:"parallel_tool_calls,omitempty"`
+	Stream            bool           `json:"stream"`
+	StreamOptions     *streamOptions `json:"stream_options,omitempty"`
+}
+
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type chatTool struct {
+	Type     string       `json:"type"`
+	Function chatFunction `json:"function"`
+}
+
+type chatFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// translateChatRequest maps an Anthropic Messages request to a Chat Completions
+// request. thinking is dropped (most compatible endpoints don't accept it); the
+// usage chunk is requested via stream_options.include_usage.
+func translateChatRequest(a *anthropicRequest) (*chatRequest, error) {
+	r := &chatRequest{
+		Model:         a.Model,
+		MaxTokens:     a.MaxTokens,
+		Stream:        true,
+		StreamOptions: &streamOptions{IncludeUsage: true},
+	}
+	if sys := systemText(a.System); sys != "" {
+		r.Messages = append(r.Messages, map[string]any{"role": "system", "content": sys})
+	}
+	for _, m := range a.Messages {
+		items, err := translateChatMessage(m)
+		if err != nil {
+			return nil, err
+		}
+		r.Messages = append(r.Messages, items...)
+	}
+	for _, t := range a.Tools {
+		r.Tools = append(r.Tools, chatTool{Type: "function", Function: chatFunction{
+			Name: t.Name, Description: t.Description, Parameters: t.InputSchema,
+		}})
+	}
+	r.ToolChoice, r.ParallelToolCalls = translateChatToolChoice(a.ToolChoice)
+	return r, nil
+}
+
+// translateChatMessage maps one Anthropic message to one or more Chat messages.
+// tool_result blocks become role:"tool" messages emitted FIRST (Chat requires a
+// tool result to immediately follow the assistant turn that called it); text +
+// images form the message content; assistant tool_use blocks become tool_calls.
+func translateChatMessage(m anthropicMessage) ([]any, error) {
+	if s := stringContent(m.Content); s != nil {
+		return []any{map[string]any{"role": m.Role, "content": *s}}, nil
+	}
+	var blocks []contentBlock
+	if err := json.Unmarshal(m.Content, &blocks); err != nil {
+		return nil, fmt.Errorf("message content: %w", err)
+	}
+
+	var (
+		toolMsgs  []any
+		parts     []map[string]any
+		hasImage  bool
+		text      strings.Builder
+		toolCalls []map[string]any
+	)
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			parts = append(parts, map[string]any{"type": "text", "text": b.Text})
+			text.WriteString(b.Text)
+		case "image":
+			if u := imageDataURL(b.Source); u != "" {
+				parts = append(parts, map[string]any{"type": "image_url", "image_url": map[string]any{"url": u}})
+				hasImage = true
+			}
+		case "tool_use":
+			toolCalls = append(toolCalls, map[string]any{
+				"id": b.ID, "type": "function",
+				"function": map[string]any{"name": b.Name, "arguments": string(rawOrEmptyObject(b.Input))},
+			})
+		case "tool_result":
+			toolMsgs = append(toolMsgs, map[string]any{
+				"role": "tool", "tool_call_id": b.ToolUseID, "content": toolResultText(b.Content),
+			})
+		case "thinking":
+			// dropped — Chat Completions has no thinking input channel.
+		}
+	}
+
+	out := toolMsgs // tool results precede any trailing text for this turn
+	var content any
+	switch {
+	case hasImage:
+		content = parts // array form carries text parts + image parts
+	case text.Len() > 0:
+		content = text.String()
+	}
+	if m.Role == "assistant" {
+		if content == nil {
+			content = "" // assistant turn with only tool_calls
+		}
+		msg := map[string]any{"role": "assistant", "content": content}
+		if len(toolCalls) > 0 {
+			msg["tool_calls"] = toolCalls
+		}
+		out = append(out, msg)
+	} else if content != nil {
+		out = append(out, map[string]any{"role": m.Role, "content": content})
+	}
+	return out, nil
+}
+
+// stringContent returns the message content as a *string when it is a plain
+// string, else nil (it is a block array).
+func stringContent(raw json.RawMessage) *string {
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return &s
+	}
+	return nil
+}
+
+// translateChatToolChoice maps Anthropic tool_choice to the Chat form plus the
+// parallel-tool-calls flag (set only when explicitly disabled). auto->auto,
+// any->required, {type:tool,name}->{type:function,function:{name}}, none->none.
+func translateChatToolChoice(raw json.RawMessage) (choice any, parallel *bool) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var tc struct {
+		Type                   string `json:"type"`
+		Name                   string `json:"name"`
+		DisableParallelToolUse bool   `json:"disable_parallel_tool_use"`
+	}
+	if json.Unmarshal(raw, &tc) != nil {
+		return nil, nil
+	}
+	if tc.DisableParallelToolUse {
+		f := false
+		parallel = &f
+	}
+	switch tc.Type {
+	case "any":
+		return "required", parallel
+	case "tool":
+		return map[string]any{"type": "function", "function": map[string]any{"name": tc.Name}}, parallel
+	case "none":
+		return "none", parallel
+	default:
+		return "auto", parallel
+	}
+}

--- a/internal/codexproxy/openai_chat_stream.go
+++ b/internal/codexproxy/openai_chat_stream.go
@@ -1,0 +1,287 @@
+package codexproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/ethanhq/cc-fleet/internal/redact"
+)
+
+// chatStreamConverter turns a Chat Completions SSE stream (chat.completion.chunk)
+// into a valid Anthropic Messages SSE stream, with the same grammar + idempotent
+// guards as the Responses converter: a clean stream is message_start -> per-block
+// start/delta/stop -> message_delta -> message_stop; a mid-stream error chunk or a
+// transport read error ends on an Anthropic error event with open blocks closed,
+// never a clean message_stop.
+type chatStreamConverter struct {
+	out   sseSink
+	model string
+	// redact masks a streaming error message before it reaches the client (set by
+	// the openai-chat upstream to scrub an echoed key, exact + pattern). When nil
+	// it falls back to the generic key-pattern mask.
+	redact func(string) string
+
+	started   bool
+	failed    bool
+	nextIndex int
+
+	textOpen  bool
+	textIndex int
+	tools     map[int]int  // chat tool_calls index -> Anthropic block index
+	toolOpen  map[int]bool // chat tool_calls index -> open
+
+	stopReason string
+	inTokens   int
+	outTokens  int
+}
+
+func newChatStreamConverter(out sseSink, model string) *chatStreamConverter {
+	return &chatStreamConverter{
+		out: out, model: model, textIndex: -1,
+		tools: map[int]int{}, toolOpen: map[int]bool{}, stopReason: "end_turn",
+	}
+}
+
+type chatChunk struct {
+	Choices []chatChoice `json:"choices"`
+	Usage   *chatUsage   `json:"usage"`
+	Error   *chatError   `json:"error"`
+}
+
+type chatChoice struct {
+	Delta        chatDelta `json:"delta"`
+	FinishReason *string   `json:"finish_reason"`
+}
+
+type chatDelta struct {
+	Role             string              `json:"role"`
+	Content          *string             `json:"content"`
+	ReasoningContent *string             `json:"reasoning_content"`
+	Refusal          *string             `json:"refusal"`
+	ToolCalls        []chatToolCallDelta `json:"tool_calls"`
+}
+
+type chatToolCallDelta struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type chatUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+type chatError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+// Convert reads the Chat Completions SSE body to completion, emitting Anthropic
+// SSE. A clean end-of-stream closes open blocks and emits message_delta +
+// message_stop; an error chunk or a transport read error emits an Anthropic error
+// event instead, so a failure is never handed to Claude as a successful answer.
+func (c *chatStreamConverter) Convert(body io.Reader) error {
+	if err := c.ensureStarted(); err != nil {
+		return err
+	}
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var ev chatChunk
+		if json.Unmarshal([]byte(payload), &ev) != nil {
+			continue
+		}
+		if ev.Error != nil {
+			return c.emitError("openai upstream: " + ev.Error.Message)
+		}
+		if err := c.handle(&ev); err != nil {
+			return err
+		}
+	}
+	if err := sc.Err(); err != nil {
+		_ = c.emitError("openai upstream stream read error")
+		return err
+	}
+	c.finish()
+	return nil
+}
+
+func (c *chatStreamConverter) handle(ev *chatChunk) error {
+	if ev.Usage != nil {
+		if ev.Usage.PromptTokens > 0 {
+			c.inTokens = ev.Usage.PromptTokens
+		}
+		if ev.Usage.CompletionTokens > 0 {
+			c.outTokens = ev.Usage.CompletionTokens
+		}
+	}
+	if len(ev.Choices) == 0 {
+		return nil // a usage-only chunk carries no choices
+	}
+	ch := ev.Choices[0]
+	// content text and refusal both surface as visible text; reasoning_content is a
+	// separate channel and is deliberately dropped (never concatenated into text).
+	if txt := chatVisibleText(ch.Delta); txt != "" {
+		if err := c.textDelta(txt); err != nil {
+			return err
+		}
+	}
+	for _, tc := range ch.Delta.ToolCalls {
+		if err := c.toolDelta(tc); err != nil {
+			return err
+		}
+	}
+	if ch.FinishReason != nil {
+		c.applyFinish(*ch.FinishReason)
+	}
+	return nil
+}
+
+// chatVisibleText returns the user-visible text of a delta: content, or a refusal
+// (surfaced, not silently dropped). A nil/empty content opens no block.
+func chatVisibleText(d chatDelta) string {
+	if d.Content != nil {
+		return *d.Content
+	}
+	if d.Refusal != nil {
+		return *d.Refusal
+	}
+	return ""
+}
+
+func (c *chatStreamConverter) textDelta(txt string) error {
+	if !c.textOpen {
+		c.textIndex = c.nextIndex
+		c.nextIndex++
+		c.textOpen = true
+		if err := c.out.event("content_block_start", map[string]any{
+			"type": "content_block_start", "index": c.textIndex,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		}); err != nil {
+			return err
+		}
+	}
+	return c.out.event("content_block_delta", map[string]any{
+		"type": "content_block_delta", "index": c.textIndex,
+		"delta": map[string]any{"type": "text_delta", "text": txt},
+	})
+}
+
+// toolDelta opens a tool_use block on the first fragment for a chat tool index
+// (which carries the id + name) and streams later argument fragments as
+// input_json_delta — never buffered-and-parsed.
+func (c *chatStreamConverter) toolDelta(tc chatToolCallDelta) error {
+	idx, ok := c.tools[tc.Index]
+	if !ok {
+		idx = c.nextIndex
+		c.nextIndex++
+		c.tools[tc.Index] = idx
+		c.toolOpen[tc.Index] = true
+		c.stopReason = "tool_use"
+		if err := c.out.event("content_block_start", map[string]any{
+			"type": "content_block_start", "index": idx,
+			"content_block": map[string]any{"type": "tool_use", "id": tc.ID, "name": tc.Function.Name, "input": map[string]any{}},
+		}); err != nil {
+			return err
+		}
+	}
+	if tc.Function.Arguments == "" {
+		return nil
+	}
+	return c.out.event("content_block_delta", map[string]any{
+		"type": "content_block_delta", "index": idx,
+		"delta": map[string]any{"type": "input_json_delta", "partial_json": tc.Function.Arguments},
+	})
+}
+
+// applyFinish maps a Chat finish_reason to an Anthropic stop_reason. stop /
+// content_filter / absent leave the current reason (end_turn, or tool_use if a
+// tool block opened); length and tool_calls override explicitly.
+func (c *chatStreamConverter) applyFinish(reason string) {
+	switch reason {
+	case "length":
+		c.stopReason = "max_tokens"
+	case "tool_calls":
+		c.stopReason = "tool_use"
+	}
+}
+
+func (c *chatStreamConverter) ensureStarted() error {
+	if c.started {
+		return nil
+	}
+	c.started = true
+	return c.out.event("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg_codexproxy", "type": "message", "role": "assistant", "model": c.model,
+			"content": []any{}, "stop_reason": nil, "stop_sequence": nil,
+			"usage": map[string]any{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+}
+
+// finish closes any still-open block and emits message_delta + message_stop.
+// Guarded by started (a failure before message_start emits nothing) and failed
+// (an errored stream ends on its error event, not a clean stop).
+func (c *chatStreamConverter) finish() {
+	if !c.started || c.failed {
+		return
+	}
+	_ = c.closeAllOpen()
+	_ = c.out.event("message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": c.stopReason, "stop_sequence": nil},
+		"usage": map[string]any{"input_tokens": c.inTokens, "output_tokens": c.outTokens},
+	})
+	_ = c.out.event("message_stop", map[string]any{"type": "message_stop"})
+}
+
+// emitError closes any open block and emits a redacted Anthropic error event,
+// marking the stream failed so finish() skips the clean message_delta/stop.
+func (c *chatStreamConverter) emitError(msg string) error {
+	if err := c.closeAllOpen(); err != nil {
+		return err
+	}
+	c.failed = true
+	if c.redact != nil {
+		msg = c.redact(msg)
+	} else {
+		msg = redact.MaskKeyLikeString(msg)
+	}
+	return c.out.event("error", map[string]any{
+		"type": "error", "error": map[string]any{"type": "api_error", "message": msg},
+	})
+}
+
+func (c *chatStreamConverter) closeAllOpen() error {
+	if c.textOpen {
+		c.textOpen = false
+		if err := c.out.event("content_block_stop", map[string]any{"type": "content_block_stop", "index": c.textIndex}); err != nil {
+			return err
+		}
+	}
+	for chatIdx, idx := range c.tools {
+		if c.toolOpen[chatIdx] {
+			c.toolOpen[chatIdx] = false
+			if err := c.out.event("content_block_stop", map[string]any{"type": "content_block_stop", "index": idx}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/codexproxy/openai_chat_test.go
+++ b/internal/codexproxy/openai_chat_test.go
@@ -1,0 +1,266 @@
+package codexproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func parseReq(t *testing.T, raw string) *anthropicRequest {
+	t.Helper()
+	var a anthropicRequest
+	if err := json.Unmarshal([]byte(raw), &a); err != nil {
+		t.Fatalf("parse request: %v", err)
+	}
+	return &a
+}
+
+func asMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("not a map: %#v", v)
+	}
+	return m
+}
+
+// ---- request translation ---------------------------------------------------
+
+func TestChatTranslate_SystemAndText(t *testing.T) {
+	a := parseReq(t, `{"model":"m","max_tokens":10,"system":"be brief","messages":[{"role":"user","content":"hi"}]}`)
+	r, err := translateChatRequest(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Stream || r.StreamOptions == nil || !r.StreamOptions.IncludeUsage {
+		t.Fatal("stream + include_usage must be set")
+	}
+	if r.MaxTokens != 10 {
+		t.Fatalf("max_tokens = %d", r.MaxTokens)
+	}
+	if len(r.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(r.Messages))
+	}
+	sys := asMap(t, r.Messages[0])
+	if sys["role"] != "system" || sys["content"] != "be brief" {
+		t.Fatalf("system msg = %v", sys)
+	}
+	usr := asMap(t, r.Messages[1])
+	if usr["role"] != "user" || usr["content"] != "hi" {
+		t.Fatalf("user msg = %v", usr)
+	}
+}
+
+func TestChatTranslate_AssistantTextAndToolUse(t *testing.T) {
+	content := `[{"type":"text","text":"let me check"},{"type":"tool_use","id":"t1","name":"lookup","input":{"k":"v"}}]`
+	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":`+content+`}]}`)
+	r, _ := translateChatRequest(a)
+	if len(r.Messages) != 1 {
+		t.Fatalf("a text+tool_use assistant turn must be ONE message, got %d", len(r.Messages))
+	}
+	m := asMap(t, r.Messages[0])
+	if m["role"] != "assistant" || m["content"] != "let me check" {
+		t.Fatalf("assistant msg = %v", m)
+	}
+	calls, ok := m["tool_calls"].([]map[string]any)
+	if !ok || len(calls) != 1 {
+		t.Fatalf("tool_calls = %#v", m["tool_calls"])
+	}
+	fn := asMap(t, calls[0]["function"])
+	if calls[0]["id"] != "t1" || fn["name"] != "lookup" || fn["arguments"] != `{"k":"v"}` {
+		t.Fatalf("tool_call = %v", calls[0])
+	}
+}
+
+func TestChatTranslate_ToolResultOrderedFirst(t *testing.T) {
+	content := `[{"type":"tool_result","tool_use_id":"t1","content":"the result"},{"type":"text","text":"thanks"}]`
+	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":`+content+`}]}`)
+	r, _ := translateChatRequest(a)
+	if len(r.Messages) != 2 {
+		t.Fatalf("messages = %d, want tool then user", len(r.Messages))
+	}
+	tool := asMap(t, r.Messages[0])
+	if tool["role"] != "tool" || tool["tool_call_id"] != "t1" || tool["content"] != "the result" {
+		t.Fatalf("tool msg must come first: %v", tool)
+	}
+	usr := asMap(t, r.Messages[1])
+	if usr["role"] != "user" || usr["content"] != "thanks" {
+		t.Fatalf("trailing user text = %v", usr)
+	}
+}
+
+func TestChatTranslate_ToolChoiceAndTools(t *testing.T) {
+	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"lookup","description":"d","input_schema":{"type":"object"}}],
+		"tool_choice":{"type":"any","disable_parallel_tool_use":true}}`)
+	r, _ := translateChatRequest(a)
+	if len(r.Tools) != 1 || r.Tools[0].Function.Name != "lookup" {
+		t.Fatalf("tools = %#v", r.Tools)
+	}
+	if r.ToolChoice != "required" {
+		t.Fatalf("tool_choice = %v, want required", r.ToolChoice)
+	}
+	if r.ParallelToolCalls == nil || *r.ParallelToolCalls != false {
+		t.Fatalf("disable_parallel_tool_use must set parallel_tool_calls=false")
+	}
+}
+
+func TestChatTranslate_Image(t *testing.T) {
+	content := `[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}},{"type":"text","text":"see"}]`
+	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":`+content+`}]}`)
+	r, _ := translateChatRequest(a)
+	m := asMap(t, r.Messages[0])
+	parts, ok := m["content"].([]map[string]any)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("image message content must be a parts array: %#v", m["content"])
+	}
+	img := asMap(t, parts[0])
+	if img["type"] != "image_url" || asMap(t, img["image_url"])["url"] != "data:image/png;base64,AAAA" {
+		t.Fatalf("image part = %v", img)
+	}
+}
+
+// ---- streaming conversion --------------------------------------------------
+
+func replayChat(t *testing.T, name string) *recSink {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name+".sse"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recSink{}
+	if err := newChatStreamConverter(sink, "gpt-x").Convert(bytes.NewReader(b)); err != nil {
+		t.Fatalf("convert %s: %v", name, err)
+	}
+	return sink
+}
+
+func TestChatFixture_Text(t *testing.T) {
+	sink := replayChat(t, "chat_text")
+	assertGrammar(t, sink)
+	if got := collectDeltas(sink, "text_delta", "text"); got != "pong" {
+		t.Fatalf("text = %q", got)
+	}
+	if sr := stopReason(t, sink); sr != "end_turn" {
+		t.Fatalf("stop_reason = %q", sr)
+	}
+	usage, _ := sink.payload("message_delta", 0)["usage"].(map[string]any)
+	if usage["input_tokens"] != 12 || usage["output_tokens"] != 3 {
+		t.Fatalf("usage = %v", usage)
+	}
+}
+
+func TestChatFixture_StreamedToolCall(t *testing.T) {
+	sink := replayChat(t, "chat_tool")
+	assertGrammar(t, sink)
+	args := collectDeltas(sink, "input_json_delta", "partial_json")
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(args), &parsed); err != nil || parsed["key"] != "alpha" {
+		t.Fatalf("streamed tool args %q: %v", args, err)
+	}
+	if sr := stopReason(t, sink); sr != "tool_use" {
+		t.Fatalf("stop_reason = %q", sr)
+	}
+}
+
+func TestChatFixture_ParallelTools(t *testing.T) {
+	sink := replayChat(t, "chat_parallel")
+	assertGrammar(t, sink)
+	names := map[string]bool{}
+	for i, ev := range sink.events {
+		if ev != "content_block_start" {
+			continue
+		}
+		cb, _ := sink.payloads[i].(map[string]any)
+		block, _ := cb["content_block"].(map[string]any)
+		if block["type"] == "tool_use" {
+			names[block["name"].(string)] = true
+		}
+	}
+	if !names["f0"] || !names["f1"] {
+		t.Fatalf("both parallel tool blocks must open: %v", names)
+	}
+}
+
+func TestChatFixture_LengthStop(t *testing.T) {
+	sink := replayChat(t, "chat_length")
+	assertGrammar(t, sink)
+	if sr := stopReason(t, sink); sr != "max_tokens" {
+		t.Fatalf("finish_reason length must map to max_tokens, got %q", sr)
+	}
+}
+
+// call hits <upstream>/chat/completions with a Bearer key and streams a real
+// chat backend's response; a non-2xx body that echoes the key is redacted (here
+// with a key that does NOT match the generic pattern, exercising the exact-key
+// path) before it becomes an upstreamError.
+func TestOpenAIChatUpstream_CallConvertAndRedact(t *testing.T) {
+	const key = "raw-vendor-key-9999" // not an sk-/Bearer shape: only exact-match redaction catches it
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" || r.Header.Get("Authorization") != "Bearer "+key {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer ok.Close()
+	u := newOpenAIChatUpstream(ok.URL + "/v1")
+	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`)
+	body, err := u.call(context.Background(), a, key)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	sink := &recSink{}
+	_ = u.convert(body, sink, "m", key)
+	body.Close()
+	if got := collectDeltas(sink, "text_delta", "text"); got != "hi" {
+		t.Fatalf("converted text = %q", got)
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("invalid key " + key + " rejected"))
+	}))
+	defer bad.Close()
+	_, err = newOpenAIChatUpstream(bad.URL+"/v1").call(context.Background(), a, key)
+	ue, ok2 := err.(*upstreamError)
+	if !ok2 || ue.kind != upAuth {
+		t.Fatalf("want upAuth upstreamError, got %v", err)
+	}
+	if strings.Contains(ue.message, key) {
+		t.Fatalf("upstreamError leaked the key: %q", ue.message)
+	}
+}
+
+// A mid-stream error chunk ends on a redacted Anthropic error event (open blocks
+// closed), never a clean message_stop, and never leaks the echoed key.
+func TestChatFixture_ErrorRedacted(t *testing.T) {
+	sink := replayChat(t, "chat_error")
+	last := sink.events[len(sink.events)-1]
+	if last != "error" {
+		t.Fatalf("stream must end on an error event, got %q (%s)", last, sink.seq())
+	}
+	if strings.Contains(sink.seq(), "message_stop") {
+		t.Fatal("an errored stream must not emit a clean message_stop")
+	}
+	errPayload := sink.payload("error", 0)
+	em, _ := errPayload["error"].(map[string]any)
+	msg, _ := em["message"].(string)
+	if strings.Contains(msg, "SECRET12345678") {
+		t.Fatalf("error leaked the key: %q", msg)
+	}
+	if !strings.Contains(msg, "REDACTED") {
+		t.Fatalf("error must be redacted: %q", msg)
+	}
+	// the open text block must have been closed before the error.
+	if sink.payload("content_block_stop", 0) == nil {
+		t.Fatal("open text block must be closed before the error event")
+	}
+}

--- a/internal/codexproxy/openai_responses.go
+++ b/internal/codexproxy/openai_responses.go
@@ -1,0 +1,64 @@
+package codexproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// openaiResponsesUpstream speaks the OpenAI Responses API
+// (POST <upstream>/responses) with a per-request Bearer key. It REUSES codex's
+// Responses request translator + SSE converter; only the auth, URL, headers, and
+// the max_output_tokens cap differ (codex omits the cap and rides the ChatGPT
+// backend over OAuth). It is the upstream for the openai-responses protocol.
+type openaiResponsesUpstream struct {
+	http    *http.Client
+	baseURL string
+}
+
+func newOpenAIResponsesUpstream(baseURL string) *openaiResponsesUpstream {
+	return &openaiResponsesUpstream{http: &http.Client{Timeout: 0}, baseURL: baseURL}
+}
+
+// models is empty: the model list comes from the real upstream models_endpoint.
+func (u *openaiResponsesUpstream) models() []string { return nil }
+
+func (u *openaiResponsesUpstream) convert(body io.Reader, sink sseSink, model, apiKey string) error {
+	c := newStreamConverter(sink, model)
+	c.redact = func(s string) string { return redactKey(s, apiKey) }
+	return c.Convert(body)
+}
+
+// call translates the Anthropic request with the shared Responses translator,
+// adds the max_output_tokens cap (a billed account honors it), and sends it with
+// Authorization: Bearer <apiKey> — no codex headers, no OAuth refresh, no
+// Cloudflare path. A non-2xx body is redacted before becoming an upstreamError.
+func (u *openaiResponsesUpstream) call(ctx context.Context, areq *anthropicRequest, apiKey string) (io.ReadCloser, error) {
+	rreq, err := translateRequest(areq)
+	if err != nil {
+		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, err.Error()}
+	}
+	if areq.MaxTokens > 0 {
+		rreq.MaxOutputTokens = areq.MaxTokens
+	}
+	body, _ := json.Marshal(rreq)
+	endpoint, err := url.JoinPath(u.baseURL, "responses")
+	if err != nil {
+		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, "invalid upstream url"}
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := u.http.Do(req)
+	if err != nil {
+		return nil, &upstreamError{upTransient, http.StatusBadGateway, "openai upstream: " + redactKey(err.Error(), apiKey)}
+	}
+	if resp.StatusCode/100 == 2 {
+		return resp.Body, nil
+	}
+	return nil, classifyOpenAI(resp, apiKey)
+}

--- a/internal/codexproxy/openai_responses_test.go
+++ b/internal/codexproxy/openai_responses_test.go
@@ -1,0 +1,128 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The openai-responses upstream sends to <upstream>/responses with a Bearer key,
+// maps Anthropic max_tokens -> max_output_tokens, drops the codex OpenAI-Beta
+// header, and converts the Responses stream with the shared converter.
+func TestOpenAIResponsesUpstream_CallMapsMaxOutput(t *testing.T) {
+	var gotBody map[string]any
+	var gotBeta, gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBeta = r.Header.Get("OpenAI-Beta")
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.added","item":{"id":"m1","type":"message"}}
+
+data: {"type":"response.output_text.delta","item_id":"m1","delta":"yo"}
+
+data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}
+
+`))
+	}))
+	defer srv.Close()
+
+	u := newOpenAIResponsesUpstream(srv.URL + "/v1")
+	a := parseReq(t, `{"model":"gpt-x","max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`)
+	body, err := u.call(context.Background(), a, "sk-billed-123")
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	sink := &recSink{}
+	_ = u.convert(body, sink, "gpt-x", "sk-billed-123")
+	body.Close()
+
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if gotAuth != "Bearer sk-billed-123" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+	if gotBeta != "" {
+		t.Fatalf("openai-responses must not send the codex OpenAI-Beta header, got %q", gotBeta)
+	}
+	if gotBody["max_output_tokens"] != float64(256) {
+		t.Fatalf("max_output_tokens = %v, want 256", gotBody["max_output_tokens"])
+	}
+	if got := collectDeltas(sink, "text_delta", "text"); got != "yo" {
+		t.Fatalf("converted text = %q", got)
+	}
+}
+
+// translateRequest (the codex path) never sets max_output_tokens — the ChatGPT
+// backend 400s on it, so omitempty must drop it.
+func TestResponsesTranslate_CodexOmitsMaxOutput(t *testing.T) {
+	a := parseReq(t, `{"model":"m","max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`)
+	r, _ := translateRequest(a)
+	b, _ := json.Marshal(r)
+	if strings.Contains(string(b), "max_output_tokens") {
+		t.Fatalf("codex request must omit max_output_tokens: %s", b)
+	}
+}
+
+// A streaming error chunk that echoes a non-pattern key is redacted via the
+// upstream's per-request convert redactor (the exact-key path), for both the
+// Chat and Responses converters.
+func TestOpenAIConvert_RedactsStreamingErrorKey(t *testing.T) {
+	const key = "raw-vendor-key-9999" // not an sk-/Bearer shape
+
+	chatBody := `data: {"error":{"message":"upstream rejected ` + key + ` here"}}` + "\n\n"
+	csink := &recSink{}
+	_ = newOpenAIChatUpstream("https://x/v1").convert(strings.NewReader(chatBody), csink, "m", key)
+	if msg := errMessage(csink); strings.Contains(msg, key) {
+		t.Fatalf("chat streaming error leaked the key: %q", msg)
+	}
+
+	respBody := `data: {"type":"response.failed","response":{"error":{"message":"bad ` + key + ` token"}}}` + "\n\n"
+	rsink := &recSink{}
+	_ = newOpenAIResponsesUpstream("https://x/v1").convert(strings.NewReader(respBody), rsink, "m", key)
+	if msg := errMessage(rsink); strings.Contains(msg, key) {
+		t.Fatalf("responses streaming error leaked the key: %q", msg)
+	}
+}
+
+func errMessage(sink *recSink) string {
+	p := sink.payload("error", 0)
+	em, _ := p["error"].(map[string]any)
+	s, _ := em["message"].(string)
+	return s
+}
+
+// reasoning_text.* maps to the thinking block and refusal.* is surfaced as text —
+// neither is silently dropped (the two MUST-VERIFY stream shapes).
+func TestResponsesConverter_ReasoningTextAndRefusal(t *testing.T) {
+	sse := `data: {"type":"response.output_item.added","item":{"id":"r1","type":"reasoning"}}
+
+data: {"type":"response.reasoning_text.delta","item_id":"r1","delta":"thinking"}
+
+data: {"type":"response.output_item.done","item":{"id":"r1","type":"reasoning"}}
+
+data: {"type":"response.output_item.added","item":{"id":"m1","type":"message"}}
+
+data: {"type":"response.refusal.delta","item_id":"m1","delta":"cannot help"}
+
+data: {"type":"response.output_item.done","item":{"id":"m1","type":"message"}}
+
+data: {"type":"response.completed","response":{"status":"completed"}}
+
+`
+	sink := runConvert(t, sse)
+	assertGrammar(t, sink)
+	if got := collectDeltas(sink, "thinking_delta", "thinking"); got != "thinking" {
+		t.Fatalf("reasoning_text must map to thinking: %q", got)
+	}
+	if got := collectDeltas(sink, "text_delta", "text"); got != "cannot help" {
+		t.Fatalf("refusal must surface as text: %q", got)
+	}
+}

--- a/internal/codexproxy/protocol.go
+++ b/internal/codexproxy/protocol.go
@@ -1,0 +1,44 @@
+package codexproxy
+
+// Codex/ChatGPT OAuth + Responses protocol constants. These are factual interop
+// values (a public PKCE client id and fixed endpoint URLs), not configuration.
+const (
+	// oauthClientID is the public PKCE client (no secret) shared by the codex CLI.
+	oauthClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+	// oauthTokenURL serves both the authorization-code exchange and refresh grants.
+	oauthTokenURL = "https://auth.openai.com/oauth/token"
+
+	// Device-code login: start, then poll for the authorization code + verifier.
+	deviceUserCodeURL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
+	deviceTokenURL    = "https://auth.openai.com/api/accounts/deviceauth/token"
+	deviceRedirectURI = "https://auth.openai.com/deviceauth/callback"
+	// deviceVerifyURL is shown to the user alongside the user code.
+	deviceVerifyURL = "https://auth.openai.com/codex/device"
+
+	// responsesURL is the ChatGPT-backend Responses endpoint a subscription token
+	// authenticates against (api.openai.com does not accept this token).
+	responsesURL = "https://chatgpt.com/backend-api/codex/responses"
+	// modelsURL lists the models available to the subscription.
+	modelsURL = "https://chatgpt.com/backend-api/codex/models"
+)
+
+// Upstream request headers. originator + a codex-shaped User-Agent present this as
+// a genuine codex client (required to pass the backend's edge); OpenAI-Beta and
+// chatgpt-account-id are required for a successful Responses call.
+const (
+	originatorValue = "codex_cli_rs"
+	userAgentValue  = "codex_cli_rs/0.137.0"
+	openAIBetaValue = "responses=experimental"
+
+	// jwtAuthClaim is the namespaced id_token/access_token claim holding the
+	// chatgpt_account_id used for the chatgpt-account-id header.
+	jwtAuthClaim = "https://api.openai.com/auth"
+)
+
+// SecretBackend is the vendors.toml secret_backend value selecting a codex provider,
+// and the sentinel secret_ref it pairs with (config requires a non-empty secret_ref).
+const (
+	SecretBackend = "codex-oauth"
+	SecretRef     = "codex-oauth"
+)

--- a/internal/codexproxy/scan.go
+++ b/internal/codexproxy/scan.go
@@ -1,0 +1,62 @@
+package codexproxy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Loopback port selection for the codex vendor's base_url: a small reserved
+// scan range starting at a fixed literal. The chosen port is persisted into
+// vendors.toml at add time and baked into the cached profile, so it must stay
+// stable across daemon restarts (never ephemeral).
+const (
+	defaultPortBase = 17222
+	portScanWidth   = 10
+)
+
+// ScanDefaultModel reads the default model from the codex CLI's
+// ~/.codex/config.toml — the one sanctioned read of that tree (never auth).
+// Falls back when the file or key is absent.
+func ScanDefaultModel(fallback string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fallback
+	}
+	var doc struct {
+		Model string `toml:"model"`
+	}
+	if _, err := toml.DecodeFile(filepath.Join(home, ".codex", "config.toml"), &doc); err != nil || doc.Model == "" {
+		return fallback
+	}
+	return doc.Model
+}
+
+// ChoosePort picks the daemon's loopback port for a new codex vendor: the
+// explicit preference when usable, else the first usable port in the reserved
+// range. Usable = free to bind, or already held by a live cc-fleet codex
+// daemon (re-adding the vendor while the daemon runs must not fail).
+func ChoosePort(preferred int) (int, error) {
+	if preferred > 0 {
+		if portUsable(preferred) {
+			return preferred, nil
+		}
+		return 0, fmt.Errorf("port %d is held by another process; free it or pass a different --port", preferred)
+	}
+	for p := defaultPortBase; p < defaultPortBase+portScanWidth; p++ {
+		if portUsable(p) {
+			return p, nil
+		}
+	}
+	return 0, fmt.Errorf("no free port in %d-%d; pass --port", defaultPortBase, defaultPortBase+portScanWidth-1)
+}
+
+func portUsable(port int) bool {
+	if !whoHoldsPort(port) {
+		return true // free to bind
+	}
+	st, err := readState()
+	return err == nil && st.Port == port && st.PID > 0 && pidAlive(st.PID, st.ProcStart) && portResponds(port)
+}

--- a/internal/codexproxy/scan.go
+++ b/internal/codexproxy/scan.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
 )
 
 // Loopback port selection for the codex vendor's base_url: a small reserved
@@ -34,29 +36,52 @@ func ScanDefaultModel(fallback string) string {
 	return doc.Model
 }
 
-// ChoosePort picks the daemon's loopback port for a new codex vendor: the
-// explicit preference when usable, else the first usable port in the reserved
-// range. Usable = free to bind, or already held by a live cc-fleet codex
-// daemon (re-adding the vendor while the daemon runs must not fail).
+// ChoosePort picks a new daemon-backed vendor's loopback port: the explicit
+// preference when usable, else the first usable port in the reserved range.
+// Usable = not already assigned to another vendor in vendors.toml AND (free to
+// bind, or held by a live cc-fleet daemon — re-adding while the daemon runs must
+// not fail). Skipping assigned ports keeps two daemon-backed providers from
+// thrashing one port (daemons start lazily, so neither is bound at add time).
 func ChoosePort(preferred int) (int, error) {
+	assigned := assignedPorts()
 	if preferred > 0 {
-		if portUsable(preferred) {
+		if !assigned[preferred] && portUsable(preferred) {
 			return preferred, nil
 		}
-		return 0, fmt.Errorf("port %d is held by another process; free it or pass a different --port", preferred)
+		return 0, fmt.Errorf("port %d is in use or already assigned; pass a different --port", preferred)
 	}
 	for p := defaultPortBase; p < defaultPortBase+portScanWidth; p++ {
-		if portUsable(p) {
+		if !assigned[p] && portUsable(p) {
 			return p, nil
 		}
 	}
 	return 0, fmt.Errorf("no free port in %d-%d; pass --port", defaultPortBase, defaultPortBase+portScanWidth-1)
 }
 
+// assignedPorts is the set of loopback ports already bound to a daemon-backed
+// vendor in vendors.toml, so a new provider never reuses one. A config-load
+// failure yields an empty set (the bind check below still guards live ports).
+func assignedPorts() map[int]bool {
+	used := map[int]bool{}
+	cfg, err := config.Load()
+	if err != nil {
+		return used
+	}
+	for _, v := range cfg.Vendors {
+		if !v.DaemonBacked() {
+			continue
+		}
+		if p, err := PortFromBaseURL(v.BaseURL); err == nil {
+			used[p] = true
+		}
+	}
+	return used
+}
+
 func portUsable(port int) bool {
 	if !whoHoldsPort(port) {
 		return true // free to bind
 	}
-	st, err := readState()
+	st, err := readState(port)
 	return err == nil && st.Port == port && st.PID > 0 && pidAlive(st.PID, st.ProcStart) && portResponds(port)
 }

--- a/internal/codexproxy/scan_test.go
+++ b/internal/codexproxy/scan_test.go
@@ -1,0 +1,68 @@
+package codexproxy
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanDefaultModel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if got := ScanDefaultModel("fallback"); got != "fallback" {
+		t.Fatalf("absent config.toml: %q", got)
+	}
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"),
+		[]byte("model = \"gpt-5.5\"\nmodel_reasoning_effort = \"xhigh\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ScanDefaultModel("fallback"); got != "gpt-5.5" {
+		t.Fatalf("scanned model: %q", got)
+	}
+}
+
+func TestChoosePort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no daemon state file
+	t.Setenv("HOME", t.TempDir())
+
+	// A held port (not ours) is rejected when explicitly preferred.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	held := ln.Addr().(*net.TCPAddr).Port
+	if _, err := ChoosePort(held); err == nil {
+		t.Fatalf("held port %d must be rejected", held)
+	}
+
+	// A free explicit preference is honored.
+	free := freePort(t)
+	if got, err := ChoosePort(free); err != nil || got != free {
+		t.Fatalf("ChoosePort(%d) = %d, %v", free, got, err)
+	}
+
+	// Auto-pick lands in the reserved range.
+	got, err := ChoosePort(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got < defaultPortBase || got >= defaultPortBase+portScanWidth {
+		t.Fatalf("auto port %d outside the reserved range", got)
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}

--- a/internal/codexproxy/scan_test.go
+++ b/internal/codexproxy/scan_test.go
@@ -1,10 +1,13 @@
 package codexproxy
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
 )
 
 func TestScanDefaultModel(t *testing.T) {
@@ -54,6 +57,44 @@ func TestChoosePort(t *testing.T) {
 	}
 	if got < defaultPortBase || got >= defaultPortBase+portScanWidth {
 		t.Fatalf("auto port %d outside the reserved range", got)
+	}
+}
+
+// A port already assigned to a daemon-backed vendor in vendors.toml is never
+// handed to a new provider (daemons start lazily, so the bind check alone would
+// let two providers collide on one port).
+func TestChoosePort_SkipsAssigned(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	base := fmt.Sprintf("http://127.0.0.1:%d/", defaultPortBase)
+	cfg := &config.Config{Version: config.SchemaVersion, Vendors: map[string]*config.Vendor{
+		"codex": {
+			Name: "codex", BaseURL: base, ModelsEndpoint: base + "v1/models",
+			DefaultModel: "gpt-5.5", SecretBackend: config.CodexOAuthBackend,
+			SecretRef: config.CodexOAuthBackend, Enabled: true,
+		},
+	}}
+	p, err := config.VendorsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveToPath(cfg, p); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ChoosePort(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == defaultPortBase {
+		t.Fatalf("auto-pick must skip the assigned port %d, got %d", defaultPortBase, got)
+	}
+	if _, err := ChoosePort(defaultPortBase); err == nil {
+		t.Fatalf("preferring the assigned port %d must fail", defaultPortBase)
 	}
 }
 

--- a/internal/codexproxy/serve.go
+++ b/internal/codexproxy/serve.go
@@ -7,35 +7,44 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/procintrospect"
 )
 
-// Serve runs the codex proxy daemon: it binds the loopback port, records its state,
-// serves the conversion handler, and self-exits once no codex worker and no launch
-// lease remain (re-checked under the proxy lock; a scan error keeps it alive).
-func Serve(port int) error {
-	// Read the handshake secret lock-free: EnsureDaemon creates it under the proxy
-	// lock BEFORE spawning this daemon and holds that lock across waitReady, so
-	// taking it here would deadlock. A manual `codex-proxy serve` (no EnsureDaemon)
-	// falls back to creating it directly.
-	secret, err := loadOrCreateSecret()
+// Serve runs a proxy daemon for protocol on port: it binds the loopback port,
+// builds the protocol's upstream, records its state, serves the conversion
+// handler, and self-exits once no matching worker and no launch lease remain
+// (re-checked under the port's proxy lock; a scan error keeps it alive).
+func Serve(port int, protocol, upstreamURL string) error {
+	if protocol == "" {
+		protocol = config.ProtocolCodexOAuth
+	}
+	up, err := buildUpstream(protocol, upstreamURL)
 	if err != nil {
 		return err
 	}
-	source, err := newOwnStore()
-	if err != nil {
-		return err
+	// codex gates /v1/messages on the handshake secret (its OAuth bearer lives
+	// only here); an openai-* daemon takes the real key per request, so it needs
+	// none. Read it lock-free: EnsureDaemon created it under the global secret
+	// lock before spawning this daemon. A manual `serve` falls back to creating it.
+	var secret string
+	if protocol == config.ProtocolCodexOAuth {
+		if secret, err = loadOrCreateSecret(); err != nil {
+			return err
+		}
 	}
-	srv := newServer(source, secret)
+	srv := newServer(up, protocol, secret)
 
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return fmt.Errorf("bind 127.0.0.1:%d: %w", port, err)
 	}
 	start, _ := procintrospect.ProcStart(os.Getpid())
-	if err := writeState(proxyState{Port: port, PID: os.Getpid(), ProcStart: start}); err != nil {
+	if err := writeState(proxyState{Port: port, PID: os.Getpid(), ProcStart: start, Protocol: protocol, UpstreamURL: upstreamURL}); err != nil {
 		ln.Close()
 		return err
 	}
@@ -52,24 +61,24 @@ func Serve(port int) error {
 	if err := httpSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
-	clearStateIfOwner()
+	clearStateIfOwner(port)
 	return nil
 }
 
-// maybeShutdown decides under the proxy lock whether the daemon may stop, and if so
-// shuts the listener (releasing the port) and clears its own state — all WITHIN the
-// lock so a concurrent EnsureDaemon never observes a half-torn-down daemon (state
-// gone but the port still held) nor has its own fresh state deleted by us. It may
-// stop only when no unexpired launch lease and no live codex worker remain and it
-// has been idle past the grace period; any introspection uncertainty (-1 workers)
-// keeps it alive.
+// maybeShutdown decides under the port's proxy lock whether the daemon may stop,
+// and if so shuts the listener (releasing the port) and clears its own state — all
+// WITHIN the lock so a concurrent EnsureDaemon never observes a half-torn-down
+// daemon (state gone but the port still held) nor has its own fresh state deleted
+// by us. It may stop only when no unexpired launch lease and no live worker remain
+// and it has been idle past the grace period; any introspection uncertainty (-1
+// workers) keeps it alive.
 func maybeShutdown(port int, srv *server, httpSrv *http.Server) bool {
 	stopped := false
-	_ = withProxyLock(func() error {
-		if activeLeases() > 0 {
+	_ = withProxyLock(port, func() error {
+		if activeLeases(port) > 0 {
 			return nil
 		}
-		if workers := liveCodexWorkers(port); workers != 0 {
+		if workers := liveWorkers(port); workers != 0 {
 			return nil // >0 live, or -1 unknown -> stay alive
 		}
 		if time.Since(time.Unix(0, srv.lastActivity.Load())) < idleGrace {
@@ -78,91 +87,114 @@ func maybeShutdown(port int, srv *server, httpSrv *http.Server) bool {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = httpSrv.Shutdown(ctx)
 		cancel()
-		clearStateIfOwner()
+		clearStateIfOwner(port)
 		stopped = true
 		return nil
 	})
 	return stopped
 }
 
-func clearState() {
-	if p, err := statePath(); err == nil {
+func clearState(port int) {
+	if p, err := statePath(port); err == nil {
 		os.Remove(p)
 	}
 }
 
 // clearStateIfOwner removes the state file only when it still describes THIS
 // process, so a shutting-down daemon never deletes a replacement's fresh state.
-func clearStateIfOwner() {
-	if st, err := readState(); err == nil && st.PID != os.Getpid() {
+func clearStateIfOwner(port int) {
+	if st, err := readState(port); err == nil && st.PID != os.Getpid() {
 		return
 	}
-	clearState()
+	clearState(port)
 }
 
-// StopDaemon stops a running daemon (explicit `cc-fleet codex-proxy stop` / uninstall).
+// StopDaemon stops every running proxy daemon (explicit `cc-fleet codex-proxy
+// stop` / logout / uninstall). Each port is stopped under its own proxy lock.
 func StopDaemon() error {
-	return withProxyLock(func() error {
-		st, err := readState()
-		if err != nil {
-			return nil // not running
-		}
-		if st.PID > 0 && pidAlive(st.PID, st.ProcStart) {
-			if proc, e := os.FindProcess(st.PID); e == nil {
-				_ = proc.Signal(os.Interrupt)
+	for _, st := range listStates() {
+		port := st.Port
+		_ = withProxyLock(port, func() error {
+			cur, err := readState(port)
+			if err != nil {
+				return nil // already gone
 			}
-		}
-		clearState()
-		return nil
-	})
-}
-
-// Status reports whether a daemon is running and on which port.
-func Status() (running bool, port int) {
-	st, err := readState()
-	if err != nil || st.PID <= 0 || !pidAlive(st.PID, st.ProcStart) {
-		return false, 0
+			if cur.PID > 0 && pidAlive(cur.PID, cur.ProcStart) {
+				if proc, e := os.FindProcess(cur.PID); e == nil {
+					_ = proc.Signal(os.Interrupt)
+				}
+			}
+			clearState(port)
+			return nil
+		})
 	}
-	return true, st.Port
+	return nil
 }
 
-// Purge stops the daemon and removes every codex-proxy state file (state,
-// handshake secret, leases, lock files) for uninstall. The login token chain
-// is a credential: kept when keepToken (uninstall's KeepSecrets), else
-// removed. Best-effort — failures land in kept with the reason, never abort.
+// DaemonInfo describes a running proxy daemon for `codex-proxy status`.
+type DaemonInfo struct {
+	Port     int
+	Protocol string
+}
+
+// RunningDaemons lists every live proxy daemon.
+func RunningDaemons() []DaemonInfo {
+	var out []DaemonInfo
+	for _, st := range listStates() {
+		if st.PID > 0 && pidAlive(st.PID, st.ProcStart) {
+			out = append(out, DaemonInfo{Port: st.Port, Protocol: st.Protocol})
+		}
+	}
+	return out
+}
+
+// Purge stops every daemon and removes all proxy state (per-port state files,
+// lease dirs, lock files, the handshake secret, the secret + token locks) for
+// uninstall. The login token chain is a credential: kept when keepToken (uninstall's
+// KeepSecrets), else removed. Best-effort — failures land in kept with the reason,
+// never abort.
 func Purge(keepToken bool) (removed, kept []string) {
-	_ = StopDaemon() // clears the state file
+	_ = StopDaemon() // clears each per-port state file
 
-	paths := make([]string, 0, 4)
-	for _, f := range []func() (string, error){secretPath, lockPath} {
-		if p, err := f(); err == nil {
-			paths = append(paths, p)
-		}
-	}
-	if p, err := joinConfig(".cc-fleet-codex-token.lock"); err == nil {
-		paths = append(paths, p)
-	}
-	tokenPath, terr := storePath()
-	if terr == nil && !keepToken {
-		paths = append(paths, tokenPath)
-	}
-	for _, p := range paths {
+	rm := func(p string) {
 		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
 			kept = append(kept, fmt.Sprintf("%s (remove failed: %v)", p, err))
-			continue
+			return
 		}
 		removed = append(removed, p)
 	}
-	if terr == nil && keepToken {
-		if _, err := os.Stat(tokenPath); err == nil {
-			kept = append(kept, tokenPath)
+	if dir, err := config.ConfigDir(); err == nil {
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			name := e.Name()
+			full := filepath.Join(dir, name)
+			switch {
+			case strings.HasPrefix(name, "codex-proxy-leases-"):
+				if rerr := os.RemoveAll(full); rerr != nil {
+					kept = append(kept, fmt.Sprintf("%s (rm -rf failed: %v)", full, rerr))
+				} else {
+					removed = append(removed, full)
+				}
+			case strings.HasPrefix(name, "codex-proxy-") && strings.HasSuffix(name, ".json"):
+				rm(full)
+			case strings.HasPrefix(name, ".cc-fleet-codex-proxy-") && strings.HasSuffix(name, ".lock"):
+				rm(full)
+			case name == "codex-proxy-secret",
+				name == ".cc-fleet-codex-secret.lock",
+				name == ".cc-fleet-codex-token.lock":
+				rm(full)
+			}
 		}
 	}
-	if d, err := leasesDir(); err == nil {
-		if err := os.RemoveAll(d); err != nil {
-			kept = append(kept, fmt.Sprintf("%s (rm -rf failed: %v)", d, err))
+
+	tokenPath, terr := storePath()
+	if terr == nil {
+		if keepToken {
+			if _, err := os.Stat(tokenPath); err == nil {
+				kept = append(kept, tokenPath)
+			}
 		} else {
-			removed = append(removed, d)
+			rm(tokenPath)
 		}
 	}
 	return removed, kept

--- a/internal/codexproxy/serve.go
+++ b/internal/codexproxy/serve.go
@@ -1,0 +1,169 @@
+package codexproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/procintrospect"
+)
+
+// Serve runs the codex proxy daemon: it binds the loopback port, records its state,
+// serves the conversion handler, and self-exits once no codex worker and no launch
+// lease remain (re-checked under the proxy lock; a scan error keeps it alive).
+func Serve(port int) error {
+	// Read the handshake secret lock-free: EnsureDaemon creates it under the proxy
+	// lock BEFORE spawning this daemon and holds that lock across waitReady, so
+	// taking it here would deadlock. A manual `codex-proxy serve` (no EnsureDaemon)
+	// falls back to creating it directly.
+	secret, err := loadOrCreateSecret()
+	if err != nil {
+		return err
+	}
+	source, err := newOwnStore()
+	if err != nil {
+		return err
+	}
+	srv := newServer(source, secret)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("bind 127.0.0.1:%d: %w", port, err)
+	}
+	start, _ := procintrospect.ProcStart(os.Getpid())
+	if err := writeState(proxyState{Port: port, PID: os.Getpid(), ProcStart: start}); err != nil {
+		ln.Close()
+		return err
+	}
+
+	httpSrv := &http.Server{Handler: srv.handler()}
+	go func() {
+		for {
+			time.Sleep(60 * time.Second)
+			if maybeShutdown(port, srv, httpSrv) {
+				return
+			}
+		}
+	}()
+	if err := httpSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	clearStateIfOwner()
+	return nil
+}
+
+// maybeShutdown decides under the proxy lock whether the daemon may stop, and if so
+// shuts the listener (releasing the port) and clears its own state — all WITHIN the
+// lock so a concurrent EnsureDaemon never observes a half-torn-down daemon (state
+// gone but the port still held) nor has its own fresh state deleted by us. It may
+// stop only when no unexpired launch lease and no live codex worker remain and it
+// has been idle past the grace period; any introspection uncertainty (-1 workers)
+// keeps it alive.
+func maybeShutdown(port int, srv *server, httpSrv *http.Server) bool {
+	stopped := false
+	_ = withProxyLock(func() error {
+		if activeLeases() > 0 {
+			return nil
+		}
+		if workers := liveCodexWorkers(port); workers != 0 {
+			return nil // >0 live, or -1 unknown -> stay alive
+		}
+		if time.Since(time.Unix(0, srv.lastActivity.Load())) < idleGrace {
+			return nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = httpSrv.Shutdown(ctx)
+		cancel()
+		clearStateIfOwner()
+		stopped = true
+		return nil
+	})
+	return stopped
+}
+
+func clearState() {
+	if p, err := statePath(); err == nil {
+		os.Remove(p)
+	}
+}
+
+// clearStateIfOwner removes the state file only when it still describes THIS
+// process, so a shutting-down daemon never deletes a replacement's fresh state.
+func clearStateIfOwner() {
+	if st, err := readState(); err == nil && st.PID != os.Getpid() {
+		return
+	}
+	clearState()
+}
+
+// StopDaemon stops a running daemon (explicit `cc-fleet codex-proxy stop` / uninstall).
+func StopDaemon() error {
+	return withProxyLock(func() error {
+		st, err := readState()
+		if err != nil {
+			return nil // not running
+		}
+		if st.PID > 0 && pidAlive(st.PID, st.ProcStart) {
+			if proc, e := os.FindProcess(st.PID); e == nil {
+				_ = proc.Signal(os.Interrupt)
+			}
+		}
+		clearState()
+		return nil
+	})
+}
+
+// Status reports whether a daemon is running and on which port.
+func Status() (running bool, port int) {
+	st, err := readState()
+	if err != nil || st.PID <= 0 || !pidAlive(st.PID, st.ProcStart) {
+		return false, 0
+	}
+	return true, st.Port
+}
+
+// Purge stops the daemon and removes every codex-proxy state file (state,
+// handshake secret, leases, lock files) for uninstall. The login token chain
+// is a credential: kept when keepToken (uninstall's KeepSecrets), else
+// removed. Best-effort — failures land in kept with the reason, never abort.
+func Purge(keepToken bool) (removed, kept []string) {
+	_ = StopDaemon() // clears the state file
+
+	paths := make([]string, 0, 4)
+	for _, f := range []func() (string, error){secretPath, lockPath} {
+		if p, err := f(); err == nil {
+			paths = append(paths, p)
+		}
+	}
+	if p, err := joinConfig(".cc-fleet-codex-token.lock"); err == nil {
+		paths = append(paths, p)
+	}
+	tokenPath, terr := storePath()
+	if terr == nil && !keepToken {
+		paths = append(paths, tokenPath)
+	}
+	for _, p := range paths {
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			kept = append(kept, fmt.Sprintf("%s (remove failed: %v)", p, err))
+			continue
+		}
+		removed = append(removed, p)
+	}
+	if terr == nil && keepToken {
+		if _, err := os.Stat(tokenPath); err == nil {
+			kept = append(kept, tokenPath)
+		}
+	}
+	if d, err := leasesDir(); err == nil {
+		if err := os.RemoveAll(d); err != nil {
+			kept = append(kept, fmt.Sprintf("%s (rm -rf failed: %v)", d, err))
+		} else {
+			removed = append(removed, d)
+		}
+	}
+	return removed, kept
+}

--- a/internal/codexproxy/server.go
+++ b/internal/codexproxy/server.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
 )
 
 // models offered to a ChatGPT subscription (served at /v1/models for the probe and
@@ -17,16 +19,19 @@ var codexModels = []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"
 // before the lazily-started daemon has ever run (the add path skips the probe).
 func StaticModels() []string { return append([]string(nil), codexModels...) }
 
-// server is the loopback HTTP handler set: /v1/messages (Anthropic inbound) and
-// /v1/models (probe). It records last-activity so the daemon can gauge idleness.
+// server is the loopback HTTP handler set: /v1/messages (Anthropic inbound),
+// /v1/models (codex probe list), and /healthz (upstream-independent readiness).
+// It records last-activity so the daemon can gauge idleness. The upstream + auth
+// behavior are chosen by the daemon's protocol.
 type server struct {
-	upstream     *upstreamClient
-	loopbackAuth string
+	up           upstream
+	protocol     string
+	handshake    string       // codex-oauth handshake secret; "" for openai-*
 	lastActivity atomic.Int64 // unix nanos of the last /v1/messages request
 }
 
-func newServer(source tokenSource, loopbackAuth string) *server {
-	s := &server{upstream: newUpstreamClient(source), loopbackAuth: loopbackAuth}
+func newServer(up upstream, protocol, handshake string) *server {
+	s := &server{up: up, protocol: protocol, handshake: handshake}
 	s.lastActivity.Store(time.Now().UnixNano())
 	return s
 }
@@ -35,16 +40,35 @@ func (s *server) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/messages", s.handleMessages)
 	mux.HandleFunc("/v1/models", s.handleModels)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	return mux
 }
 
 func (s *server) handleModels(w http.ResponseWriter, _ *http.Request) {
-	data := make([]map[string]any, 0, len(codexModels))
-	for _, m := range codexModels {
+	list := s.up.models()
+	data := make([]map[string]any, 0, len(list))
+	for _, m := range list {
 		data = append(data, map[string]any{"id": m, "type": "model"})
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+}
+
+// authorize checks the inbound x-api-key for the daemon's protocol and returns the
+// credential to use upstream. codex requires the handshake secret (its OAuth
+// bearer lives only here) and uses no upstream key; an openai-* daemon forwards
+// the presented real key verbatim as the upstream Bearer.
+func (s *server) authorize(key string) (upstreamKey string, ok bool) {
+	if s.protocol == config.ProtocolCodexOAuth {
+		if s.handshake == "" || key != s.handshake {
+			return "", false
+		}
+		return "", true
+	}
+	if key == "" {
+		return "", false
+	}
+	return key, true
 }
 
 func (s *server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -52,8 +76,8 @@ func (s *server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	// claude sends keyget's output (the loopback handshake secret) as x-api-key.
-	if s.loopbackAuth != "" && r.Header.Get("x-api-key") != s.loopbackAuth {
+	upstreamKey, ok := s.authorize(r.Header.Get("x-api-key"))
+	if !ok {
 		writeAnthropicError(w, http.StatusUnauthorized, "authentication_error", "proxy handshake failed")
 		return
 	}
@@ -64,31 +88,24 @@ func (s *server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "bad request body: "+err.Error())
 		return
 	}
-	rreq, err := translateRequest(&areq)
-	if err != nil {
-		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
-		return
-	}
-	body, _ := json.Marshal(rreq)
 
-	resp, err := s.upstream.call(r.Context(), body)
+	body, err := s.up.call(r.Context(), &areq, upstreamKey)
 	if err != nil {
 		ue, _ := err.(*upstreamError)
 		status, etype, msg := anthropicErrorFor(ue)
 		writeAnthropicError(w, status, etype, msg)
 		return
 	}
-	defer resp.Body.Close()
+	defer body.Close()
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	sink := &httpSSE{w: w, flusher: w.(http.Flusher)}
-	conv := newStreamConverter(sink, areq.Model)
-	// Convert already emitted the client-visible terminal event (a clean
+	// convert already emitted the client-visible terminal event (a clean
 	// message_stop, or an error event on a failed-upstream / read-error stream),
 	// so its returned error needs no further handling on the wire.
-	_ = conv.Convert(resp.Body)
+	_ = s.up.convert(body, sink, areq.Model, upstreamKey)
 }
 
 // httpSSE writes Anthropic SSE events to the response and flushes each one.

--- a/internal/codexproxy/server.go
+++ b/internal/codexproxy/server.go
@@ -1,0 +1,139 @@
+package codexproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// models offered to a ChatGPT subscription (served at /v1/models for the probe and
+// `cc-fleet models`). Pass-through: an unsupported slug surfaces the backend error.
+var codexModels = []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2-codex"}
+
+// StaticModels is the codex model list, copied for callers outside the package.
+// `cc-fleet codex add` seeds it into the models cache so model resolution works
+// before the lazily-started daemon has ever run (the add path skips the probe).
+func StaticModels() []string { return append([]string(nil), codexModels...) }
+
+// server is the loopback HTTP handler set: /v1/messages (Anthropic inbound) and
+// /v1/models (probe). It records last-activity so the daemon can gauge idleness.
+type server struct {
+	upstream     *upstreamClient
+	loopbackAuth string
+	lastActivity atomic.Int64 // unix nanos of the last /v1/messages request
+}
+
+func newServer(source tokenSource, loopbackAuth string) *server {
+	s := &server{upstream: newUpstreamClient(source), loopbackAuth: loopbackAuth}
+	s.lastActivity.Store(time.Now().UnixNano())
+	return s
+}
+
+func (s *server) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages", s.handleMessages)
+	mux.HandleFunc("/v1/models", s.handleModels)
+	return mux
+}
+
+func (s *server) handleModels(w http.ResponseWriter, _ *http.Request) {
+	data := make([]map[string]any, 0, len(codexModels))
+	for _, m := range codexModels {
+		data = append(data, map[string]any{"id": m, "type": "model"})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+}
+
+func (s *server) handleMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// claude sends keyget's output (the loopback handshake secret) as x-api-key.
+	if s.loopbackAuth != "" && r.Header.Get("x-api-key") != s.loopbackAuth {
+		writeAnthropicError(w, http.StatusUnauthorized, "authentication_error", "proxy handshake failed")
+		return
+	}
+	s.lastActivity.Store(time.Now().UnixNano())
+
+	var areq anthropicRequest
+	if err := json.NewDecoder(r.Body).Decode(&areq); err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "bad request body: "+err.Error())
+		return
+	}
+	rreq, err := translateRequest(&areq)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	body, _ := json.Marshal(rreq)
+
+	resp, err := s.upstream.call(r.Context(), body)
+	if err != nil {
+		ue, _ := err.(*upstreamError)
+		status, etype, msg := anthropicErrorFor(ue)
+		writeAnthropicError(w, status, etype, msg)
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	sink := &httpSSE{w: w, flusher: w.(http.Flusher)}
+	conv := newStreamConverter(sink, areq.Model)
+	// Convert already emitted the client-visible terminal event (a clean
+	// message_stop, or an error event on a failed-upstream / read-error stream),
+	// so its returned error needs no further handling on the wire.
+	_ = conv.Convert(resp.Body)
+}
+
+// httpSSE writes Anthropic SSE events to the response and flushes each one.
+type httpSSE struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+}
+
+func (h *httpSSE) event(name string, data any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(h.w, "event: %s\ndata: %s\n\n", name, b); err != nil {
+		return err
+	}
+	h.flusher.Flush()
+	return nil
+}
+
+// anthropicErrorFor maps a classified upstream failure to an Anthropic error
+// (status, type, message). The status is what vendorclass / the claude client see.
+func anthropicErrorFor(ue *upstreamError) (int, string, string) {
+	if ue == nil {
+		return http.StatusBadGateway, "api_error", "codex upstream error"
+	}
+	switch ue.kind {
+	case upQuota:
+		return http.StatusTooManyRequests, "rate_limit_error", ue.message
+	case upCloudflare:
+		return http.StatusForbidden, "api_error", ue.message
+	case upAuth:
+		return http.StatusUnauthorized, "authentication_error", ue.message
+	case upTransient:
+		return http.StatusBadGateway, "api_error", ue.message
+	default:
+		return http.StatusBadRequest, "invalid_request_error", ue.message
+	}
+}
+
+func writeAnthropicError(w http.ResponseWriter, status int, etype, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":  "error",
+		"error": map[string]any{"type": etype, "message": message},
+	})
+}

--- a/internal/codexproxy/server_test.go
+++ b/internal/codexproxy/server_test.go
@@ -1,0 +1,152 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/procintrospect"
+)
+
+// stubUpstream records the apiKey handed to call and emits a single terminal
+// event, so a handler test can assert auth + key forwarding without a backend.
+type stubUpstream struct {
+	mu     sync.Mutex
+	gotKey string
+}
+
+func (s *stubUpstream) call(_ context.Context, _ *anthropicRequest, apiKey string) (io.ReadCloser, error) {
+	s.mu.Lock()
+	s.gotKey = apiKey
+	s.mu.Unlock()
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (s *stubUpstream) convert(_ io.Reader, sink sseSink, _, _ string) error {
+	return sink.event("message_stop", map[string]any{"type": "message_stop"})
+}
+
+func (s *stubUpstream) models() []string { return []string{"stub-1"} }
+
+func postMessages(t *testing.T, base, key string) int {
+	t.Helper()
+	body := `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, base+"/v1/messages", strings.NewReader(body))
+	if key != "" {
+		req.Header.Set("x-api-key", key)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+// codex gates on the handshake secret and uses no upstream key; openai-* forwards
+// the presented real key (b1) and rejects an empty one.
+func TestServerAuthPerProtocol(t *testing.T) {
+	cu := &stubUpstream{}
+	codex := httptest.NewServer(newServer(cu, config.ProtocolCodexOAuth, "secret").handler())
+	defer codex.Close()
+	if got := postMessages(t, codex.URL, "wrong"); got != http.StatusUnauthorized {
+		t.Fatalf("codex wrong handshake = %d, want 401", got)
+	}
+	if got := postMessages(t, codex.URL, "secret"); got != http.StatusOK {
+		t.Fatalf("codex right handshake = %d, want 200", got)
+	}
+	if cu.gotKey != "" {
+		t.Fatalf("codex must not forward an upstream key, got %q", cu.gotKey)
+	}
+
+	ou := &stubUpstream{}
+	openai := httptest.NewServer(newServer(ou, config.ProtocolOpenAIChat, "").handler())
+	defer openai.Close()
+	if got := postMessages(t, openai.URL, ""); got != http.StatusUnauthorized {
+		t.Fatalf("openai empty key = %d, want 401", got)
+	}
+	if got := postMessages(t, openai.URL, "sk-real"); got != http.StatusOK {
+		t.Fatalf("openai real key = %d, want 200", got)
+	}
+	if ou.gotKey != "sk-real" {
+		t.Fatalf("openai must forward the real key (b1), got %q", ou.gotKey)
+	}
+}
+
+func TestServerHealthzAndModels(t *testing.T) {
+	s := httptest.NewServer(newServer(&stubUpstream{}, config.ProtocolCodexOAuth, "secret").handler())
+	defer s.Close()
+
+	r, err := http.Get(s.URL + "/healthz")
+	if err != nil || r.StatusCode != http.StatusOK {
+		t.Fatalf("/healthz = %v / %d", err, r.StatusCode)
+	}
+	r.Body.Close()
+
+	r, err = http.Get(s.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+	var doc struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if json.NewDecoder(r.Body).Decode(&doc) != nil || len(doc.Data) != 1 || doc.Data[0].ID != "stub-1" {
+		t.Fatalf("/v1/models = %+v", doc)
+	}
+}
+
+// A live daemon is reused only when its persisted identity matches the requested
+// (protocol, upstream_url); a mismatch is not reused.
+func TestHealthyReusesOnlyOnIdentityMatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	hs := &http.Server{Handler: mux}
+	go hs.Serve(ln)
+	defer hs.Close()
+	for i := 0; i < 50 && !portResponds(port); i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	dir, err := config.ConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	start, _ := procintrospect.ProcStart(os.Getpid())
+	if err := writeState(proxyState{Port: port, PID: os.Getpid(), ProcStart: start, Protocol: config.ProtocolCodexOAuth}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !healthy(port, config.ProtocolCodexOAuth, "") {
+		t.Fatal("matching identity must be reused")
+	}
+	if healthy(port, config.ProtocolOpenAIChat, "") {
+		t.Fatal("a different protocol must not be reused")
+	}
+	if healthy(port, config.ProtocolCodexOAuth, "https://api.openai.com/v1") {
+		t.Fatal("a different upstream_url must not be reused")
+	}
+}

--- a/internal/codexproxy/stream.go
+++ b/internal/codexproxy/stream.go
@@ -1,0 +1,352 @@
+package codexproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// sseSink writes Anthropic SSE events and flushes each one.
+type sseSink interface {
+	event(name string, data any) error
+}
+
+// blockKind is the Anthropic content-block type a Responses output item maps to.
+type blockKind int
+
+const (
+	blockText blockKind = iota
+	blockToolUse
+	blockThinking
+)
+
+type blockState struct {
+	index int
+	kind  blockKind
+	open  bool
+}
+
+// streamConverter turns a Responses SSE stream into a valid Anthropic Messages SSE
+// stream. A clean stream is message_start -> per-block start/delta/stop ->
+// message_delta -> message_stop, with idempotent guards so a block is never left
+// open (Claude Code hangs on a dangling block). A failed upstream event or a
+// transport read error instead ends on an Anthropic error event (open blocks
+// closed first), never a clean message_stop.
+type streamConverter struct {
+	out   sseSink
+	model string
+
+	started         bool
+	failed          bool // an upstream failure was surfaced as an Anthropic error event
+	nextIndex       int
+	blocks          map[string]*blockState // keyed by Responses item id (or output_index)
+	stopReason      string
+	inTokens        int
+	outTokens       int
+	cacheReadTokens int
+}
+
+func newStreamConverter(out sseSink, model string) *streamConverter {
+	return &streamConverter{out: out, model: model, blocks: map[string]*blockState{}, stopReason: "end_turn"}
+}
+
+// responsesEvent is the union of Responses streaming event fields we read.
+type responsesEvent struct {
+	Type        string          `json:"type"`
+	OutputIndex *int            `json:"output_index"`
+	ItemID      string          `json:"item_id"`
+	Item        *responsesItem  `json:"item"`
+	Delta       string          `json:"delta"`
+	Response    json.RawMessage `json:"response"`
+	Error       *responsesError `json:"error"`
+}
+
+type responsesItem struct {
+	ID               string `json:"id"`
+	Type             string `json:"type"` // message | function_call | reasoning
+	Name             string `json:"name"`
+	CallID           string `json:"call_id"`
+	EncryptedContent string `json:"encrypted_content"`
+}
+
+type responsesError struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+// Convert reads the upstream SSE body to completion, emitting Anthropic SSE. A
+// clean end-of-stream — including a body that stopped early without a
+// done/completed event but WITH no read error — closes open blocks and emits
+// message_delta + message_stop. A response.failed/error event (see failStream) or
+// a transport read error mid-stream instead emits an Anthropic error event, so a
+// transport failure is never handed to Claude as a successful answer.
+func (c *streamConverter) Convert(body io.Reader) error {
+	if err := c.ensureStarted(); err != nil {
+		return err
+	}
+
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var ev responsesEvent
+		if json.Unmarshal([]byte(payload), &ev) != nil {
+			continue
+		}
+		if err := c.handle(&ev); err != nil {
+			return err
+		}
+	}
+	if err := sc.Err(); err != nil {
+		_ = c.emitError("codex upstream stream read error")
+		return err
+	}
+	c.finish()
+	return nil
+}
+
+func (c *streamConverter) key(ev *responsesEvent) string {
+	if ev.ItemID != "" {
+		return ev.ItemID
+	}
+	if ev.Item != nil && ev.Item.ID != "" {
+		return ev.Item.ID
+	}
+	if ev.OutputIndex != nil {
+		return "idx-" + strconv.Itoa(*ev.OutputIndex)
+	}
+	return ""
+}
+
+func (c *streamConverter) handle(ev *responsesEvent) error {
+	switch {
+	case ev.Type == "response.output_item.added" && ev.Item != nil:
+		return c.openBlock(ev)
+	case ev.Type == "response.output_text.delta":
+		return c.blockDelta(ev, "text_delta", "text", ev.Delta)
+	case ev.Type == "response.function_call_arguments.delta":
+		return c.blockDelta(ev, "input_json_delta", "partial_json", ev.Delta)
+	case ev.Type == "response.reasoning_summary_text.delta":
+		return c.blockDelta(ev, "thinking_delta", "thinking", ev.Delta)
+	case ev.Type == "response.output_item.done":
+		return c.finishItem(ev)
+	case ev.Type == "response.completed" || ev.Type == "response.done" || ev.Type == "response.incomplete":
+		c.readUsageAndStop(ev.Response)
+	case ev.Type == "response.failed" || ev.Type == "error":
+		return c.failStream(ev)
+	}
+	return nil
+}
+
+// finishItem closes a finished output item's block. A reasoning item's
+// encrypted_content is emitted first as the thinking block's signature_delta —
+// claude hands it back as the block's signature on the next turn, which is how
+// reasoning context survives a stateless (store:false) conversation.
+func (c *streamConverter) finishItem(ev *responsesEvent) error {
+	key := c.key(ev)
+	if bs := c.blocks[key]; bs != nil && bs.open && bs.kind == blockThinking &&
+		ev.Item != nil && ev.Item.EncryptedContent != "" {
+		if err := c.out.event("content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": bs.index,
+			"delta": map[string]any{"type": "signature_delta", "signature": ev.Item.EncryptedContent},
+		}); err != nil {
+			return err
+		}
+	}
+	return c.closeBlock(key)
+}
+
+// failStream surfaces an upstream mid-stream failure as an Anthropic error
+// event: open blocks are closed, the error event is emitted, and finish()
+// skips the normal message_delta/message_stop (the turn did not complete — a
+// clean stop here would make a failed answer look like a short success).
+func (c *streamConverter) failStream(ev *responsesEvent) error {
+	msg := "codex upstream stream failed"
+	rerr := ev.Error
+	if rerr == nil && len(ev.Response) > 0 {
+		var r struct {
+			Error *responsesError `json:"error"`
+		}
+		if json.Unmarshal(ev.Response, &r) == nil {
+			rerr = r.Error
+		}
+	}
+	if rerr != nil && rerr.Message != "" {
+		msg = "codex upstream: " + rerr.Message
+	}
+	return c.emitError(msg)
+}
+
+// emitError closes any open block and emits an Anthropic error event, marking the
+// stream failed so finish() skips the normal message_delta/message_stop.
+func (c *streamConverter) emitError(msg string) error {
+	if err := c.closeAllOpen(); err != nil {
+		return err
+	}
+	c.failed = true
+	return c.out.event("error", map[string]any{
+		"type": "error", "error": map[string]any{"type": "api_error", "message": msg},
+	})
+}
+
+func (c *streamConverter) openBlock(ev *responsesEvent) error {
+	key := c.key(ev)
+	if key == "" || c.blocks[key] != nil {
+		return nil
+	}
+	var (
+		kind blockKind
+		cb   map[string]any
+	)
+	switch ev.Item.Type {
+	case "function_call":
+		kind = blockToolUse
+		c.stopReason = "tool_use"
+		cb = map[string]any{"type": "tool_use", "id": ev.Item.CallID, "name": ev.Item.Name, "input": map[string]any{}}
+	case "reasoning":
+		kind = blockThinking
+		cb = map[string]any{"type": "thinking", "thinking": "", "signature": ""}
+	case "message":
+		kind = blockText
+		cb = map[string]any{"type": "text", "text": ""}
+	default:
+		return nil // unknown item type: no block
+	}
+	bs := &blockState{index: c.nextIndex, kind: kind, open: true}
+	c.nextIndex++
+	c.blocks[key] = bs
+	return c.out.event("content_block_start", map[string]any{
+		"type": "content_block_start", "index": bs.index, "content_block": cb,
+	})
+}
+
+// blockDelta routes a Responses delta to its Anthropic block, lazily opening a text
+// block if the upstream emitted text deltas without an explicit item.added (defensive).
+func (c *streamConverter) blockDelta(ev *responsesEvent, deltaType, field, val string) error {
+	key := c.key(ev)
+	bs := c.blocks[key]
+	if bs == nil {
+		bs = &blockState{index: c.nextIndex, kind: blockText, open: true}
+		c.nextIndex++
+		c.blocks[key] = bs
+		if err := c.out.event("content_block_start", map[string]any{
+			"type": "content_block_start", "index": bs.index, "content_block": map[string]any{"type": "text", "text": ""},
+		}); err != nil {
+			return err
+		}
+	}
+	if val == "" {
+		return nil
+	}
+	return c.out.event("content_block_delta", map[string]any{
+		"type": "content_block_delta", "index": bs.index,
+		"delta": map[string]any{"type": deltaType, field: val},
+	})
+}
+
+func (c *streamConverter) closeBlock(key string) error {
+	bs := c.blocks[key]
+	if bs == nil || !bs.open {
+		return nil
+	}
+	bs.open = false
+	return c.out.event("content_block_stop", map[string]any{"type": "content_block_stop", "index": bs.index})
+}
+
+func (c *streamConverter) ensureStarted() error {
+	if c.started {
+		return nil
+	}
+	c.started = true
+	return c.out.event("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg_codexproxy", "type": "message", "role": "assistant", "model": c.model,
+			"content": []any{}, "stop_reason": nil, "stop_sequence": nil,
+			"usage": map[string]any{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+}
+
+// finish closes any still-open block and emits message_delta + message_stop. Safe to
+// call once; guarded by started so a failure before message_start emits nothing, and
+// by failed so an errored stream ends on its error event, not a clean stop.
+func (c *streamConverter) finish() {
+	if !c.started || c.failed {
+		return
+	}
+	_ = c.closeAllOpen()
+	_ = c.out.event("message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": c.stopReason, "stop_sequence": nil},
+		"usage": map[string]any{
+			"input_tokens":            c.inTokens,
+			"output_tokens":           c.outTokens,
+			"cache_read_input_tokens": c.cacheReadTokens,
+		},
+	})
+	_ = c.out.event("message_stop", map[string]any{"type": "message_stop"})
+}
+
+// closeAllOpen emits content_block_stop for every still-open block.
+func (c *streamConverter) closeAllOpen() error {
+	for _, bs := range c.blocks {
+		if bs.open {
+			bs.open = false
+			if err := c.out.event("content_block_stop", map[string]any{"type": "content_block_stop", "index": bs.index}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// readUsageAndStop pulls usage + a terminal status from a response.completed/
+// done/incomplete envelope and maps the status to an Anthropic stop_reason
+// (unless a tool_use block already set it). OpenAI input_tokens INCLUDES the
+// cached prefix while Anthropic's excludes cache reads, so the cached count is
+// subtracted out and reported as cache_read_input_tokens.
+func (c *streamConverter) readUsageAndStop(raw json.RawMessage) {
+	var r struct {
+		Status string `json:"status"`
+		Usage  struct {
+			InputTokens        int `json:"input_tokens"`
+			OutputTokens       int `json:"output_tokens"`
+			InputTokensDetails struct {
+				CachedTokens int `json:"cached_tokens"`
+			} `json:"input_tokens_details"`
+		} `json:"usage"`
+	}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &r)
+	}
+	if r.Usage.InputTokens > 0 {
+		cached := r.Usage.InputTokensDetails.CachedTokens
+		if cached < 0 || cached > r.Usage.InputTokens {
+			cached = 0
+		}
+		c.inTokens = r.Usage.InputTokens - cached
+		c.cacheReadTokens = cached
+	}
+	if r.Usage.OutputTokens > 0 {
+		c.outTokens = r.Usage.OutputTokens
+	}
+	if c.stopReason == "tool_use" {
+		return
+	}
+	switch r.Status {
+	case "incomplete":
+		c.stopReason = "max_tokens"
+	default:
+		c.stopReason = "end_turn"
+	}
+}

--- a/internal/codexproxy/stream.go
+++ b/internal/codexproxy/stream.go
@@ -37,6 +37,10 @@ type blockState struct {
 type streamConverter struct {
 	out   sseSink
 	model string
+	// redact masks a streaming error message before it reaches the client (set by
+	// the openai-responses upstream to scrub an echoed key); nil for codex, whose
+	// upstream error messages are canonical.
+	redact func(string) string
 
 	started         bool
 	failed          bool // an upstream failure was surfaced as an Anthropic error event
@@ -135,8 +139,13 @@ func (c *streamConverter) handle(ev *responsesEvent) error {
 		return c.blockDelta(ev, "text_delta", "text", ev.Delta)
 	case ev.Type == "response.function_call_arguments.delta":
 		return c.blockDelta(ev, "input_json_delta", "partial_json", ev.Delta)
-	case ev.Type == "response.reasoning_summary_text.delta":
+	case ev.Type == "response.reasoning_summary_text.delta" || ev.Type == "response.reasoning_text.delta":
+		// Some models stream reasoning as reasoning_text.* rather than the summary
+		// variant; both map to the thinking block.
 		return c.blockDelta(ev, "thinking_delta", "thinking", ev.Delta)
+	case ev.Type == "response.refusal.delta":
+		// A refusal is visible model output — surface it as text, never drop it.
+		return c.blockDelta(ev, "text_delta", "text", ev.Delta)
 	case ev.Type == "response.output_item.done":
 		return c.finishItem(ev)
 	case ev.Type == "response.completed" || ev.Type == "response.done" || ev.Type == "response.incomplete":
@@ -193,6 +202,9 @@ func (c *streamConverter) emitError(msg string) error {
 		return err
 	}
 	c.failed = true
+	if c.redact != nil {
+		msg = c.redact(msg)
+	}
 	return c.out.event("error", map[string]any{
 		"type": "error", "error": map[string]any{"type": "api_error", "message": msg},
 	})

--- a/internal/codexproxy/stream_test.go
+++ b/internal/codexproxy/stream_test.go
@@ -1,0 +1,181 @@
+package codexproxy
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// recSink records emitted Anthropic events (names + payloads) for assertions.
+type recSink struct {
+	events   []string
+	payloads []any
+}
+
+func (r *recSink) event(name string, data any) error {
+	r.events = append(r.events, name)
+	r.payloads = append(r.payloads, data)
+	return nil
+}
+
+func (r *recSink) seq() string { return strings.Join(r.events, ",") }
+
+// payload returns the i-th payload (0 = first) of the named event, or nil.
+func (r *recSink) payload(name string, i int) map[string]any {
+	for j, n := range r.events {
+		if n != name {
+			continue
+		}
+		if i == 0 {
+			m, _ := r.payloads[j].(map[string]any)
+			return m
+		}
+		i--
+	}
+	return nil
+}
+
+func runConvert(t *testing.T, sse string) *recSink {
+	t.Helper()
+	sink := &recSink{}
+	c := newStreamConverter(sink, "gpt-5.5")
+	if err := c.Convert(strings.NewReader(sse)); err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	return sink
+}
+
+func TestConvert_TextStreamGrammar(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"r1"}}`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"m1","type":"message"}}`,
+		`data: {"type":"response.output_text.delta","item_id":"m1","delta":"pong"}`,
+		`data: {"type":"response.output_item.done","item_id":"m1"}`,
+		`data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":1}}}`,
+		`data: [DONE]`,
+	}, "\n\n") + "\n\n"
+	got := runConvert(t, sse).seq()
+	want := "message_start,content_block_start,content_block_delta,content_block_stop,message_delta,message_stop"
+	if got != want {
+		t.Fatalf("event sequence:\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestConvert_ToolCallStreamsArgsAndSetsStopReason(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"f1","type":"function_call","call_id":"toolu_1","name":"grep"}}`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"f1","delta":"{\"q\":"}`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"f1","delta":"\"x\"}"}`,
+		`data: {"type":"response.output_item.done","item_id":"f1"}`,
+		`data: {"type":"response.completed","response":{"status":"completed"}}`,
+	}, "\n\n") + "\n\n"
+	sink := runConvert(t, sse)
+	if got := sink.seq(); got != "message_start,content_block_start,content_block_delta,content_block_delta,content_block_stop,message_delta,message_stop" {
+		t.Fatalf("tool-call sequence: %s", got)
+	}
+}
+
+func TestConvert_AlwaysClosesOnTruncatedStream(t *testing.T) {
+	// An open block with no done/completed must still close + emit message_stop.
+	sse := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"m1","type":"message"}}`,
+		`data: {"type":"response.output_text.delta","item_id":"m1","delta":"partial"}`,
+	}, "\n\n") + "\n\n"
+	got := runConvert(t, sse).seq()
+	if !strings.HasSuffix(got, "content_block_stop,message_delta,message_stop") {
+		t.Fatalf("truncated stream did not close cleanly: %s", got)
+	}
+}
+
+func TestConvert_EmptyStreamStillEndsTurn(t *testing.T) {
+	got := runConvert(t, "").seq()
+	if got != "message_start,message_delta,message_stop" {
+		t.Fatalf("empty stream: %s", got)
+	}
+}
+
+func TestConvert_ThinkingSignatureFromEncryptedContent(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs1","type":"reasoning"}}`,
+		`data: {"type":"response.reasoning_summary_text.delta","item_id":"rs1","delta":"thinking..."}`,
+		`data: {"type":"response.output_item.done","item_id":"rs1","item":{"id":"rs1","type":"reasoning","encrypted_content":"gAAAAA-enc"}}`,
+		`data: {"type":"response.completed","response":{"status":"completed"}}`,
+	}, "\n\n") + "\n\n"
+	sink := runConvert(t, sse)
+	want := "message_start,content_block_start,content_block_delta,content_block_delta,content_block_stop,message_delta,message_stop"
+	if got := sink.seq(); got != want {
+		t.Fatalf("thinking sequence:\n got=%s\nwant=%s", got, want)
+	}
+	// The second content_block_delta is the signature carrying encrypted_content.
+	sig := sink.payload("content_block_delta", 1)
+	delta, _ := sig["delta"].(map[string]any)
+	if delta["type"] != "signature_delta" || delta["signature"] != "gAAAAA-enc" {
+		t.Fatalf("signature delta = %v", delta)
+	}
+}
+
+func TestConvert_FailedStreamEmitsErrorNotCleanStop(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"m1","type":"message"}}`,
+		`data: {"type":"response.output_text.delta","item_id":"m1","delta":"par"}`,
+		`data: {"type":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"upstream exploded"}}}`,
+	}, "\n\n") + "\n\n"
+	sink := runConvert(t, sse)
+	want := "message_start,content_block_start,content_block_delta,content_block_stop,error"
+	if got := sink.seq(); got != want {
+		t.Fatalf("failed-stream sequence:\n got=%s\nwant=%s", got, want)
+	}
+	p := sink.payload("error", 0)
+	inner, _ := p["error"].(map[string]any)
+	msg, _ := inner["message"].(string)
+	if !strings.Contains(msg, "upstream exploded") {
+		t.Fatalf("error message = %q", msg)
+	}
+}
+
+// errAfterReader yields data once, then a non-EOF error — a mid-stream transport
+// failure. The converter must surface an Anthropic error event, not a clean stop.
+type errAfterReader struct {
+	data string
+	done bool
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if !r.done {
+		r.done = true
+		return copy(p, r.data), nil
+	}
+	return 0, io.ErrUnexpectedEOF
+}
+
+func TestConvert_ReadErrorEmitsErrorNotCleanStop(t *testing.T) {
+	data := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"m1","type":"message"}}`,
+		`data: {"type":"response.output_text.delta","item_id":"m1","delta":"par"}`,
+		"", // ensure the last data line is newline-terminated for the scanner
+	}, "\n\n")
+	sink := &recSink{}
+	c := newStreamConverter(sink, "gpt-5.5")
+	err := c.Convert(&errAfterReader{data: data})
+	if err == nil {
+		t.Fatal("Convert must return the read error, not swallow it")
+	}
+	if last := sink.events[len(sink.events)-1]; last != "error" {
+		t.Fatalf("a read error must end on an error event, got seq: %s", sink.seq())
+	}
+	for _, e := range sink.events {
+		if e == "message_stop" {
+			t.Fatalf("a read error must NOT emit a clean message_stop: %s", sink.seq())
+		}
+	}
+}
+
+func TestConvert_UsageSplitsCachedTokens(t *testing.T) {
+	sse := `data: {"type":"response.completed","response":{"status":"completed",` +
+		`"usage":{"input_tokens":100,"output_tokens":7,"input_tokens_details":{"cached_tokens":60}}}}` + "\n\n"
+	sink := runConvert(t, sse)
+	usage, _ := sink.payload("message_delta", 0)["usage"].(map[string]any)
+	if usage["input_tokens"] != 40 || usage["cache_read_input_tokens"] != 60 || usage["output_tokens"] != 7 {
+		t.Fatalf("usage = %v", usage)
+	}
+}

--- a/internal/codexproxy/testdata/chat_error.sse
+++ b/internal/codexproxy/testdata/chat_error.sse
@@ -1,0 +1,5 @@
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"part"},"finish_reason":null}]}
+
+data: {"error":{"message":"bad key sk-SECRET12345678 rejected","type":"invalid_request_error"}}
+
+data: [DONE]

--- a/internal/codexproxy/testdata/chat_length.sse
+++ b/internal/codexproxy/testdata/chat_length.sse
@@ -1,0 +1,5 @@
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"trunc"},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"length"}]}
+
+data: [DONE]

--- a/internal/codexproxy/testdata/chat_parallel.sse
+++ b/internal/codexproxy/testdata/chat_parallel.sse
@@ -1,0 +1,9 @@
+data: {"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"f0","arguments":"{}"}}]}}]}
+
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"f1","arguments":"{}"}}]}}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]

--- a/internal/codexproxy/testdata/chat_text.sse
+++ b/internal/codexproxy/testdata/chat_text.sse
@@ -1,0 +1,9 @@
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"content":"pong"},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":3}}
+
+data: [DONE]

--- a/internal/codexproxy/testdata/chat_tool.sse
+++ b/internal/codexproxy/testdata/chat_tool.sse
@@ -1,0 +1,13 @@
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":""}}]},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"key\":"}}]},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"alpha\"}"}}]},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"choices":[],"usage":{"prompt_tokens":20,"completion_tokens":8}}
+
+data: [DONE]

--- a/internal/codexproxy/testdata/forced_tool.sse
+++ b/internal/codexproxy/testdata/forced_tool.sse
@@ -1,0 +1,33 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_fixture01","object":"response","created_at":1780885304,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Use the lookup tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":"Look up a key","name":"lookup","parameters":{"type":"object","properties":{"key":{"type":"string"}},"required":["key"],"additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_fixture01","object":"response","created_at":1780885304,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Use the lookup tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":"Look up a key","name":"lookup","parameters":{"type":"object","properties":{"key":{"type":"string"}},"required":["key"],"additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"fc_fixture01","type":"function_call","status":"in_progress","arguments":"","call_id":"call_fixture01","name":"lookup"},"output_index":0,"sequence_number":2}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"{\"","item_id":"fc_fixture01","obfuscation":"YGWMwS7ha8MVAW","output_index":0,"sequence_number":3}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"key","item_id":"fc_fixture01","obfuscation":"5789aiJwy9PrV","output_index":0,"sequence_number":4}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_fixture01","obfuscation":"6mLbtUVk6PR9I","output_index":0,"sequence_number":5}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"alpha","item_id":"fc_fixture01","obfuscation":"d8LjpZ2Gsjz","output_index":0,"sequence_number":6}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\"}","item_id":"fc_fixture01","obfuscation":"V8QztXfGexRgMQ","output_index":0,"sequence_number":7}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","arguments":"{\"key\":\"alpha\"}","item_id":"fc_fixture01","output_index":0,"sequence_number":8}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"fc_fixture01","type":"function_call","status":"completed","arguments":"{\"key\":\"alpha\"}","call_id":"call_fixture01","name":"lookup"},"output_index":0,"sequence_number":9}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_fixture01","object":"response","created_at":1780885304,"status":"completed","background":false,"completed_at":1780885306,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Use the lookup tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":"Look up a key","name":"lookup","parameters":{"type":"object","properties":{"key":{"type":"string"}},"required":["key"],"additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":56,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":73},"user":null,"metadata":{}},"sequence_number":10}
+

--- a/internal/codexproxy/testdata/text.sse
+++ b/internal/codexproxy/testdata/text.sse
@@ -1,0 +1,27 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_fixture01","object":"response","created_at":1780885302,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are terse.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_fixture01","object":"response","created_at":1780885302,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are terse.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"msg_fixture01","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":2}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_fixture01","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"pong","item_id":"msg_fixture01","logprobs":[],"obfuscation":"KwYZN8JcH5T2","output_index":0,"sequence_number":4}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_fixture01","logprobs":[],"output_index":0,"sequence_number":5,"text":"pong"}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_fixture01","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"pong"},"sequence_number":6}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_fixture01","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"pong"}],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":7}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_fixture01","object":"response","created_at":1780885302,"status":"completed","background":false,"completed_at":1780885303,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are terse.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":19,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":24},"user":null,"metadata":{}},"sequence_number":8}
+

--- a/internal/codexproxy/testdata/thinking.sse
+++ b/internal/codexproxy/testdata/thinking.sse
@@ -1,0 +1,33 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_fixture01","object":"response","created_at":1780885307,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Think briefly, answer tersely.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_fixture01","object":"response","created_at":1780885307,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Think briefly, answer tersely.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"rs_fixture01","type":"reasoning","content":[],"encrypted_content":"gAAAAA-fixture-stub","summary":[]},"output_index":0,"sequence_number":2}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"rs_fixture01","type":"reasoning","content":[],"encrypted_content":"gAAAAA-fixture-stub","summary":[]},"output_index":0,"sequence_number":3}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"msg_fixture01","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":4}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_fixture01","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":5}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"391","item_id":"msg_fixture01","logprobs":[],"obfuscation":"EMwJUmqB1nNEo","output_index":1,"sequence_number":6}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_fixture01","logprobs":[],"output_index":1,"sequence_number":7,"text":"391"}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_fixture01","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"391"},"sequence_number":8}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_fixture01","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"391"}],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":9}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_fixture01","object":"response","created_at":1780885307,"status":"completed","background":false,"completed_at":1780885308,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Think briefly, answer tersely.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fixture-cache-key","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","summary":"detailed"},"safety_identifier":"user-fixture","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":30,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":12},"total_tokens":49},"user":null,"metadata":{}},"sequence_number":10}
+

--- a/internal/codexproxy/tokenstore.go
+++ b/internal/codexproxy/tokenstore.go
@@ -1,0 +1,199 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/fileutil"
+)
+
+// tokenStoreFile is cc-fleet's own credential store, independent of ~/.codex.
+const tokenStoreFile = "codex_oauth.json"
+
+// storeData is the on-disk shape (0600). The access token is NOT persisted — only
+// the durable refresh chain + account id.
+type storeData struct {
+	RefreshToken string `json:"refresh_token"`
+	AccountID    string `json:"account_id"`
+	IDToken      string `json:"id_token,omitempty"`
+}
+
+// bearer is a resolved upstream credential plus the generation it came from, so a
+// caller that sees a 401 can invalidate exactly that generation and force a refresh.
+type bearer struct {
+	accessToken string
+	accountID   string
+	generation  uint64
+}
+
+// tokenSource hands out a valid upstream bearer and refreshes as needed.
+type tokenSource interface {
+	// token returns a valid bearer, refreshing under its own lock if near expiry.
+	token(ctx context.Context) (bearer, error)
+	// invalidate forces the next token() to refresh if gen is still current.
+	invalidate(gen uint64)
+}
+
+// ownStore is the production source: an independent refresh chain persisted to
+// ~/.config/cc-fleet/codex_oauth.json. The cross-process token-store flock is
+// held only for read/refresh/persist — never across the Responses stream — so a
+// login process and the daemon's refresher cannot clobber each other's rotation
+// (the in-process mutex alone cannot serialize two processes).
+type ownStore struct {
+	path  string
+	oauth *oauthClient
+
+	mu       sync.Mutex
+	data     storeData
+	access   string
+	expiry   time.Time
+	gen      uint64
+	poisoned bool // a refresh succeeded but its rotated token failed to persist
+}
+
+func storePath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, tokenStoreFile), nil
+}
+
+// withTokenLock serializes token-store read/refresh/persist across processes.
+// Standalone — held with none of the other flock scopes, so no ordering cycle.
+func withTokenLock(fn func() error) error {
+	p, err := joinConfig(".cc-fleet-codex-token.lock")
+	if err != nil {
+		return err
+	}
+	return config.WithFlock(p, fn)
+}
+
+func newOwnStore() (*ownStore, error) {
+	p, err := storePath()
+	if err != nil {
+		return nil, err
+	}
+	s := &ownStore{path: p, oauth: newOAuthClient()}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *ownStore) load() error {
+	b, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil // not logged in yet; token() will return ErrReauth
+	}
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, &s.data)
+}
+
+// save persists the durable chain atomically at 0600.
+func (s *ownStore) save() error {
+	b, err := json.MarshalIndent(s.data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fileutil.AtomicWrite(s.path, b, 0o600)
+}
+
+// setLogin records a fresh chain from a completed device login and persists it
+// under the token lock (a concurrently-refreshing daemon must not interleave).
+func (s *ownStore) setLogin(tk *tokens) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := withTokenLock(func() error {
+		s.data = storeData{RefreshToken: tk.RefreshToken, AccountID: tk.AccountID, IDToken: tk.IDToken}
+		return s.save()
+	}); err != nil {
+		return err
+	}
+	s.access = tk.AccessToken
+	if exp, ok := tokenExpiry(tk.AccessToken); ok {
+		s.expiry = exp
+	}
+	s.poisoned = false
+	s.gen++
+	return nil
+}
+
+func (s *ownStore) token(ctx context.Context) (bearer, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.poisoned {
+		return bearer{}, ErrReauth
+	}
+	if s.access != "" && time.Now().Before(s.expiry.Add(-refreshSkew)) {
+		return bearer{s.access, s.data.AccountID, s.gen}, nil
+	}
+	if err := withTokenLock(func() error { return s.refreshLocked(ctx) }); err != nil {
+		return bearer{}, err
+	}
+	return bearer{s.access, s.data.AccountID, s.gen}, nil
+}
+
+// refreshLocked refreshes the access token. Runs under BOTH s.mu and the
+// cross-process token lock; the lock covers read→refresh→persist only (the
+// upstream Responses stream is never under it).
+func (s *ownStore) refreshLocked(ctx context.Context) error {
+	// Double-check from disk: another process (a login, a parallel refresher)
+	// may have rotated the chain since this store last read it — refreshing
+	// with the superseded token would trip OpenAI's reuse detection.
+	if err := s.load(); err != nil {
+		return err
+	}
+	if s.data.RefreshToken == "" {
+		return ErrReauth
+	}
+	tk, err := s.oauth.refresh(ctx, s.data.RefreshToken)
+	if err != nil {
+		return err
+	}
+	// Persist-before-use: the old refresh token is already invalidated server-side,
+	// so a persist failure means the only live chain is unsaved — poison and require
+	// re-login rather than serve a token whose refresh token we can't recover.
+	rotated := tk.RefreshToken != s.data.RefreshToken
+	s.data.RefreshToken = tk.RefreshToken
+	if tk.AccountID != "" {
+		s.data.AccountID = tk.AccountID
+	}
+	if tk.IDToken != "" {
+		s.data.IDToken = tk.IDToken
+	}
+	if rotated {
+		if err := s.save(); err != nil {
+			s.poisoned = true
+			return ErrReauth
+		}
+	}
+	s.access = tk.AccessToken
+	if exp, ok := tokenExpiry(tk.AccessToken); ok {
+		s.expiry = exp
+	}
+	s.gen++
+	return nil
+}
+
+func (s *ownStore) invalidate(gen uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if gen == s.gen {
+		s.expiry = time.Time{} // force a refresh on next token()
+	}
+}
+
+func (s *ownStore) loggedIn() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.data.RefreshToken != ""
+}

--- a/internal/codexproxy/tokenstore.go
+++ b/internal/codexproxy/tokenstore.go
@@ -80,7 +80,9 @@ func newOwnStore() (*ownStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	s := &ownStore{path: p, oauth: newOAuthClient()}
+	// gen starts at 1 so an own-chain bearer is never generation 0, which the
+	// cliRideStore reserves for its read-only CLI-ride token.
+	s := &ownStore{path: p, oauth: newOAuthClient(), gen: 1}
 	if err := s.load(); err != nil {
 		return nil, err
 	}

--- a/internal/codexproxy/tokenstore_test.go
+++ b/internal/codexproxy/tokenstore_test.go
@@ -1,0 +1,96 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// rewriteRT redirects every request to the test server, keeping the path.
+type rewriteRT struct{ target *url.URL }
+
+func (rt rewriteRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = rt.target.Scheme
+	req.URL.Host = rt.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// Two stores (simulating the login CLI and the daemon) sharing one on-disk
+// chain: the second refresh must reload the rotated token from disk under the
+// token lock — presenting the superseded one trips reuse detection (401).
+func TestOwnStore_RefreshReloadsRotatedChainFromDisk(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	var mu sync.Mutex
+	valid := map[string]bool{"rt-0": true}
+	n := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		rt := r.PostFormValue("refresh_token")
+		mu.Lock()
+		defer mu.Unlock()
+		if !valid[rt] {
+			w.WriteHeader(http.StatusUnauthorized) // reuse detection
+			return
+		}
+		delete(valid, rt)
+		n++
+		next := fmt.Sprintf("rt-%d", n)
+		valid[next] = true
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  fakeJWT(map[string]any{"exp": float64(time.Now().Add(time.Hour).Unix())}),
+			"refresh_token": next,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	target, _ := url.Parse(srv.URL)
+
+	p, err := storePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"refresh_token":"rt-0","account_id":"acc"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mk := func() *ownStore {
+		s, err := newOwnStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.oauth = &oauthClient{http: &http.Client{Transport: rewriteRT{target}}}
+		return s
+	}
+	a, b := mk(), mk() // both loaded rt-0 into memory
+
+	if _, err := a.token(context.Background()); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	// b still holds rt-0 in memory; without the on-disk double-check this
+	// presents a consumed token and dies with ErrReauth.
+	if _, err := b.token(context.Background()); err != nil {
+		t.Fatalf("second store's refresh must reload the rotated chain: %v", err)
+	}
+
+	disk, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(disk), "rt-2") {
+		t.Fatalf("disk chain not at the latest rotation: %s", disk)
+	}
+}

--- a/internal/codexproxy/translate.go
+++ b/internal/codexproxy/translate.go
@@ -1,0 +1,311 @@
+package codexproxy
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// anthropicRequest is the subset of the Anthropic Messages request that the claude
+// CLI sends; unknown fields are ignored.
+type anthropicRequest struct {
+	Model      string             `json:"model"`
+	MaxTokens  int                `json:"max_tokens"`
+	System     json.RawMessage    `json:"system"` // string OR []{type:text,text}
+	Messages   []anthropicMessage `json:"messages"`
+	Tools      []anthropicTool    `json:"tools"`
+	ToolChoice json.RawMessage    `json:"tool_choice"` // {type:auto|any|tool,name,disable_parallel_tool_use}
+	Stream     bool               `json:"stream"`
+	Thinking   *anthropicThinking `json:"thinking"`
+	Metadata   struct {
+		UserID string `json:"user_id"`
+	} `json:"metadata"`
+}
+
+type anthropicThinking struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens"`
+}
+
+type anthropicMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string OR []block
+}
+
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type contentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`          // tool_use id
+	Name      string          `json:"name"`        // tool_use name
+	Input     json.RawMessage `json:"input"`       // tool_use input
+	ToolUseID string          `json:"tool_use_id"` // tool_result -> the tool_use id
+	Content   json.RawMessage `json:"content"`     // tool_result content (string OR []block)
+	Source    *imageSource    `json:"source"`      // image
+	Thinking  string          `json:"thinking"`    // thinking block text
+	Signature string          `json:"signature"`   // thinking block signature = the replayed encrypted_content
+}
+
+type imageSource struct {
+	Type      string `json:"type"` // base64 | url
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+	URL       string `json:"url"`
+}
+
+// responsesRequest is the OpenAI Responses body sent to the ChatGPT backend.
+type responsesRequest struct {
+	Model             string          `json:"model"`
+	Instructions      string          `json:"instructions,omitempty"`
+	Input             []any           `json:"input"`
+	Tools             []responsesTool `json:"tools,omitempty"`
+	ToolChoice        any             `json:"tool_choice,omitempty"`
+	ParallelToolCalls bool            `json:"parallel_tool_calls"`
+	Reasoning         *reasoningOpt   `json:"reasoning,omitempty"`
+	Include           []string        `json:"include,omitempty"`
+	Store             bool            `json:"store"`
+	Stream            bool            `json:"stream"`
+	PromptCacheKey    string          `json:"prompt_cache_key,omitempty"`
+}
+
+type reasoningOpt struct {
+	Effort  string `json:"effort"`
+	Summary string `json:"summary"`
+}
+
+type responsesTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// translateRequest maps an Anthropic Messages request to a Responses request.
+// max_tokens and temperature are intentionally omitted (the ChatGPT backend 400s
+// on them). store is forced false. The claude session id inside metadata.user_id
+// becomes prompt_cache_key so the backend's prompt cache follows the conversation.
+func translateRequest(a *anthropicRequest) (*responsesRequest, error) {
+	choice, parallel := translateToolChoice(a.ToolChoice)
+	r := &responsesRequest{
+		Model:             a.Model,
+		Instructions:      systemText(a.System),
+		Store:             false,
+		Stream:            true,
+		ToolChoice:        choice,
+		ParallelToolCalls: parallel,
+		PromptCacheKey:    a.Metadata.UserID,
+	}
+	for _, m := range a.Messages {
+		items, err := translateMessage(m)
+		if err != nil {
+			return nil, err
+		}
+		r.Input = append(r.Input, items...)
+	}
+	for _, t := range a.Tools {
+		r.Tools = append(r.Tools, responsesTool{
+			Type: "function", Name: t.Name, Description: t.Description, Parameters: t.InputSchema,
+		})
+	}
+	// "enabled" carries a budget; "adaptive" (claude's default-on mode) has none
+	// and lands in the low bucket. Either way the model reasons — requesting the
+	// summary + encrypted_content keeps that reasoning replayable across turns.
+	if a.Thinking != nil && (a.Thinking.Type == "enabled" || a.Thinking.Type == "adaptive") {
+		r.Reasoning = &reasoningOpt{Effort: effortBucket(a.Thinking.BudgetTokens), Summary: "auto"}
+		r.Include = []string{"reasoning.encrypted_content"}
+	}
+	return r, nil
+}
+
+// systemText flattens the Anthropic system field (string OR []{type:text,text})
+// to the Responses instructions string.
+func systemText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []contentBlock
+	if json.Unmarshal(raw, &blocks) == nil {
+		out := ""
+		for _, b := range blocks {
+			if b.Type == "text" {
+				if out != "" {
+					out += "\n"
+				}
+				out += b.Text
+			}
+		}
+		return out
+	}
+	return ""
+}
+
+// translateToolChoice maps Anthropic tool_choice to the Responses form plus the
+// parallel-tool-calls flag. auto->auto, any->required, {type:tool,name}->
+// {type:function,name}; nil/absent -> auto. It is NOT hard-forced to auto (that
+// would break forced-tool / StructuredOutput paths). disable_parallel_tool_use
+// flips parallel_tool_calls off.
+func translateToolChoice(raw json.RawMessage) (choice any, parallel bool) {
+	if len(raw) == 0 {
+		return "auto", true
+	}
+	var tc struct {
+		Type                   string `json:"type"`
+		Name                   string `json:"name"`
+		DisableParallelToolUse bool   `json:"disable_parallel_tool_use"`
+	}
+	if json.Unmarshal(raw, &tc) != nil {
+		return "auto", true
+	}
+	parallel = !tc.DisableParallelToolUse
+	switch tc.Type {
+	case "any":
+		return "required", parallel
+	case "tool":
+		return map[string]any{"type": "function", "name": tc.Name}, parallel
+	default:
+		return "auto", parallel
+	}
+}
+
+// effortBucket maps an Anthropic thinking budget to a Responses reasoning effort.
+func effortBucket(budget int) string {
+	switch {
+	case budget <= 0:
+		return "low"
+	case budget <= 8192:
+		return "medium"
+	default:
+		return "high"
+	}
+}
+
+// translateMessage maps one Anthropic message to one or more Responses input items.
+func translateMessage(m anthropicMessage) ([]any, error) {
+	// claude -p sends mid-conversation system-role messages (e.g. the skills
+	// listing); the codex backend rejects role "system" in input, so they ride
+	// as "developer" (same authority tier in the Responses role hierarchy).
+	role := m.Role
+	if role == "system" {
+		role = "developer"
+	}
+	// string content -> a single text message
+	var s string
+	if json.Unmarshal(m.Content, &s) == nil {
+		return []any{textMessage(role, s)}, nil
+	}
+	var blocks []contentBlock
+	if err := json.Unmarshal(m.Content, &blocks); err != nil {
+		return nil, fmt.Errorf("message content: %w", err)
+	}
+	var items []any
+	var textParts []map[string]any
+	flushText := func() {
+		if len(textParts) > 0 {
+			items = append(items, map[string]any{"type": "message", "role": role, "content": textParts})
+			textParts = nil
+		}
+	}
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			textParts = append(textParts, map[string]any{"type": textKind(role), "text": b.Text})
+		case "image":
+			if url := imageDataURL(b.Source); url != "" {
+				textParts = append(textParts, map[string]any{"type": "input_image", "image_url": url})
+			}
+		case "thinking":
+			// Reasoning continuity: the block's signature carries the Responses
+			// encrypted_content the stream converter emitted; replay it as a
+			// reasoning item WITHOUT an id (store:false rejects replayed ids).
+			// A signature-less thinking block has nothing replayable — skip it.
+			if b.Signature == "" {
+				continue
+			}
+			flushText()
+			summary := []map[string]any{}
+			if b.Thinking != "" {
+				summary = append(summary, map[string]any{"type": "summary_text", "text": b.Thinking})
+			}
+			items = append(items, map[string]any{
+				"type": "reasoning", "summary": summary, "encrypted_content": b.Signature,
+			})
+		case "tool_use":
+			flushText()
+			items = append(items, map[string]any{
+				"type": "function_call", "call_id": b.ID, "name": b.Name,
+				"arguments": string(rawOrEmptyObject(b.Input)),
+			})
+		case "tool_result":
+			flushText()
+			items = append(items, map[string]any{
+				"type": "function_call_output", "call_id": b.ToolUseID, "output": toolResultText(b.Content),
+			})
+		}
+	}
+	flushText()
+	return items, nil
+}
+
+func textMessage(role, text string) map[string]any {
+	return map[string]any{"type": "message", "role": role,
+		"content": []map[string]any{{"type": textKind(role), "text": text}}}
+}
+
+// textKind picks the Responses content type for a role's plain text.
+func textKind(role string) string {
+	if role == "assistant" {
+		return "output_text"
+	}
+	return "input_text"
+}
+
+func imageDataURL(src *imageSource) string {
+	if src == nil {
+		return ""
+	}
+	if src.Type == "url" && src.URL != "" {
+		return src.URL
+	}
+	if src.Type == "base64" && src.Data != "" {
+		return fmt.Sprintf("data:%s;base64,%s", src.MediaType, src.Data)
+	}
+	return ""
+}
+
+func rawOrEmptyObject(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage("{}")
+	}
+	return raw
+}
+
+// toolResultText flattens an Anthropic tool_result content (string OR []block) to
+// the plain string the Responses function_call_output carries.
+func toolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []contentBlock
+	if json.Unmarshal(raw, &blocks) == nil {
+		out := ""
+		for _, b := range blocks {
+			if b.Type == "text" {
+				out += b.Text
+			}
+		}
+		return out
+	}
+	return string(raw)
+}

--- a/internal/codexproxy/translate.go
+++ b/internal/codexproxy/translate.go
@@ -70,6 +70,10 @@ type responsesRequest struct {
 	Store             bool            `json:"store"`
 	Stream            bool            `json:"stream"`
 	PromptCacheKey    string          `json:"prompt_cache_key,omitempty"`
+	// MaxOutputTokens is set only by the openai-responses upstream (a billed
+	// account honors the cap); the codex backend 400s on it, so translateRequest
+	// leaves it 0 and omitempty drops it.
+	MaxOutputTokens int `json:"max_output_tokens,omitempty"`
 }
 
 type reasoningOpt struct {

--- a/internal/codexproxy/translate_test.go
+++ b/internal/codexproxy/translate_test.go
@@ -1,0 +1,199 @@
+package codexproxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSystemText(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", ``, ""},
+		{"string", `"hello"`, "hello"},
+		{"blocks", `[{"type":"text","text":"a"},{"type":"text","text":"b"}]`, "a\nb"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := systemText(json.RawMessage(c.raw)); got != c.want {
+				t.Fatalf("systemText(%s)=%q want %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTranslateToolChoice(t *testing.T) {
+	cases := []struct {
+		raw          string
+		want         any
+		wantParallel bool
+	}{
+		{``, "auto", true},
+		{`{"type":"auto"}`, "auto", true},
+		{`{"type":"any"}`, "required", true},
+		{`{"type":"tool","name":"grep"}`, map[string]any{"type": "function", "name": "grep"}, true},
+		{`{"type":"auto","disable_parallel_tool_use":true}`, "auto", false},
+	}
+	for _, c := range cases {
+		got, parallel := translateToolChoice(json.RawMessage(c.raw))
+		if parallel != c.wantParallel {
+			t.Fatalf("toolChoice(%s) parallel=%v want %v", c.raw, parallel, c.wantParallel)
+		}
+		if m, ok := c.want.(map[string]any); ok {
+			gm, ok := got.(map[string]any)
+			if !ok || gm["type"] != m["type"] || gm["name"] != m["name"] {
+				t.Fatalf("toolChoice(%s)=%v want %v", c.raw, got, c.want)
+			}
+			continue
+		}
+		if got != c.want {
+			t.Fatalf("toolChoice(%s)=%v want %v", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestEffortBucket(t *testing.T) {
+	for _, c := range []struct {
+		budget int
+		want   string
+	}{{0, "low"}, {1024, "medium"}, {8192, "medium"}, {32000, "high"}} {
+		if got := effortBucket(c.budget); got != c.want {
+			t.Fatalf("effortBucket(%d)=%s want %s", c.budget, got, c.want)
+		}
+	}
+}
+
+func TestTranslateRequest_OmitsForbiddenFieldsAndForcesStore(t *testing.T) {
+	a := &anthropicRequest{
+		Model:     "gpt-5.5",
+		MaxTokens: 999,
+		System:    json.RawMessage(`"sys"`),
+		Messages: []anthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"hi"`)},
+		},
+	}
+	a.Metadata.UserID = "user_abc_session_123"
+	r, err := translateRequest(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(r)
+	s := string(b)
+	if contains(s, "max_output_tokens") || contains(s, "max_tokens") || contains(s, "temperature") {
+		t.Fatalf("request leaked a forbidden field: %s", s)
+	}
+	if r.Store {
+		t.Fatal("store must be false")
+	}
+	if r.Instructions != "sys" {
+		t.Fatalf("instructions=%q", r.Instructions)
+	}
+	if len(r.Input) != 1 {
+		t.Fatalf("want 1 input item, got %d", len(r.Input))
+	}
+	if r.PromptCacheKey != "user_abc_session_123" {
+		t.Fatalf("prompt_cache_key=%q (want the metadata user_id)", r.PromptCacheKey)
+	}
+}
+
+func TestTranslateMessage_SystemRoleRidesAsDeveloper(t *testing.T) {
+	// claude -p sends a system-role skills message; the codex backend rejects
+	// role "system" in input, so it must ride as "developer".
+	items, err := translateMessage(anthropicMessage{
+		Role:    "system",
+		Content: json.RawMessage(`"The following skills are available"`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := items[0].(map[string]any)
+	if m["role"] != "developer" {
+		t.Fatalf("system message role = %v, want developer", m["role"])
+	}
+	blocks, _ := m["content"].([]map[string]any)
+	if len(blocks) != 1 || blocks[0]["type"] != "input_text" {
+		t.Fatalf("developer content = %v", m["content"])
+	}
+}
+
+func TestTranslateMessage_ThinkingReplaysEncryptedReasoning(t *testing.T) {
+	items, err := translateMessage(anthropicMessage{
+		Role: "assistant",
+		Content: json.RawMessage(`[
+			{"type":"thinking","thinking":"plan...","signature":"gAAAAA-enc"},
+			{"type":"thinking","thinking":"no signature -> skipped"},
+			{"type":"text","text":"answer"}
+		]`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want reasoning + message, got %d items: %v", len(items), items)
+	}
+	r := items[0].(map[string]any)
+	if r["type"] != "reasoning" || r["encrypted_content"] != "gAAAAA-enc" {
+		t.Fatalf("reasoning item = %v", r)
+	}
+	if _, hasID := r["id"]; hasID {
+		t.Fatal("replayed reasoning item must not carry an id (store:false rejects it)")
+	}
+	sum := r["summary"].([]map[string]any)
+	if len(sum) != 1 || sum[0]["text"] != "plan..." {
+		t.Fatalf("summary = %v", sum)
+	}
+}
+
+func TestTranslateMessage_ToolUseAndResult(t *testing.T) {
+	// assistant tool_use -> function_call
+	items, err := translateMessage(anthropicMessage{
+		Role:    "assistant",
+		Content: json.RawMessage(`[{"type":"tool_use","id":"toolu_1","name":"grep","input":{"q":"x"}}]`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+	m := items[0].(map[string]any)
+	if m["type"] != "function_call" || m["call_id"] != "toolu_1" || m["name"] != "grep" {
+		t.Fatalf("bad function_call item: %v", m)
+	}
+	if m["arguments"] != `{"q":"x"}` {
+		t.Fatalf("arguments=%v", m["arguments"])
+	}
+	// user tool_result -> function_call_output
+	items, _ = translateMessage(anthropicMessage{
+		Role:    "user",
+		Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"toolu_1","content":"42"}]`),
+	})
+	m = items[0].(map[string]any)
+	if m["type"] != "function_call_output" || m["call_id"] != "toolu_1" || m["output"] != "42" {
+		t.Fatalf("bad function_call_output item: %v", m)
+	}
+}
+
+func TestImageDataURL(t *testing.T) {
+	if got := imageDataURL(&imageSource{Type: "base64", MediaType: "image/png", Data: "AAAA"}); got != "data:image/png;base64,AAAA" {
+		t.Fatalf("base64 image url=%q", got)
+	}
+	if got := imageDataURL(&imageSource{Type: "url", URL: "https://x/y.png"}); got != "https://x/y.png" {
+		t.Fatalf("url image=%q", got)
+	}
+	if got := imageDataURL(nil); got != "" {
+		t.Fatalf("nil image=%q", got)
+	}
+}
+
+// contains is a tiny helper local to tests.
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codexproxy/upstream.go
+++ b/internal/codexproxy/upstream.go
@@ -1,0 +1,156 @@
+package codexproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// upstreamError carries a classified upstream failure so the server can map it to an
+// Anthropic-shaped error body + HTTP status that vendorclass understands.
+type upstreamError struct {
+	kind    upstreamKind
+	status  int
+	message string
+}
+
+func (e *upstreamError) Error() string { return e.message }
+
+type upstreamKind int
+
+const (
+	upTransient  upstreamKind = iota // 5xx / network: retryable
+	upAuth                           // 401/403 after a refresh attempt
+	upCloudflare                     // 403 cf-mitigated: IP/fingerprint block
+	upQuota                          // 429 usage limit: terminal
+	upBadRequest                     // 4xx request shape
+)
+
+// upstreamClient POSTs to the ChatGPT Responses backend with the reused bearer and
+// the codex client headers, refreshing once on a 401.
+type upstreamClient struct {
+	http   *http.Client
+	source tokenSource
+}
+
+func newUpstreamClient(source tokenSource) *upstreamClient {
+	return &upstreamClient{http: &http.Client{Timeout: 0}, source: source}
+}
+
+// call sends the Responses body and returns the streaming response on success. The
+// caller owns resp.Body. On failure it returns a classified *upstreamError.
+func (u *upstreamClient) call(ctx context.Context, body []byte) (*http.Response, error) {
+	resp, gen, err := u.do(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	// One refresh+retry on a 401 (expired access token mid-flight): invalidate
+	// exactly the generation that was sent, so a token already rotated by a
+	// concurrent caller is never wiped.
+	if resp.StatusCode == http.StatusUnauthorized {
+		b := drain(resp)
+		u.source.invalidate(gen)
+		resp, _, err = u.do(ctx, body)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			drain(resp)
+			return nil, &upstreamError{upAuth, http.StatusUnauthorized, "codex auth rejected: " + b}
+		}
+	}
+	if resp.StatusCode/100 == 2 {
+		return resp, nil
+	}
+	return nil, classifyUpstream(resp)
+}
+
+// do sends one upstream request, returning the bearer generation it used so a
+// 401 can invalidate precisely that credential.
+func (u *upstreamClient) do(ctx context.Context, body []byte) (*http.Response, uint64, error) {
+	bear, err := u.source.token(ctx)
+	if err != nil {
+		if errors.Is(err, ErrReauth) {
+			return nil, 0, &upstreamError{upAuth, http.StatusUnauthorized, "codex login required (run: cc-fleet codex login)"}
+		}
+		return nil, 0, &upstreamError{upTransient, http.StatusBadGateway, "codex token: " + err.Error()}
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, responsesURL, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+bear.accessToken)
+	req.Header.Set("chatgpt-account-id", bear.accountID)
+	req.Header.Set("OpenAI-Beta", openAIBetaValue)
+	req.Header.Set("originator", originatorValue)
+	req.Header.Set("User-Agent", userAgentValue)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := u.http.Do(req)
+	if err != nil {
+		return nil, 0, &upstreamError{upTransient, http.StatusBadGateway, "codex upstream: " + err.Error()}
+	}
+	return resp, bear.generation, nil
+}
+
+// classifyUpstream maps a non-2xx Responses status+body to an upstreamError.
+func classifyUpstream(resp *http.Response) *upstreamError {
+	body := drain(resp)
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &upstreamError{upQuota, http.StatusTooManyRequests, quotaMessage(body)}
+	case resp.StatusCode == http.StatusForbidden && isCloudflareChallenge(resp.Header, body):
+		return &upstreamError{upCloudflare, http.StatusForbidden, "blocked by Cloudflare (codex backend rejected this IP/client)"}
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &upstreamError{upAuth, resp.StatusCode, "codex auth rejected: " + body}
+	case resp.StatusCode/100 == 5:
+		return &upstreamError{upTransient, resp.StatusCode, fmt.Sprintf("codex upstream http %d", resp.StatusCode)}
+	default:
+		return &upstreamError{upBadRequest, resp.StatusCode, fmt.Sprintf("codex upstream http %d: %s", resp.StatusCode, body)}
+	}
+}
+
+// quotaMessage renders a 429: the backend's error code and, when reported, the
+// reset time (error.resets_at, unix seconds) — the quota signal a lead can act
+// on. An unparseable body falls back to a bounded raw snippet.
+func quotaMessage(body string) string {
+	var doc struct {
+		Error struct {
+			Code     string `json:"code"`
+			ResetsAt int64  `json:"resets_at"`
+		} `json:"error"`
+	}
+	if json.Unmarshal([]byte(body), &doc) != nil || doc.Error.Code == "" {
+		return "codex usage limit reached: " + body
+	}
+	msg := "codex " + doc.Error.Code
+	if doc.Error.ResetsAt > 0 {
+		msg += " (resets at " + time.Unix(doc.Error.ResetsAt, 0).UTC().Format(time.RFC3339) + ")"
+	}
+	return msg
+}
+
+// isCloudflareChallenge detects a Cloudflare edge block from headers/body markers.
+func isCloudflareChallenge(h http.Header, body string) bool {
+	if h.Get("cf-mitigated") != "" {
+		return true
+	}
+	lower := body
+	if len(lower) > 4096 {
+		lower = lower[:4096]
+	}
+	return (h.Get("Server") == "cloudflare") &&
+		(strings.Contains(lower, "Just a moment") || strings.Contains(lower, "Attention Required") || strings.Contains(lower, "cf-mitigated"))
+}
+
+// drain reads a bounded prefix of an error body (never the success stream) so the
+// connection can be reused, returning a short, log-safe snippet.
+func drain(resp *http.Response) string {
+	const max = 2048
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, max))
+	resp.Body.Close()
+	return string(b)
+}

--- a/internal/codexproxy/upstream.go
+++ b/internal/codexproxy/upstream.go
@@ -32,20 +32,36 @@ const (
 	upBadRequest                     // 4xx request shape
 )
 
-// upstreamClient POSTs to the ChatGPT Responses backend with the reused bearer and
-// the codex client headers, refreshing once on a 401.
-type upstreamClient struct {
+// codexUpstream POSTs to the ChatGPT Responses backend with the reused
+// subscription bearer and the codex client headers, refreshing once on a 401. It
+// is the upstream implementation for the codex-oauth protocol.
+type codexUpstream struct {
 	http   *http.Client
 	source tokenSource
 }
 
-func newUpstreamClient(source tokenSource) *upstreamClient {
-	return &upstreamClient{http: &http.Client{Timeout: 0}, source: source}
+func newCodexUpstream(source tokenSource) *codexUpstream {
+	return &codexUpstream{http: &http.Client{Timeout: 0}, source: source}
 }
 
-// call sends the Responses body and returns the streaming response on success. The
-// caller owns resp.Body. On failure it returns a classified *upstreamError.
-func (u *upstreamClient) call(ctx context.Context, body []byte) (*http.Response, error) {
+func (u *codexUpstream) models() []string { return append([]string(nil), codexModels...) }
+
+func (u *codexUpstream) convert(body io.Reader, sink sseSink, model, _ string) error {
+	// codex's upstream errors are canonical (no key), so no redactor is needed.
+	return newStreamConverter(sink, model).Convert(body)
+}
+
+// call translates the Anthropic request to a Responses request, sends it, and
+// returns the streaming body on success (the caller owns it). apiKey is ignored —
+// codex authenticates with its OAuth bearer. On failure it returns a classified
+// *upstreamError; a 401 triggers one refresh+retry.
+func (u *codexUpstream) call(ctx context.Context, areq *anthropicRequest, _ string) (io.ReadCloser, error) {
+	rreq, err := translateRequest(areq)
+	if err != nil {
+		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, err.Error()}
+	}
+	body, _ := json.Marshal(rreq)
+
 	resp, gen, err := u.do(ctx, body)
 	if err != nil {
 		return nil, err
@@ -66,14 +82,14 @@ func (u *upstreamClient) call(ctx context.Context, body []byte) (*http.Response,
 		}
 	}
 	if resp.StatusCode/100 == 2 {
-		return resp, nil
+		return resp.Body, nil
 	}
 	return nil, classifyUpstream(resp)
 }
 
 // do sends one upstream request, returning the bearer generation it used so a
 // 401 can invalidate precisely that credential.
-func (u *upstreamClient) do(ctx context.Context, body []byte) (*http.Response, uint64, error) {
+func (u *codexUpstream) do(ctx context.Context, body []byte) (*http.Response, uint64, error) {
 	bear, err := u.source.token(ctx)
 	if err != nil {
 		if errors.Is(err, ErrReauth) {

--- a/internal/codexproxy/upstream_iface.go
+++ b/internal/codexproxy/upstream_iface.go
@@ -1,0 +1,44 @@
+package codexproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// upstream is the wire-specific half of the daemon: one implementation per
+// protocol. call translates the Anthropic request to the upstream format, sends
+// it, and returns the streaming body (or a classified *upstreamError); convert
+// runs that stream through the upstream's SSE→Anthropic converter; models is the
+// /v1/models list (static for codex, unused for openai — its models come from the
+// real upstream's models_endpoint, not this daemon).
+type upstream interface {
+	call(ctx context.Context, areq *anthropicRequest, apiKey string) (io.ReadCloser, error)
+	// convert runs the upstream's SSE→Anthropic converter. apiKey is the presented
+	// key (openai-*) so a streaming error chunk that echoes it is redacted before
+	// it reaches the client; codex ignores it (its bearer is OAuth, not the key).
+	convert(body io.Reader, sink sseSink, model, apiKey string) error
+	models() []string
+}
+
+// buildUpstream selects the upstream implementation for a daemon's protocol.
+// codex builds its own OAuth token source; openai-* carries the real key per
+// request (apiKey passed to call), so it only needs the upstream base URL.
+func buildUpstream(protocol, upstreamURL string) (upstream, error) {
+	switch protocol {
+	case config.ProtocolCodexOAuth:
+		source, err := newCLIRideStore()
+		if err != nil {
+			return nil, err
+		}
+		return newCodexUpstream(source), nil
+	case config.ProtocolOpenAIChat:
+		return newOpenAIChatUpstream(upstreamURL), nil
+	case config.ProtocolOpenAIResponses:
+		return newOpenAIResponsesUpstream(upstreamURL), nil
+	default:
+		return nil, fmt.Errorf("codexproxy: unsupported protocol %q", protocol)
+	}
+}

--- a/internal/config/protocol_test.go
+++ b/internal/config/protocol_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validOpenAIChat returns an openai-chat Vendor that should pass Validate: a
+// loopback daemon base_url + a real upstream_url + a real-key backend.
+func validOpenAIChat(name string) *Vendor {
+	v := validVendor(name)
+	v.Protocol = ProtocolOpenAIChat
+	v.BaseURL = "http://127.0.0.1:17240/"
+	v.UpstreamURL = "https://api.openai.com/v1"
+	v.ModelsEndpoint = "https://api.openai.com/v1/models"
+	v.SecretBackend = "file"
+	return v
+}
+
+// A codex row predating the protocol field (codex-oauth backend, no protocol)
+// resolves to the codex protocol and validates exactly as it did before.
+func TestProtocolCompatNormalize(t *testing.T) {
+	v := validVendor("codex")
+	v.SecretBackend = CodexOAuthBackend
+	v.SecretRef = CodexOAuthBackend
+	v.BaseURL = "http://127.0.0.1:17222/"
+	v.ModelsEndpoint = "http://127.0.0.1:17222/v1/models"
+	v.Protocol = "" // shipped codex rows carry no protocol line
+
+	if got := v.EffectiveProtocol(); got != ProtocolCodexOAuth {
+		t.Fatalf("EffectiveProtocol = %q, want codex-oauth", got)
+	}
+	if !v.DaemonBacked() {
+		t.Fatal("a codex row must be daemon-backed")
+	}
+	if err := v.validate("codex"); err != nil {
+		t.Fatalf("protocol-less codex row must validate: %v", err)
+	}
+}
+
+func TestProtocolClosedSet(t *testing.T) {
+	v := validVendor("x")
+	v.Protocol = "openai-completions" // not in the closed set
+	if err := v.validate("x"); err == nil || !strings.Contains(err.Error(), "protocol") {
+		t.Fatalf("unknown protocol must be rejected, got %v", err)
+	}
+}
+
+func TestValidateWire(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Vendor)
+		wantErr string // substring; "" = must pass
+	}{
+		{"openai-chat ok", func(v *Vendor) {}, ""},
+		{"openai-responses ok", func(v *Vendor) { v.Protocol = ProtocolOpenAIResponses }, ""},
+		{"openai missing upstream_url", func(v *Vendor) { v.UpstreamURL = "" }, "requires upstream_url"},
+		{"openai with codex backend", func(v *Vendor) { v.SecretBackend = CodexOAuthBackend; v.SecretRef = CodexOAuthBackend }, "not the codex-oauth backend"},
+		{"openai non-loopback base", func(v *Vendor) { v.BaseURL = "https://api.openai.com/" }, "base_url"},
+		{"openai bad upstream", func(v *Vendor) { v.UpstreamURL = "http://api.openai.com/v1" }, "upstream_url"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := validOpenAIChat("oai")
+			c.mutate(v)
+			err := v.validate("oai")
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want pass, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("want error containing %q, got %v", c.wantErr, err)
+			}
+		})
+	}
+
+	// codex-oauth protocol cross-checks.
+	t.Run("codex wrong backend", func(t *testing.T) {
+		v := validVendor("c")
+		v.Protocol = ProtocolCodexOAuth
+		v.BaseURL = "http://127.0.0.1:17222/"
+		v.ModelsEndpoint = "http://127.0.0.1:17222/v1/models"
+		if err := v.validate("c"); err == nil || !strings.Contains(err.Error(), "requires secret_backend") {
+			t.Fatalf("codex protocol needs the codex backend, got %v", err)
+		}
+	})
+	t.Run("codex with upstream_url", func(t *testing.T) {
+		v := validVendor("c")
+		v.SecretBackend = CodexOAuthBackend
+		v.SecretRef = CodexOAuthBackend
+		v.BaseURL = "http://127.0.0.1:17222/"
+		v.ModelsEndpoint = "http://127.0.0.1:17222/v1/models"
+		v.UpstreamURL = "https://api.openai.com/v1"
+		if err := v.validate("c"); err == nil || !strings.Contains(err.Error(), "must not set upstream_url") {
+			t.Fatalf("codex must reject upstream_url, got %v", err)
+		}
+	})
+
+	// Anthropic-native must not carry upstream_url.
+	t.Run("anthropic with upstream_url", func(t *testing.T) {
+		v := validVendor("a")
+		v.UpstreamURL = "https://api.openai.com/v1"
+		if err := v.validate("a"); err == nil || !strings.Contains(err.Error(), "only valid for an openai-*") {
+			t.Fatalf("anthropic-native must reject upstream_url, got %v", err)
+		}
+	})
+}
+
+func TestValidateUpstreamURL(t *testing.T) {
+	ok := []string{
+		"https://api.openai.com/v1",
+		"https://api.groq.com/openai/v1",
+		"https://api.fireworks.ai/inference/v1",
+		"https://openrouter.ai/api/v1",
+		"http://127.0.0.1:11434/v1",
+		"http://localhost:8000/v1",
+		"https://api.openai.com/v1/", // a single trailing slash is tolerated
+	}
+	for _, u := range ok {
+		if err := ValidateUpstreamURL(u); err != nil {
+			t.Errorf("ValidateUpstreamURL(%q) = %v, want nil", u, err)
+		}
+	}
+	bad := []string{
+		"http://api.openai.com/v1",         // http for a remote host
+		"https://x@api.openai.com/v1",      // userinfo
+		"https://api.openai.com/v1?k=1",    // query
+		"https://api.openai.com/v1#frag",   // fragment
+		"https://api.openai.com/v1/../etc", // unsafe path
+		"ftp://api.openai.com/v1",          // scheme
+		"https:///v1",                      // missing host
+		" https://api.openai.com/v1",       // leading space (daemon uses it verbatim)
+		"https://api.openai.com/v1 ",       // trailing space
+	}
+	for _, u := range bad {
+		if err := ValidateUpstreamURL(u); err == nil {
+			t.Errorf("ValidateUpstreamURL(%q) = nil, want error", u)
+		}
+	}
+}
+
+// An existing Anthropic-native config (no protocol/upstream_url lines) is
+// byte-stable through Save: omitempty must not introduce either field.
+func TestAnthropicNativeSaveByteStable(t *testing.T) {
+	cfg := &Config{Version: SchemaVersion, Vendors: map[string]*Vendor{
+		"deepseek": validVendor("deepseek"),
+	}}
+	p := filepath.Join(t.TempDir(), "vendors.toml")
+	if err := SaveToPath(cfg, p); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "protocol") || strings.Contains(string(b), "upstream_url") {
+		t.Fatalf("Anthropic-native row gained a protocol/upstream_url line:\n%s", b)
+	}
+}

--- a/internal/config/vendor.go
+++ b/internal/config/vendor.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -24,9 +25,16 @@ import (
 // SchemaVersion is the only supported vendors.toml schema version.
 const SchemaVersion = 1
 
+// CodexOAuthBackend is the secret_backend value for a codex (ChatGPT
+// subscription) provider. Its keyget hands back a loopback handshake secret —
+// the upstream OAuth bearer lives only in the codex proxy daemon — so its
+// base_url and models_endpoint MUST be loopback http (enforced at validate, so a
+// hand-edited or `cc-fleet edit` vendor can never send that secret off-host).
+const CodexOAuthBackend = "codex-oauth"
+
 // validSecretBackends is the closed set of supported secret_backend values.
 // Order is the canonical order used in error messages.
-var validSecretBackends = []string{"file", "pass", "1password", "vault", "keyring"}
+var validSecretBackends = []string{"file", "pass", "1password", "vault", "keyring", CodexOAuthBackend}
 
 // Config is the parsed contents of vendors.toml.
 //
@@ -262,6 +270,17 @@ func (v *Vendor) validate(mapKey string) error {
 	if v.SecretRef == "" {
 		return fmt.Errorf("config: vendor %q: secret_ref is required", name)
 	}
+	// A codex-oauth vendor's endpoints must be loopback: keyget hands the launched
+	// claude only a handshake secret, and the proxy receives it on base_url — a
+	// remote/https endpoint would leak that secret off-host.
+	if v.SecretBackend == CodexOAuthBackend {
+		if _, err := ParseLoopbackURL(v.BaseURL); err != nil {
+			return fmt.Errorf("config: vendor %q: codex base_url %w", name, err)
+		}
+		if _, err := ParseLoopbackURL(v.ModelsEndpoint); err != nil {
+			return fmt.Errorf("config: vendor %q: codex models_endpoint %w", name, err)
+		}
+	}
 	if !isValidKeyRotation(v.KeyRotation) {
 		return fmt.Errorf("config: vendor %q: key_rotation %q invalid (want one of %v)",
 			name, v.KeyRotation, ValidKeyRotations())
@@ -300,4 +319,25 @@ func validateHTTPURL(field, s string) error {
 		return fmt.Errorf("%s %q missing host", field, s)
 	}
 	return nil
+}
+
+// ParseLoopbackURL validates raw is a plain http://127.0.0.1|localhost[:port] URL
+// (no userinfo, no https / remote host) and returns it. The one definition the
+// codex-oauth validate path and the codex proxy daemon both use, so the loopback
+// invariant can't drift between load-time rejection and run-time defense.
+func ParseLoopbackURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%q is not a valid URL: %w", raw, err)
+	}
+	if u.Scheme != "http" {
+		return nil, fmt.Errorf("%q must use http (loopback only)", raw)
+	}
+	if u.User != nil {
+		return nil, fmt.Errorf("%q must not carry userinfo", raw)
+	}
+	if h := u.Hostname(); h != "127.0.0.1" && h != "localhost" {
+		return nil, fmt.Errorf("%q must be loopback (127.0.0.1 or localhost), got %q", raw, h)
+	}
+	return u, nil
 }

--- a/internal/config/vendor.go
+++ b/internal/config/vendor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -35,6 +36,21 @@ const CodexOAuthBackend = "codex-oauth"
 // validSecretBackends is the closed set of supported secret_backend values.
 // Order is the canonical order used in error messages.
 var validSecretBackends = []string{"file", "pass", "1password", "vault", "keyring", CodexOAuthBackend}
+
+// Wire protocol values for Vendor.protocol — orthogonal to secret_backend. "" is
+// Anthropic-native (the vendor speaks the Anthropic Messages API directly, no
+// daemon). The others ride the loopback conversion daemon: openai-chat and
+// openai-responses speak the OpenAI API with a real key; codex-oauth reuses a
+// ChatGPT subscription over OAuth.
+const (
+	ProtocolOpenAIChat      = "openai-chat"
+	ProtocolOpenAIResponses = "openai-responses"
+	ProtocolCodexOAuth      = CodexOAuthBackend // "codex-oauth"
+)
+
+// validProtocols is the closed set of supported protocol values (the empty
+// default included), rejected at Load like every other enum.
+var validProtocols = []string{"", ProtocolOpenAIChat, ProtocolOpenAIResponses, ProtocolCodexOAuth}
 
 // Config is the parsed contents of vendors.toml.
 //
@@ -63,7 +79,31 @@ type Vendor struct {
 	// off/single-key vendors' files byte-identical (no key_rotation line); an
 	// absent field parses as off.
 	KeyRotation string `toml:"key_rotation,omitempty"`
+	// Protocol is the wire class (one of validProtocols). "" = Anthropic-native;
+	// omitempty keeps every existing vendors.toml byte-identical. A codex-oauth
+	// secret_backend with no protocol is treated as the codex protocol — see
+	// EffectiveProtocol.
+	Protocol string `toml:"protocol,omitempty"`
+	// UpstreamURL is the real OpenAI-compatible base URL for an openai-* protocol
+	// (claude talks to the loopback daemon on base_url; the daemon forwards here).
+	// Required for openai-*, forbidden otherwise. May carry a clean path prefix,
+	// usually ending in /v1.
+	UpstreamURL string `toml:"upstream_url,omitempty"`
 }
+
+// EffectiveProtocol resolves the wire protocol, applying the backward-compat rule
+// that a codex-oauth secret_backend with no explicit protocol means the codex
+// protocol — the codex providers shipped before the protocol field existed.
+func (v *Vendor) EffectiveProtocol() string {
+	if v.Protocol == "" && v.SecretBackend == CodexOAuthBackend {
+		return ProtocolCodexOAuth
+	}
+	return v.Protocol
+}
+
+// DaemonBacked reports whether the vendor's traffic rides the loopback conversion
+// daemon (any non-Anthropic-native protocol).
+func (v *Vendor) DaemonBacked() bool { return v.EffectiveProtocol() != "" }
 
 // Load reads, parses, and returns the contents of the default vendors.toml.
 //
@@ -270,16 +310,12 @@ func (v *Vendor) validate(mapKey string) error {
 	if v.SecretRef == "" {
 		return fmt.Errorf("config: vendor %q: secret_ref is required", name)
 	}
-	// A codex-oauth vendor's endpoints must be loopback: keyget hands the launched
-	// claude only a handshake secret, and the proxy receives it on base_url — a
-	// remote/https endpoint would leak that secret off-host.
-	if v.SecretBackend == CodexOAuthBackend {
-		if _, err := ParseLoopbackURL(v.BaseURL); err != nil {
-			return fmt.Errorf("config: vendor %q: codex base_url %w", name, err)
-		}
-		if _, err := ParseLoopbackURL(v.ModelsEndpoint); err != nil {
-			return fmt.Errorf("config: vendor %q: codex models_endpoint %w", name, err)
-		}
+	if !isValidProtocol(v.Protocol) {
+		return fmt.Errorf("config: vendor %q: protocol %q invalid (want one of %v)",
+			name, v.Protocol, validProtocols)
+	}
+	if err := v.validateWire(name); err != nil {
+		return err
 	}
 	if !isValidKeyRotation(v.KeyRotation) {
 		return fmt.Errorf("config: vendor %q: key_rotation %q invalid (want one of %v)",
@@ -295,6 +331,105 @@ func isValidSecretBackend(b string) bool {
 		}
 	}
 	return false
+}
+
+func isValidProtocol(p string) bool {
+	for _, ok := range validProtocols {
+		if p == ok {
+			return true
+		}
+	}
+	return false
+}
+
+// validateWire enforces the protocol/secret_backend/upstream_url/loopback
+// cross-checks for the resolved (compat-normalized) wire protocol.
+func (v *Vendor) validateWire(name string) error {
+	switch v.EffectiveProtocol() {
+	case ProtocolCodexOAuth:
+		if v.SecretBackend != CodexOAuthBackend {
+			return fmt.Errorf("config: vendor %q: codex-oauth protocol requires secret_backend %q", name, CodexOAuthBackend)
+		}
+		if v.UpstreamURL != "" {
+			return fmt.Errorf("config: vendor %q: codex-oauth must not set upstream_url", name)
+		}
+		// keyget hands the launched claude only a handshake secret it presents on
+		// base_url, and a probe sends it to models_endpoint — both must be loopback
+		// http so that secret can never leave the host.
+		if _, err := ParseLoopbackURL(v.BaseURL); err != nil {
+			return fmt.Errorf("config: vendor %q: codex base_url %w", name, err)
+		}
+		if _, err := ParseLoopbackURL(v.ModelsEndpoint); err != nil {
+			return fmt.Errorf("config: vendor %q: codex models_endpoint %w", name, err)
+		}
+	case ProtocolOpenAIChat, ProtocolOpenAIResponses:
+		if v.SecretBackend == CodexOAuthBackend {
+			return fmt.Errorf("config: vendor %q: %s protocol carries a real key, not the codex-oauth backend", name, v.EffectiveProtocol())
+		}
+		if v.UpstreamURL == "" {
+			return fmt.Errorf("config: vendor %q: %s protocol requires upstream_url", name, v.EffectiveProtocol())
+		}
+		if err := ValidateUpstreamURL(v.UpstreamURL); err != nil {
+			return fmt.Errorf("config: vendor %q: upstream_url %w", name, err)
+		}
+		// claude talks to the loopback conversion daemon on base_url; the real
+		// upstream lives in upstream_url.
+		if _, err := ParseLoopbackURL(v.BaseURL); err != nil {
+			return fmt.Errorf("config: vendor %q: openai base_url %w", name, err)
+		}
+	default: // "" Anthropic-native — claude talks to the vendor directly.
+		if v.UpstreamURL != "" {
+			return fmt.Errorf("config: vendor %q: upstream_url is only valid for an openai-* protocol", name)
+		}
+	}
+	return nil
+}
+
+// ValidateUpstreamURL validates an openai-* upstream_url: an OpenAI-compatible
+// base URL (scheme://host[:port][/clean/prefix], the prefix usually ending in
+// /v1) onto which the daemon joins endpoint suffixes with url.JoinPath. https is
+// required for a remote host; http is allowed only for a loopback host (local
+// Ollama/vLLM). userinfo, query, fragment, and unclean or .. path segments are
+// rejected — it rides the daemon argv.
+func ValidateUpstreamURL(raw string) error {
+	// Validate the exact stored value (the daemon uses it verbatim): surrounding
+	// whitespace would pass a trimmed check yet break url.JoinPath at run time.
+	if raw != strings.TrimSpace(raw) {
+		return fmt.Errorf("%q must not have surrounding whitespace", raw)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid URL: %w", raw, err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%q missing host", raw)
+	}
+	if u.User != nil {
+		return fmt.Errorf("%q must not carry userinfo", raw)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("%q must not carry a query or fragment", raw)
+	}
+	if p := strings.TrimSuffix(u.Path, "/"); p != "" {
+		// path.Clean rejects every real traversal (".."/"."/"//"); an explicit
+		// Contains("..") would also reject a legitimate segment that merely contains
+		// the bytes, so it is not needed.
+		if !strings.HasPrefix(p, "/") || path.Clean(p) != p {
+			return fmt.Errorf("%q has an unsafe path %q", raw, u.Path)
+		}
+	}
+	loopback := u.Hostname() == "127.0.0.1" || u.Hostname() == "localhost"
+	switch u.Scheme {
+	case "https":
+		// ok for any host
+	case "http":
+		if !loopback {
+			return fmt.Errorf("%q must use https for a remote host (http is loopback-only)", raw)
+		}
+	default:
+		return fmt.Errorf("%q must use http or https (got %q)", raw, u.Scheme)
+	}
+	return nil
 }
 
 func isValidKeyRotation(r string) bool {

--- a/internal/config/vendor_load_strict_test.go
+++ b/internal/config/vendor_load_strict_test.go
@@ -67,6 +67,57 @@ added_at = 2026-05-24T05:00:00Z
 	}
 }
 
+// A codex-oauth vendor with a remote base_url must be rejected at load — the
+// loopback handshake secret must never be sent off-host.
+func TestLoadFromPath_RejectsRemoteCodexBaseURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vendors.toml")
+	body := `version = 1
+
+[codex]
+base_url = "https://evil.example.com/"
+default_model = "gpt-5.5"
+models_endpoint = "http://127.0.0.1:17222/v1/models"
+secret_backend = "codex-oauth"
+secret_ref = "codex-oauth"
+enabled = true
+added_at = 2026-06-08T05:00:00Z
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := LoadFromPath(path)
+	if err == nil {
+		t.Fatal("LoadFromPath: want error for a remote codex base_url, got nil")
+	}
+	if !strings.Contains(err.Error(), "codex base_url") || !strings.Contains(err.Error(), "loopback") {
+		t.Fatalf("err %q should call out the codex loopback requirement", err.Error())
+	}
+}
+
+// A codex-oauth vendor with loopback endpoints loads cleanly.
+func TestLoadFromPath_AcceptsLoopbackCodex(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vendors.toml")
+	body := `version = 1
+
+[codex]
+base_url = "http://127.0.0.1:17222/"
+default_model = "gpt-5.5"
+models_endpoint = "http://127.0.0.1:17222/v1/models"
+secret_backend = "codex-oauth"
+secret_ref = "codex-oauth"
+enabled = true
+added_at = 2026-06-08T05:00:00Z
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LoadFromPath(path); err != nil {
+		t.Fatalf("loopback codex vendor must load, got %v", err)
+	}
+}
+
 // TestLoadFromPath_RejectsEmptySecretRef: every vendor needs a secret_ref so
 // keyget knows what to fetch.
 func TestLoadFromPath_RejectsEmptySecretRef(t *testing.T) {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/ethanhq/cc-fleet/internal/childenv"
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 	"github.com/ethanhq/cc-fleet/internal/ids"
@@ -100,6 +101,13 @@ func Run(req Request) error {
 	bin, err := resolveBinary()
 	if err != nil {
 		return err
+	}
+
+	// For a codex provider, ensure the conversion daemon is up before the profile
+	// write (and before the exec that replaces this process — there is no
+	// after-exec hook), fail-before-mutation.
+	if err := codexproxy.EnsureForVendor(v); err != nil {
+		return fmt.Errorf("codex proxy unavailable: %w", err)
 	}
 
 	profilePath, err := profile.WriteForVendor(v, "")

--- a/internal/secrets/dispatch.go
+++ b/internal/secrets/dispatch.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 )
 
@@ -53,8 +54,17 @@ func Keyget(vendor string) ([]byte, error) {
 		return keygetVault(vendor, v)
 	case "keyring":
 		return keygetKeyring(vendor, v)
+	case "codex-oauth":
+		// The upstream OAuth bearer lives in the codex proxy daemon, never here:
+		// keyget hands the launched claude only the low-value loopback handshake
+		// secret that gates the daemon's /v1/messages.
+		secret, err := codexproxy.SecretForKeyget()
+		if err != nil {
+			return nil, fmt.Errorf("keyget %s: codex proxy secret: %w", vendor, err)
+		}
+		return []byte(secret), nil
 	default:
-		return nil, fmt.Errorf("keyget %s: unknown backend %q (want file|pass|1password|vault|keyring)",
+		return nil, fmt.Errorf("keyget %s: unknown backend %q (want file|pass|1password|vault|keyring|codex-oauth)",
 			vendor, v.SecretBackend)
 	}
 }

--- a/internal/secrets/dispatch_test.go
+++ b/internal/secrets/dispatch_test.go
@@ -79,6 +79,38 @@ func fileVendor(name, ref string) *config.Config {
 	}
 }
 
+// An openai-* provider carries a real key via a normal backend (b1): keyget
+// returns that key for the daemon to forward, never the codex handshake secret.
+func TestKeyget_OpenAIChat_ReturnsRealKey(t *testing.T) {
+	cfg := &config.Config{
+		Version: config.SchemaVersion,
+		Vendors: map[string]*config.Vendor{
+			"groq": {
+				Name:           "groq",
+				BaseURL:        "http://127.0.0.1:17240/",
+				DefaultModel:   "llama-3.3",
+				ModelsEndpoint: "https://api.groq.com/openai/v1/models",
+				SecretBackend:  "file",
+				SecretRef:      "groq.key",
+				Protocol:       config.ProtocolOpenAIChat,
+				UpstreamURL:    "https://api.groq.com/openai/v1",
+				Enabled:        true,
+				AddedAt:        time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	setupConfig(t, cfg)
+	writeSecretFile(t, "groq.key", []byte("sk-real-groq-key"))
+
+	got, err := Keyget("groq")
+	if err != nil {
+		t.Fatalf("Keyget: %v", err)
+	}
+	if string(got) != "sk-real-groq-key" {
+		t.Fatalf("Keyget = %q, want the real key (b1, not the handshake secret)", got)
+	}
+}
+
 func TestKeyget_File_OK(t *testing.T) {
 	setupConfig(t, fileVendor("deepseek", "deepseek.key"))
 	writeSecretFile(t, "deepseek.key", []byte("sk-deepseek-abc123"))

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -164,8 +164,9 @@ func Spawn(req Request) Result {
 	// 4. Optional vendor probe (3s GET against models_endpoint, with key).
 	//    Skipped for a codex provider: its models endpoint is served by the
 	//    lazily-started conversion daemon, so probing here (before 5c starts it)
-	//    would always fail — daemon readiness at 5c is the real health signal.
-	if req.Probe && v.SecretBackend != codexproxy.SecretBackend {
+	//    would always fail — daemon readiness at 5c is the real health signal. An
+	//    openai-* provider still probes (its models_endpoint is the real upstream).
+	if req.Probe && v.EffectiveProtocol() != config.ProtocolCodexOAuth {
 		if res := probeVendor(v); res != nil {
 			res.Vendor = req.Vendor
 			return *res

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 	"github.com/ethanhq/cc-fleet/internal/ids"
@@ -161,7 +162,10 @@ func Spawn(req Request) Result {
 	}
 
 	// 4. Optional vendor probe (3s GET against models_endpoint, with key).
-	if req.Probe {
+	//    Skipped for a codex provider: its models endpoint is served by the
+	//    lazily-started conversion daemon, so probing here (before 5c starts it)
+	//    would always fail — daemon readiness at 5c is the real health signal.
+	if req.Probe && v.SecretBackend != codexproxy.SecretBackend {
 		if res := probeVendor(v); res != nil {
 			res.Vendor = req.Vendor
 			return *res
@@ -208,6 +212,14 @@ func Spawn(req Request) Result {
 	// CurrentVersionExceedsRecipe's ccver probe (which can exec `claude --version`).
 	// Computed before the lock, consumed after a successful spawn below.
 	runSettle := req.Verify && fingerprint.CurrentVersionExceedsRecipe(fp)
+
+	// 5c. For a codex provider, ensure the conversion daemon is up — after the
+	//     fingerprint gate, before the profile write and the tmux split, so a
+	//     daemon failure is fail-before-mutation (no profile, no pane).
+	if err := ensureVendorProxy(v); err != nil {
+		return fail(ErrCodeProxyUnavailable, err.Error(), req.Vendor,
+			"Run cc-fleet codex login (and check the codex base_url port is free), then retry")
+	}
 
 	// 6. Ensure the per-vendor profile exists (idempotent write).
 	profilePath, err := profile.WriteForVendor(v, "")
@@ -588,6 +600,11 @@ var settleOK = func(socket, paneID string) bool {
 	time.Sleep(settleWindow)
 	return tmux.NewServer(socket).PaneExists(paneID)
 }
+
+// ensureVendorProxy ensures the codex conversion daemon for a codex provider
+// (a no-op for every other vendor). A package var so tests can stub it without
+// launching a real daemon process.
+var ensureVendorProxy = codexproxy.EnsureForVendor
 
 // rollbackSpawnedMember undoes a FULLY committed spawn (pane + config member +
 // inbox) when the post-spawn settle check fails. Unlike rollbackPane — which

--- a/internal/spawn/spawn_codex_test.go
+++ b/internal/spawn/spawn_codex_test.go
@@ -1,0 +1,93 @@
+package spawn
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// codexStanza returns a vendors.toml stanza for a codex provider whose
+// endpoints point at base.
+func codexStanza(base string) string {
+	return fmt.Sprintf(`
+[codex]
+base_url        = "%s/"
+default_model   = "gpt-5.5"
+models_endpoint = "%s/v1/models"
+secret_backend  = "codex-oauth"
+secret_ref      = "codex-oauth"
+enabled         = true
+added_at        = 2026-06-08T05:00:00Z
+`, base, base)
+}
+
+// A codex provider's models endpoint is served by the lazily-started daemon,
+// so the step-4 probe is skipped (it would always fail before 5c starts the
+// daemon); daemon readiness at 5c is the health signal instead.
+func TestSpawn_CodexSkipsProbe_EnsuresDaemon(t *testing.T) {
+	f := newFixture(t)
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	f.writeVendorsTOML(codexStanza(srv.URL))
+	f.writeFingerprint()
+
+	var ensured atomic.Int32
+	ensureVendorProxy = func(v *config.Vendor) error {
+		if v == nil || v.SecretBackend != codexproxy.SecretBackend {
+			t.Errorf("ensureVendorProxy got a non-codex vendor: %+v", v)
+		}
+		ensured.Add(1)
+		return nil
+	}
+	t.Cleanup(func() { ensureVendorProxy = codexproxy.EnsureForVendor })
+
+	res := Spawn(Request{Vendor: "codex", AgentName: "cw", Team: "ct", Probe: true, AutoTeam: true})
+	if !res.OK {
+		t.Fatalf("codex spawn: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("codex probe must be skipped; models endpoint hit %d time(s)", got)
+	}
+	if got := ensured.Load(); got != 1 {
+		t.Fatalf("ensureVendorProxy calls = %d, want 1", got)
+	}
+}
+
+// A daemon-ensure failure is fail-before-mutation: classified result, no
+// profile written, no team dir, no tmux call.
+func TestSpawn_CodexDaemonFailure_FailsBeforeMutation(t *testing.T) {
+	f := newFixture(t)
+	f.writeVendorsTOML(codexStanza("http://127.0.0.1:17222"))
+	f.writeFingerprint()
+
+	ensureVendorProxy = func(*config.Vendor) error {
+		return fmt.Errorf("codex proxy did not become ready on port 17222")
+	}
+	t.Cleanup(func() { ensureVendorProxy = codexproxy.EnsureForVendor })
+
+	res := Spawn(Request{Vendor: "codex", AgentName: "cw", Team: "ct2", Probe: false, AutoTeam: true})
+	if res.OK || res.ErrorCode != ErrCodeProxyUnavailable {
+		t.Fatalf("want CODEX_PROXY_UNAVAILABLE, got ok=%v code=%s", res.OK, res.ErrorCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.home, ".claude", "profiles", "codex.json")); !os.IsNotExist(err) {
+		t.Fatalf("profile must not be written on daemon failure (stat err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(f.home, ".claude", "teams", "ct2")); !os.IsNotExist(err) {
+		t.Fatalf("team dir must not be created on daemon failure")
+	}
+	if calls := f.readMockArgs(); len(calls) != 0 {
+		t.Fatalf("no tmux calls expected on daemon failure, got %v", calls)
+	}
+}

--- a/internal/spawn/types.go
+++ b/internal/spawn/types.go
@@ -116,6 +116,7 @@ const (
 	ErrCodeModelNotFound      = "MODEL_NOT_FOUND"
 	ErrCodeFingerprintMissing = "FINGERPRINT_MISSING"
 	ErrCodeFingerprintStale   = "FINGERPRINT_STALE"
+	ErrCodeProxyUnavailable   = "CODEX_PROXY_UNAVAILABLE"
 	ErrCodeNoLeadSession      = "NO_LEAD_SESSION"
 	ErrCodeTeamNotFound       = "TEAM_NOT_FOUND"
 	ErrCodePaneCreationFailed = "PANE_CREATION_FAILED"

--- a/internal/subagent/classify.go
+++ b/internal/subagent/classify.go
@@ -139,6 +139,11 @@ func classify(req Request, model string, stdout, stderr []byte, exitCode int, ti
 func classifyError(inner innerEnvelope) string {
 	switch inner.APIErrorStatus {
 	case 401, 403:
+		// A Cloudflare edge block answers 403 — an IP/client problem, not a bad
+		// key, so it must not surface as KEY_INVALID.
+		if vendorclass.MatchClass(inner.Result) == vendorclass.ClassCloudflareBlocked {
+			return ErrCodeCloudflareBlocked
+		}
 		return ErrCodeKeyInvalid
 	case 429, 402:
 		// Balance outranks a bare 429 — a retry can't fix being out of credit.
@@ -181,6 +186,8 @@ func errorMessage(code string, inner innerEnvelope) string {
 		return "vendor out of balance/quota (HTTP 429/402)"
 	case ErrCodeModelNotFound:
 		return "vendor rejected the model name (HTTP 400)"
+	case ErrCodeCloudflareBlocked:
+		return "vendor edge (Cloudflare) blocked this IP/client (HTTP 403)"
 	case ErrCodeVendorUnreachable:
 		return "vendor unreachable (transport failure reported by claude)"
 	case ErrCodeVendorAPIError:
@@ -243,8 +250,12 @@ func suggestionFor(code string) string {
 		return "Run cc-fleet edit <vendor> --enable"
 	case ErrCodeFingerprintMissing, ErrCodeFingerprintStale:
 		return "Run the FINGERPRINT self-heal flow (native probe → cc-fleet refresh-fingerprint), then retry"
+	case ErrCodeProxyUnavailable:
+		return "Run cc-fleet codex login (and check the codex base_url port is free), then retry"
 	case ErrCodeKeyInvalid:
 		return "Rotate the vendor API key; do not retry until fixed"
+	case ErrCodeCloudflareBlocked:
+		return "Switch network/IP or retry later; the key is not the problem"
 	case ErrCodeInsufficientBalance:
 		return "Vendor out of credit — top up, switch vendor, or fall back to native Agent"
 	case ErrCodeRateLimited:

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ethanhq/cc-fleet/internal/childenv"
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 	"github.com/ethanhq/cc-fleet/internal/ids"
@@ -87,6 +88,11 @@ func LoadFingerprint() (*fingerprint.Fingerprint, error) { return loadFP() }
 // without relying on the process tree they run under.
 var detectLeadSession = leadsession.Detect
 
+// ensureVendorProxy ensures the codex conversion daemon for a codex provider
+// (a no-op for every other vendor). A package var so tests can stub it without
+// launching a real daemon process.
+var ensureVendorProxy = codexproxy.EnsureForVendor
+
 // Run executes the full subagent pipeline and returns a structured Result. Like
 // Spawn it NEVER returns a Go error — every failure path produces a Result.
 // It builds its own timeout context (self-contained, like Spawn).
@@ -146,6 +152,13 @@ func Run(req Request) Result {
 		return fail(ErrCodeFingerprintStale,
 			err.Error(),
 			req.Vendor, suggestionFor(ErrCodeFingerprintStale))
+	}
+
+	// 3b. For a codex provider, ensure the conversion daemon is up — after the
+	//     fingerprint gate, before the profile write, so a daemon failure is
+	//     fail-before-mutation and leaves no profile behind.
+	if err := ensureVendorProxy(v); err != nil {
+		return fail(ErrCodeProxyUnavailable, err.Error(), req.Vendor, suggestionFor(ErrCodeProxyUnavailable))
 	}
 
 	// 4. Ensure the per-vendor profile exists. Atomic temp+rename + idempotent,

--- a/internal/subagent/subagent_codex_test.go
+++ b/internal/subagent/subagent_codex_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 )
 
 // A codex daemon-ensure failure is fail-before-mutation: classified result and
@@ -18,13 +19,18 @@ func TestRun_CodexDaemonFailure_FailsBeforeProfileWrite(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Fake claude on PATH so the fingerprint gate passes and 3b is reached.
-	binDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(binDir, "claude"),
-		[]byte("#!/bin/sh\ncase \"$1\" in --version) echo \"2.1.150\";; esac\nexit 0\n"), 0o755); err != nil {
+	// Inject a fingerprint pointing at a placeholder binary so the gate passes and
+	// 3b is reached. The gate only os.Stats the path, so any file works; a PATH
+	// lookup would need a claude.exe on Windows.
+	binPath := filepath.Join(t.TempDir(), "claude-2.1.150")
+	if err := os.WriteFile(binPath, []byte("placeholder"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	origFP := loadFP
+	loadFP = func() (*fingerprint.Fingerprint, error) {
+		return &fingerprint.Fingerprint{BinaryPath: binPath}, nil
+	}
+	t.Cleanup(func() { loadFP = origFP })
 
 	dir := filepath.Join(xdg, "cc-fleet")
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/internal/subagent/subagent_codex_test.go
+++ b/internal/subagent/subagent_codex_test.go
@@ -1,0 +1,60 @@
+package subagent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// A codex daemon-ensure failure is fail-before-mutation: classified result and
+// no profile file left behind.
+func TestRun_CodexDaemonFailure_FailsBeforeProfileWrite(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Fake claude on PATH so the fingerprint gate passes and 3b is reached.
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "claude"),
+		[]byte("#!/bin/sh\ncase \"$1\" in --version) echo \"2.1.150\";; esac\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dir := filepath.Join(xdg, "cc-fleet")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	toml := `version = 1
+
+[codex]
+base_url        = "http://127.0.0.1:17222/"
+default_model   = "gpt-5.5"
+models_endpoint = "http://127.0.0.1:17222/v1/models"
+secret_backend  = "codex-oauth"
+secret_ref      = "codex-oauth"
+enabled         = true
+added_at        = 2026-06-08T05:00:00Z
+`
+	if err := os.WriteFile(filepath.Join(dir, "vendors.toml"), []byte(toml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ensureVendorProxy = func(*config.Vendor) error {
+		return errors.New("codex proxy did not become ready on port 17222")
+	}
+	t.Cleanup(func() { ensureVendorProxy = codexproxy.EnsureForVendor })
+
+	res := Run(Request{Vendor: "codex", Prompt: "hi", JSON: true})
+	if res.OK || res.ErrorCode != ErrCodeProxyUnavailable {
+		t.Fatalf("want CODEX_PROXY_UNAVAILABLE, got ok=%v code=%s msg=%s", res.OK, res.ErrorCode, res.ErrorMsg)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "profiles", "codex.json")); !os.IsNotExist(err) {
+		t.Fatalf("profile must not be written on daemon failure (stat err=%v)", err)
+	}
+}

--- a/internal/subagent/subagent_test.go
+++ b/internal/subagent/subagent_test.go
@@ -139,6 +139,14 @@ func TestClassify(t *testing.T) {
 		}
 	})
 
+	t.Run("403 cloudflare block → not key invalid", func(t *testing.T) {
+		js := `{"type":"result","is_error":true,"api_error_status":403,"result":"API Error: blocked by Cloudflare (codex backend rejected this IP/client)"}`
+		res := classify(req, "m", []byte(js), nil, 1, false, true)
+		if res.ErrorCode != ErrCodeCloudflareBlocked {
+			t.Fatalf("want CODEX_CLOUDFLARE_BLOCKED, got %s", res.ErrorCode)
+		}
+	})
+
 	t.Run("400 model rejection → model not found", func(t *testing.T) {
 		js := `{"type":"result","is_error":true,"api_error_status":400,"result":"model not found; supported names: a, b"}`
 		res := classify(req, "m", []byte(js), nil, 1, false, true)

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -194,21 +194,23 @@ type Result struct {
 const (
 	// Pre-flight failures (claude never launched). Reuse spawn's code spellings
 	// so the skill already recognizes them.
-	ErrCodeBadArgs            = "SUBAGENT_BAD_ARGS"   // --prompt/--prompt-file missing or both given (CLI layer)
-	ErrCodeUnknownVendor      = "UNKNOWN_VENDOR"      // vendor not in vendors.toml
-	ErrCodeVendorDisabled     = "VENDOR_DISABLED"     // enabled = false
-	ErrCodeFingerprintMissing = "FINGERPRINT_MISSING" // never captured → skill self-heal
-	ErrCodeFingerprintStale   = "FINGERPRINT_STALE"   // BinaryPath gone from disk
+	ErrCodeBadArgs            = "SUBAGENT_BAD_ARGS"       // --prompt/--prompt-file missing or both given (CLI layer)
+	ErrCodeUnknownVendor      = "UNKNOWN_VENDOR"          // vendor not in vendors.toml
+	ErrCodeVendorDisabled     = "VENDOR_DISABLED"         // enabled = false
+	ErrCodeFingerprintMissing = "FINGERPRINT_MISSING"     // never captured → skill self-heal
+	ErrCodeFingerprintStale   = "FINGERPRINT_STALE"       // BinaryPath gone from disk
+	ErrCodeProxyUnavailable   = "CODEX_PROXY_UNAVAILABLE" // codex conversion daemon could not be started
 
 	// Probe failure (only when --probe).
 	ErrCodeVendorUnreachable = "VENDOR_UNREACHABLE" // transport-layer failure
 
 	// Runtime failures parsed from claude's inner envelope.
-	ErrCodeKeyInvalid          = "KEY_INVALID"          // api_error_status 401/403
-	ErrCodeRateLimited         = "RATE_LIMITED"         // 429 (no balance signature)
-	ErrCodeInsufficientBalance = "INSUFFICIENT_BALANCE" // 429/402 + balance signature
-	ErrCodeModelNotFound       = "MODEL_NOT_FOUND"      // 400 + model-name rejection
-	ErrCodeVendorAPIError      = "VENDOR_API_ERROR"     // other is_error / 5xx / overloaded
+	ErrCodeKeyInvalid          = "KEY_INVALID"              // api_error_status 401/403
+	ErrCodeRateLimited         = "RATE_LIMITED"             // 429 (no balance signature)
+	ErrCodeInsufficientBalance = "INSUFFICIENT_BALANCE"     // 429/402 + balance signature
+	ErrCodeModelNotFound       = "MODEL_NOT_FOUND"          // 400 + model-name rejection
+	ErrCodeVendorAPIError      = "VENDOR_API_ERROR"         // other is_error / 5xx / overloaded
+	ErrCodeCloudflareBlocked   = "CODEX_CLOUDFLARE_BLOCKED" // 403 + Cloudflare edge-block signature
 
 	// cc-fleet layer.
 	ErrCodeTimeout        = "SUBAGENT_TIMEOUT"          // --timeout deadline fired before claude returned

--- a/internal/teardown/health.go
+++ b/internal/teardown/health.go
@@ -24,6 +24,7 @@ const (
 	errClassInsufficient = "insufficient_balance" // out of balance / quota
 	errClassAuth         = "auth"                 // HTTP 401/403 / bad key
 	errClassAPIError     = "api_error"            // generic vendor API failure
+	errClassCloudflare   = "cloudflare_blocked"   // Cloudflare edge blocked this IP/client
 )
 
 // captureFn is the seam tests substitute so they never need a live tmux server
@@ -89,8 +90,8 @@ func capturePane(socket, paneID string) (string, error) {
 //
 // It returns ONLY canonical strings — never any substring of the input — so a
 // key fragment in the pane can't leak into ps output (see AnnotateHealth's
-// SECURITY note). The signature matching + priority (out-of-balance > auth >
-// rate-limit > generic API error) live in internal/vendorclass so the
+// SECURITY note). The signature matching + priority (out-of-balance > cloudflare
+// > auth > rate-limit > generic API error) live in internal/vendorclass so the
 // subagent envelope classifier shares the exact same vocabulary; here we map
 // the shared class back onto teardown's status/error_class/detail triple.
 func classifyPaneOutput(text string) (status, errorClass, detail string) {
@@ -98,6 +99,9 @@ func classifyPaneOutput(text string) (status, errorClass, detail string) {
 	case vendorclass.ClassInsufficientBalance:
 		return statusError, errClassInsufficient,
 			"vendor account out of balance / quota — top up or switch vendor"
+	case vendorclass.ClassCloudflareBlocked:
+		return statusError, errClassCloudflare,
+			"vendor edge (Cloudflare) blocked this IP/client — switch network or retry later"
 	case vendorclass.ClassAuth:
 		return statusError, errClassAuth,
 			"vendor rejected the API key (HTTP 401/403) — rotate the key"

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
 
@@ -37,12 +38,13 @@ type formField struct {
 // parent model can drive it with key messages and unit tests can assert on it
 // without a running tea.Program.
 type form struct {
-	title  string
-	intro  string
-	submit string // submit button label, e.g. "Add" / "Save"
-	fields []formField
-	focus  int    // 0..len(fields)-1 = a field; len(fields) = the submit button
-	err    string // validation message shown beneath the form
+	title      string
+	intro      string
+	submit     string // submit button label, e.g. "Add" / "Save"
+	statusNote string // optional banner above the fields (e.g. the codex login source)
+	fields     []formField
+	focus      int    // 0..len(fields)-1 = a field; len(fields) = the submit button
+	err        string // validation message shown beneath the form
 }
 
 // newTextInput builds a textinput pre-populated with value. password fields
@@ -81,22 +83,79 @@ func newAddForm(t Template) form {
 	return f
 }
 
-// newEditForm builds the edit wizard, prefilled from the vendor's current
-// row. API-key rotation is intentionally out of scope here (it's a separate
-// secret-backend concern); edit covers the vendors.toml fields userops.Edit
-// accepts plus the enabled toggle.
+// newOpenAIAddForm builds the OpenAI-protocol add wizard. The loopback base_url
+// and the protocol are assigned on submit, so the form collects only the real
+// upstream + key; models_endpoint is prefilled from the upstream base.
+func newOpenAIAddForm(t OAITemplate) form {
+	models := ""
+	if t.UpstreamURL != "" {
+		models = strings.TrimRight(t.UpstreamURL, "/") + "/models"
+	}
+	f := form{
+		title:  "Add OpenAI provider",
+		intro:  "↑/↓ or tab move · enter advances · enter on [Add] submits · esc cancels",
+		submit: "Add",
+		fields: []formField{
+			{key: "name", label: "Name", kind: fieldText, input: newTextInput(t.Name, "provider id, e.g. openai", false)},
+			{key: "upstream_url", label: "Upstream URL", kind: fieldText, input: newTextInput(t.UpstreamURL, "https://api.openai.com/v1", false)},
+			{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(models, "https://…/v1/models", false)},
+			{key: "api_key", label: "API key", kind: fieldText, input: newTextInput("", "stored at <name>.key (mode 0600)", true)},
+			{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(t.DefaultModel, "model id", false)},
+		},
+	}
+	f.setFocus(0)
+	return f
+}
+
+// newCodexAddForm builds the minimal codex add wizard. The loopback base_url +
+// models_endpoint and the codex-oauth backend are assigned on submit; the
+// upstream is the fixed ChatGPT backend, so there is no key or URL to enter.
+func newCodexAddForm(defaultModel, statusNote string) form {
+	f := form{
+		title:      "Add codex provider",
+		intro:      "↑/↓ or tab move · enter on [Add] submits · esc cancels",
+		submit:     "Add",
+		statusNote: statusNote,
+		fields: []formField{
+			{key: "name", label: "Name", kind: fieldText, input: newTextInput("codex", "provider id", false)},
+			{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(defaultModel, "model id", false)},
+		},
+	}
+	f.setFocus(0)
+	return f
+}
+
+// newEditForm builds the edit wizard, prefilled from the vendor's current row.
+// The editable endpoint depends on the class: an Anthropic-native vendor edits its
+// real base_url; an openai-* vendor edits its real upstream_url (base_url is the
+// internal loopback daemon); codex has neither (its endpoints are loopback + the
+// upstream is the fixed ChatGPT backend). codex authenticates via OAuth, so it has
+// no API key set to rotate and the key manager is omitted.
 func newEditForm(v userops.VendorView) form {
+	var fields []formField
+	switch v.Protocol {
+	case config.ProtocolOpenAIChat, config.ProtocolOpenAIResponses:
+		fields = append(fields,
+			formField{key: "upstream_url", label: "Upstream URL", kind: fieldText, input: newTextInput(v.UpstreamURL, "https://api.openai.com/v1", false)},
+			formField{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(v.ModelsEndpoint, "https://…/v1/models", false)})
+	case config.ProtocolCodexOAuth:
+		// loopback base_url + models_endpoint are internal; nothing to edit there.
+	default:
+		fields = append(fields,
+			formField{key: "base_url", label: "Base URL", kind: fieldText, input: newTextInput(v.BaseURL, "https://…/anthropic", false)},
+			formField{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(v.ModelsEndpoint, "https://…/v1/models", false)})
+	}
+	fields = append(fields,
+		formField{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(v.DefaultModel, "model id", false)},
+		formField{key: "enabled", label: "Enabled", kind: fieldToggle, on: v.Enabled})
+	if v.SecretBackend != config.CodexOAuthBackend {
+		fields = append(fields, formField{key: "manage_keys", label: "Manage API keys →", kind: fieldAction})
+	}
 	f := form{
 		title:  "Edit provider: " + v.Name,
 		intro:  "↑/↓ or tab move · space toggles Enabled · enter on [Save] submits · esc cancels",
 		submit: "Save",
-		fields: []formField{
-			{key: "base_url", label: "Base URL", kind: fieldText, input: newTextInput(v.BaseURL, "https://…/anthropic", false)},
-			{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(v.ModelsEndpoint, "https://…/v1/models", false)},
-			{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(v.DefaultModel, "model id", false)},
-			{key: "enabled", label: "Enabled", kind: fieldToggle, on: v.Enabled},
-			{key: "manage_keys", label: "Manage API keys →", kind: fieldAction},
-		},
+		fields: fields,
 	}
 	f.setFocus(0)
 	return f
@@ -223,6 +282,8 @@ func cardKey(key string) string {
 	switch key {
 	case "base_url":
 		return "base url"
+	case "upstream_url":
+		return "upstream"
 	case "models_endpoint":
 		return "models"
 	case "default_model":
@@ -239,7 +300,7 @@ func cardKey(key string) string {
 // of "key  value" rows (the edit form adds the live status line its enabled toggle drives)
 // — so entering edit barely reshapes the pane. Text-field values always render through
 // input.View() (the focused input draws its cursor; a password field stays bullet-masked).
-func (f form) viewLines() []string {
+func (f form) viewLines(width int) []string {
 	var lines []string
 	// The edit form's enabled toggle mirrors the preview card's status line, live.
 	for _, fld := range f.fields {
@@ -248,29 +309,37 @@ func (f form) viewLines() []string {
 		}
 		status := okStyle.Render("● enabled")
 		if !fld.on {
-			status = faintStyle.Render("○ disabled")
+			status = liveStyle.Render("○ disabled")
 		}
 		if dm := f.value("default_model"); dm != "" {
-			status += faintStyle.Render(" · " + trunc(dm, 28))
+			status += liveStyle.Render(" · " + trunc(dm, 28))
 		}
 		lines = append(lines, status, "")
 		break
 	}
-	// The Note section sits ABOVE the fields and is always present (a fixed slot —
-	// moving focus swaps its text, never reflows the card); the focused field's
-	// note renders bright, the empty placeholder faint.
-	note := faintStyle.Render("—")
-	if f.focus < len(f.fields) {
-		switch fld := f.fields[f.focus]; {
-		case fld.key == "default_model" && f.value("models_endpoint") != "":
-			note = contentStyle.Render("enter picks from the provider's model list")
-		case fld.kind == fieldToggle:
-			note = contentStyle.Render("enter / space toggles")
-		case fld.key == "manage_keys":
-			note = contentStyle.Render("enter opens the key manager")
+	// The Note section sits ABOVE the fields. A form-level statusNote (e.g. which
+	// codex login a codex provider reuses) takes it and wraps to the pane width;
+	// otherwise it shows the focused field's contextual hint.
+	lines = append(lines, contentStyle.Render("Note"))
+	if f.statusNote != "" {
+		for _, w := range wrapTo(f.statusNote, width-2) {
+			lines = append(lines, " "+okStyle.Render(w))
 		}
+	} else {
+		note := faintStyle.Render("—")
+		if f.focus < len(f.fields) {
+			switch fld := f.fields[f.focus]; {
+			case fld.key == "default_model" && f.value("models_endpoint") != "":
+				note = contentStyle.Render("enter picks from the provider's model list")
+			case fld.kind == fieldToggle:
+				note = contentStyle.Render("enter / space toggles")
+			case fld.key == "manage_keys":
+				note = contentStyle.Render("enter opens the key manager")
+			}
+		}
+		lines = append(lines, " "+note)
 	}
-	lines = append(lines, contentStyle.Render("Note"), " "+note, "", faintStyle.Render("Config"))
+	lines = append(lines, "", faintStyle.Render("Config"))
 	for i, fld := range f.fields {
 		focused := i == f.focus
 		key := fmt.Sprintf("%-8s", cardKey(fld.key))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/models"
 	"github.com/ethanhq/cc-fleet/internal/onboarding"
@@ -44,6 +45,24 @@ const (
 	screenKeys      // EDIT form → "Manage API keys →": per-vendor multi-key manager
 	screenSetupTmux // first-run tmux setup nudge; shown before agent-teams/hub
 	screenSetup     // first-run agent-teams setup nudge; shown before the hub
+	screenCodexAuth // CLI-auth → codex: consent → device-code login
+)
+
+// addCategory is the provider class a picker row belongs to.
+type addCategory int
+
+const (
+	addCatAnthropic addCategory = iota // Anthropic-native API (today's templates)
+	addCatOpenAI                       // OpenAI-protocol API (chat / responses)
+	addCatCLI                          // CLI auth (codex)
+)
+
+// codexAuthStage is the sub-state of screenCodexAuth.
+type codexAuthStage int
+
+const (
+	codexAuthConsent codexAuthStage = iota // risk notice; enter accepts
+	codexAuthDevice                        // device-code shown; polling for authorization
 )
 
 // formMode records whether the active form is an add or an edit so submit
@@ -85,8 +104,17 @@ type Model struct {
 	vendorsErr   error
 	vendorCursor int
 
-	// Add-wizard template picker.
-	tmplCursor int
+	// Add-wizard: the single grouped picker (cursor over the flat selectable rows)
+	// and the protocol the chosen row implies (carried into submitAdd).
+	tmplCursor  int
+	addProtocol string
+
+	// screenCodexAuth: consent → device-code login session. codexAuthEpoch tags
+	// each login attempt so a prior visit's async msgs (esc then re-enter) drop.
+	codexAuthStage codexAuthStage
+	codexAuth      *codexproxy.LoginSession
+	codexAuthErr   string
+	codexAuthEpoch int
 
 	// Agents Board (screenSpawn): live teammates, workflow runs, and async subagent
 	// jobs in one master-detail board. asMode re-roots the levels (projects → sessions →
@@ -1162,6 +1190,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case vendorsMsg:
 		m.loading = false
 		m.vendors = msg.vendors
+		// Group the list by wire class (stable, so the name order within a class
+		// that List returns is preserved).
+		sort.SliceStable(m.vendors, func(i, j int) bool {
+			return vendorClassRank(m.vendors[i].Protocol) < vendorClassRank(m.vendors[j].Protocol)
+		})
 		m.vendorsErr = msg.err
 		// The cursor may also rest on the trailing "+ Add provider…" row at index
 		// len(vendors); clamp to that, not len-1.
@@ -1401,6 +1434,48 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case codexAuthBegunMsg:
+		// Drop a begin from a prior login attempt (esc then re-enter starts a new
+		// epoch); the owningScreen gate alone can't tell visits apart.
+		if msg.epoch != m.codexAuthEpoch {
+			return m, nil
+		}
+		m.loading = false
+		if msg.err != nil {
+			m.codexAuthErr = msg.err.Error()
+			return m, nil
+		}
+		m.codexAuth = msg.session
+		return m, pollCodexAuthCmd(m.codexAuthEpoch, msg.session)
+
+	case codexAuthPollMsg:
+		if msg.epoch != m.codexAuthEpoch {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.codexAuthErr = msg.err.Error()
+			m.codexAuth = nil
+			return m, nil
+		}
+		if msg.done {
+			m.codexAuth = nil
+			m.form = newCodexAddForm(codexproxy.ScanDefaultModel("gpt-5.5"), codexSourceNote(codexproxy.StatusReport()))
+			m.formMode = modeAdd
+			m.addProtocol = config.ProtocolCodexOAuth
+			m.screen = screenForm
+			return m, textinput.Blink
+		}
+		if m.codexAuth == nil {
+			return m, nil
+		}
+		return m, codexAuthTickCmd(m.codexAuthEpoch, m.codexAuth.Interval())
+
+	case codexAuthTickMsg:
+		if msg.epoch != m.codexAuthEpoch || m.codexAuth == nil || m.screen != screenCodexAuth {
+			return m, nil
+		}
+		return m, pollCodexAuthCmd(m.codexAuthEpoch, m.codexAuth)
+
 	case keysetMsg:
 		if msg.err != nil {
 			m.keyErr = msg.err.Error()
@@ -1465,6 +1540,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateSetup(msg)
 		case screenSetupTmux:
 			return m.updateSetupTmux(msg)
+		case screenCodexAuth:
+			return m.updateCodexAuth(msg)
 		}
 	}
 	return m, nil
@@ -1531,6 +1608,7 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.form = newEditForm(v)
 		m.formMode = modeEdit
 		m.editName = v.Name
+		m.addProtocol = v.Protocol // the form's provider class (drives the codex model picker)
 		m.screen = screenForm
 		return m, textinput.Blink
 	case "d":
@@ -2654,8 +2732,55 @@ func saveWorkflowCmd(runID, name, sessionID, description string, epoch int) tea.
 	}
 }
 
+// addItem is one selectable row of the grouped add picker: a provider class plus
+// the seed it implies (a Templates index, an OAITemplates index, or neither for a
+// Custom / codex row).
+type addItem struct {
+	label string
+	class addCategory
+	tIdx  int // Templates index, or -1
+	oIdx  int // OAITemplates index, or -1
+}
+
+type addGroup struct {
+	header string
+	items  []addItem
+}
+
+// addGroups builds the grouped add picker: every provider class with its seeds
+// under one header, so a provider is chosen in a single screen.
+func addGroups() []addGroup {
+	a := addGroup{header: "Anthropic-protocol API  (DeepSeek / GLM / Kimi / Qwen / …)"}
+	for i := range Templates {
+		a.items = append(a.items, addItem{Templates[i].Label, addCatAnthropic, i, -1})
+	}
+	a.items = append(a.items, addItem{"Custom (fill everything manually)", addCatAnthropic, -1, -1})
+
+	o := addGroup{header: "OpenAI-protocol API  (OpenAI / Groq / Together / vLLM …)"}
+	for i := range OAITemplates {
+		o.items = append(o.items, addItem{OAITemplates[i].Label, addCatOpenAI, -1, i})
+	}
+	o.items = append(o.items, addItem{"Custom OpenAI-compatible (fill everything manually)", addCatOpenAI, -1, -1})
+
+	c := addGroup{header: "CLI auth  (reuse a ChatGPT subscription via codex)"}
+	c.items = append(c.items, addItem{"Codex", addCatCLI, -1, -1})
+
+	return []addGroup{a, o, c}
+}
+
+// addItems flattens the groups to the selectable rows the cursor walks.
+func addItems() []addItem {
+	var xs []addItem
+	for _, g := range addGroups() {
+		xs = append(xs, g.items...)
+	}
+	return xs
+}
+
+// updatePickTemplate drives the single grouped add picker: one cursor over every
+// provider across all three classes; enter/→ opens the chosen class's add form.
 func (m Model) updatePickTemplate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	n := len(Templates) + 1 // + synthetic "Custom" row
+	items := addItems()
 	switch msg.String() {
 	case "esc", "q", "left":
 		return m.toList()
@@ -2664,20 +2789,180 @@ func (m Model) updatePickTemplate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.tmplCursor--
 		}
 	case "down", "j":
-		if m.tmplCursor < n-1 {
+		if m.tmplCursor < len(items)-1 {
 			m.tmplCursor++
 		}
-	case "enter":
+	case "enter", "right":
+		if m.tmplCursor >= 0 && m.tmplCursor < len(items) {
+			return m.chooseAddItem(items[m.tmplCursor])
+		}
+	}
+	return m, nil
+}
+
+// chooseAddItem opens the add form (or the codex auth flow) for a picked row.
+func (m Model) chooseAddItem(it addItem) (tea.Model, tea.Cmd) {
+	switch it.class {
+	case addCatCLI:
+		return m.enterCodexFlow()
+	case addCatOpenAI:
+		var t OAITemplate
+		protocol := config.ProtocolOpenAIChat // a Custom entry defaults to Chat
+		if it.oIdx >= 0 {
+			t = OAITemplates[it.oIdx]
+			protocol = t.Protocol
+		}
+		m.form = newOpenAIAddForm(t)
+		m.addProtocol = protocol
+	default: // addCatAnthropic
 		var t Template // zero value = Custom (blank fields)
-		if m.tmplCursor < len(Templates) {
-			t = Templates[m.tmplCursor]
+		if it.tIdx >= 0 {
+			t = Templates[it.tIdx]
 		}
 		m.form = newAddForm(t)
+		m.addProtocol = ""
+	}
+	m.formMode = modeAdd
+	m.screen = screenForm
+	return m, textinput.Blink
+}
+
+// enterCodexFlow opens the codex add form when a usable credential source already
+// exists (reusing the codex CLI login, or cc-fleet's own), naming the source so the
+// user sees no key is needed; with no source it routes to the consent + device-code
+// login screen.
+func (m Model) enterCodexFlow() (tea.Model, tea.Cmd) {
+	if st := codexproxy.StatusReport(); st.Active != "none" {
+		m.form = newCodexAddForm(codexproxy.ScanDefaultModel("gpt-5.5"), codexSourceNote(st))
 		m.formMode = modeAdd
+		m.addProtocol = config.ProtocolCodexOAuth
 		m.screen = screenForm
 		return m, textinput.Blink
 	}
+	m.screen = screenCodexAuth
+	m.codexAuthStage = codexAuthConsent
+	m.codexAuthErr = ""
 	return m, nil
+}
+
+// vendorClassRank and vendorClassHeader group the providers list by wire class:
+// Anthropic-protocol (0) < OpenAI-protocol (1) < CLI auth (2).
+func vendorClassRank(protocol string) int {
+	switch protocol {
+	case config.ProtocolOpenAIChat, config.ProtocolOpenAIResponses:
+		return 1
+	case config.ProtocolCodexOAuth:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func vendorClassHeader(protocol string) string {
+	switch protocol {
+	case config.ProtocolOpenAIChat, config.ProtocolOpenAIResponses:
+		return "OpenAI-protocol"
+	case config.ProtocolCodexOAuth:
+		return "CLI auth"
+	default:
+		return "Anthropic-protocol"
+	}
+}
+
+// codexStaticModelList wraps the static codex model ids as the picker's model
+// list (codex has no live models endpoint to probe at add time).
+func codexStaticModelList() []models.Model {
+	ids := codexproxy.StaticModels()
+	out := make([]models.Model, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, models.Model{ID: id})
+	}
+	return out
+}
+
+// codexSourceNote names the login a codex provider will use, shown on the add form.
+func codexSourceNote(st codexproxy.CredStatus) string {
+	switch st.Active {
+	case "cli-ride":
+		return "reuses the codex CLI login (account " + st.Account + ") — no key needed; if it stops working, run: cc-fleet codex login"
+	case "own":
+		return "uses cc-fleet's own codex login (account " + st.Account + ")"
+	default:
+		return ""
+	}
+}
+
+// updateCodexAuth drives the codex CLI-auth screen: a consent gate, then a
+// device-code login polled on its own interval until the user authorizes.
+func (m Model) updateCodexAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.codexAuthStage {
+	case codexAuthConsent:
+		switch msg.String() {
+		case "esc", "q", "left", "n":
+			m.screen = screenPickTemplate
+			return m, nil
+		case "enter", "y":
+			m.codexAuthStage = codexAuthDevice
+			m.codexAuthErr = ""
+			m.loading = true
+			m.codexAuthEpoch++ // a fresh login attempt; a prior visit's in-flight msgs fail the gate
+			return m, beginCodexAuthCmd(m.codexAuthEpoch)
+		}
+	case codexAuthDevice:
+		if s := msg.String(); s == "esc" || s == "q" {
+			m.codexAuth = nil
+			m.loading = false
+			return m.toList()
+		}
+	}
+	return m, nil
+}
+
+// codexAuthBegunMsg carries a started device-code session (URL + code to show);
+// codexAuthPollMsg an authorization poll result; codexAuthTickMsg the interval to
+// poll again. All carry the login attempt's epoch and are owned by screenCodexAuth,
+// so a result from a prior visit (esc then re-enter) or from after the user left
+// the screen is dropped.
+type codexAuthBegunMsg struct {
+	epoch   int
+	session *codexproxy.LoginSession
+	err     error
+}
+
+func (codexAuthBegunMsg) owningScreen() screen { return screenCodexAuth }
+
+type codexAuthPollMsg struct {
+	epoch int
+	done  bool
+	err   error
+}
+
+func (codexAuthPollMsg) owningScreen() screen { return screenCodexAuth }
+
+type codexAuthTickMsg struct{ epoch int }
+
+func (codexAuthTickMsg) owningScreen() screen { return screenCodexAuth }
+
+func beginCodexAuthCmd(epoch int) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		s, err := codexproxy.BeginDeviceLogin(ctx)
+		return codexAuthBegunMsg{epoch: epoch, session: s, err: err}
+	}
+}
+
+func pollCodexAuthCmd(epoch int, s *codexproxy.LoginSession) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		done, err := s.Poll(ctx)
+		return codexAuthPollMsg{epoch: epoch, done: done, err: err}
+	}
+}
+
+func codexAuthTickCmd(epoch int, d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return codexAuthTickMsg{epoch: epoch} })
 }
 
 func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -2700,9 +2985,22 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.keys = nil
 		return m, loadKeysetCmd(m.editName)
 	}
-	// Enter on the Default model field opens the model picker instead of
-	// advancing ("pick, don't type"). It requires a models_endpoint to hit;
-	// custom vendors without one fall through to manual text entry.
+	// Enter on the Default model field opens the model picker ("pick, don't type").
+	// codex has no probeable models endpoint (its /v1/models is the lazily-started
+	// loopback daemon), so it seeds the picker from the static codex model list
+	// instead of a fetch — for both add and edit.
+	if msg.String() == "enter" && m.form.focusedKey() == "default_model" &&
+		m.addProtocol == config.ProtocolCodexOAuth {
+		m.screen = screenModelPick
+		m.loading = false
+		m.modelList = codexStaticModelList()
+		m.modelsErr = nil
+		m.modelCursor = 0
+		m.modelFilter = ""
+		return m, nil
+	}
+	// Other providers hit their models_endpoint; custom vendors without one fall
+	// through to manual text entry.
 	if msg.String() == "enter" && m.form.focusedKey() == "default_model" &&
 		m.form.value("models_endpoint") != "" {
 		m.screen = screenModelPick
@@ -2735,7 +3033,7 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) updateModelPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	filtered := m.filteredModels()
 	switch msg.String() {
-	case "esc":
+	case "esc", "left":
 		m.screen = screenForm
 		return m, textinput.Blink
 	case "enter":
@@ -3020,10 +3318,94 @@ func (m Model) keyLabel(idx int) string {
 	return fmt.Sprintf("key%d", idx+1)
 }
 
-// submitAdd validates the add form and dispatches userops.Add. Required-field
-// gaps are surfaced inline (no command) so the user can fix them in place;
-// vendor-side errors (bad key, unreachable) come back via opDoneMsg.
+// submitAdd dispatches the add form by provider class. Required-field gaps are
+// surfaced inline (no command) so the user can fix them in place; vendor-side
+// errors (bad key, unreachable) come back via opDoneMsg.
 func (m Model) submitAdd() (tea.Model, tea.Cmd) {
+	switch m.addProtocol {
+	case config.ProtocolCodexOAuth:
+		return m.submitAddCodex()
+	case config.ProtocolOpenAIChat, config.ProtocolOpenAIResponses:
+		return m.submitAddOpenAI()
+	default:
+		return m.submitAddAnthropic()
+	}
+}
+
+// submitAddOpenAI commits an OpenAI-protocol provider: the loopback base_url is
+// assigned from a free daemon port; the real upstream + key ride the form.
+func (m Model) submitAddOpenAI() (tea.Model, tea.Cmd) {
+	name := m.form.value("name")
+	upstream := m.form.value("upstream_url")
+	modelsEndpoint := m.form.value("models_endpoint")
+	apiKey := m.form.value("api_key")
+	defaultModel := m.form.value("default_model")
+
+	if missing := missingLabels(map[string]string{
+		"Name":            name,
+		"Upstream URL":    upstream,
+		"Models endpoint": modelsEndpoint,
+		"API key":         apiKey,
+		"Default model":   defaultModel,
+	}, []string{"Name", "Upstream URL", "Models endpoint", "API key", "Default model"}); len(missing) > 0 {
+		m.form.err = "required: " + strings.Join(missing, ", ")
+		return m, nil
+	}
+	port, err := codexproxy.ChoosePort(0)
+	if err != nil {
+		m.form.err = err.Error()
+		return m, nil
+	}
+	m.form.err = ""
+	m.loading = true
+	return m, addVendorCmd(userops.AddRequest{
+		Name:           name,
+		BaseURL:        fmt.Sprintf("http://127.0.0.1:%d/", port),
+		ModelsEndpoint: modelsEndpoint,
+		DefaultModel:   defaultModel,
+		SecretBackend:  "file",
+		SecretRef:      name + ".key",
+		Protocol:       m.addProtocol,
+		UpstreamURL:    upstream,
+		APIKey:         apiKey,
+		Enabled:        true,
+	})
+}
+
+// submitAddCodex commits a codex provider: a free loopback port + the codex-oauth
+// backend; the upstream is the fixed ChatGPT backend, so there is no key.
+func (m Model) submitAddCodex() (tea.Model, tea.Cmd) {
+	name := m.form.value("name")
+	defaultModel := m.form.value("default_model")
+	if missing := missingLabels(map[string]string{
+		"Name":          name,
+		"Default model": defaultModel,
+	}, []string{"Name", "Default model"}); len(missing) > 0 {
+		m.form.err = "required: " + strings.Join(missing, ", ")
+		return m, nil
+	}
+	port, err := codexproxy.ChoosePort(0)
+	if err != nil {
+		m.form.err = err.Error()
+		return m, nil
+	}
+	base := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	m.form.err = ""
+	m.loading = true
+	return m, addVendorCmd(userops.AddRequest{
+		Name:           name,
+		BaseURL:        base,
+		ModelsEndpoint: base + "v1/models",
+		DefaultModel:   defaultModel,
+		SecretBackend:  codexproxy.SecretBackend,
+		SecretRef:      codexproxy.SecretRef,
+		Protocol:       config.ProtocolCodexOAuth,
+		Enabled:        true,
+	})
+}
+
+// submitAddAnthropic validates the Anthropic-native add form and dispatches Add.
+func (m Model) submitAddAnthropic() (tea.Model, tea.Cmd) {
 	name := m.form.value("name")
 	baseURL := m.form.value("base_url")
 	modelsEndpoint := m.form.value("models_endpoint")
@@ -3057,29 +3439,38 @@ func (m Model) submitAdd() (tea.Model, tea.Cmd) {
 
 // submitEdit validates the edit form and dispatches userops.Edit.
 func (m Model) submitEdit() (tea.Model, tea.Cmd) {
-	baseURL := m.form.value("base_url")
-	modelsEndpoint := m.form.value("models_endpoint")
 	defaultModel := m.form.value("default_model")
 	enabled := m.form.boolValue("enabled")
+	req := userops.EditRequest{Name: m.editName, DefaultModel: &defaultModel, Enabled: &enabled}
 
-	if missing := missingLabels(map[string]string{
-		"Base URL":        baseURL,
-		"Models endpoint": modelsEndpoint,
-		"Default model":   defaultModel,
-	}, []string{"Base URL", "Models endpoint", "Default model"}); len(missing) > 0 {
+	// The editable endpoint follows the form's class (newEditForm): openai-* edits
+	// upstream_url, codex edits neither (loopback/internal), others edit base_url.
+	required := map[string]string{"Default model": defaultModel}
+	order := []string{"Default model"}
+	switch m.addProtocol { // set to the edited vendor's protocol on edit entry
+	case config.ProtocolOpenAIChat, config.ProtocolOpenAIResponses:
+		upstream := m.form.value("upstream_url")
+		models := m.form.value("models_endpoint")
+		req.UpstreamURL, req.ModelsEndpoint = &upstream, &models
+		required["Upstream URL"], required["Models endpoint"] = upstream, models
+		order = append([]string{"Upstream URL", "Models endpoint"}, order...)
+	case config.ProtocolCodexOAuth:
+		// only default_model + enabled are editable
+	default:
+		baseURL := m.form.value("base_url")
+		models := m.form.value("models_endpoint")
+		req.BaseURL, req.ModelsEndpoint = &baseURL, &models
+		required["Base URL"], required["Models endpoint"] = baseURL, models
+		order = append([]string{"Base URL", "Models endpoint"}, order...)
+	}
+
+	if missing := missingLabels(required, order); len(missing) > 0 {
 		m.form.err = "required: " + strings.Join(missing, ", ")
 		return m, nil
 	}
-
 	m.form.err = ""
 	m.loading = true
-	return m, editVendorCmd(userops.EditRequest{
-		Name:           m.editName,
-		BaseURL:        &baseURL,
-		ModelsEndpoint: &modelsEndpoint,
-		DefaultModel:   &defaultModel,
-		Enabled:        &enabled,
-	})
+	return m, editVendorCmd(req)
 }
 
 // missingLabels returns the labels (in the given order) whose value is empty.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -183,7 +183,7 @@ func TestAddRowOpensWizardAndPrefills(t *testing.T) {
 		t.Fatalf("enter on Add row: screen = %d, want screenPickTemplate", m.screen)
 	}
 	want := Templates[0]
-	m, _ = press(t, m, "enter")
+	m, _ = press(t, m, "enter") // choose DeepSeek -> add form
 	if m.screen != screenForm || m.formMode != modeAdd {
 		t.Fatalf("screen=%d formMode=%d, want screenForm+modeAdd", m.screen, m.formMode)
 	}
@@ -207,7 +207,7 @@ func TestAddRowOpensWizardAndPrefills(t *testing.T) {
 
 func TestAddFlowCustomIsBlank(t *testing.T) {
 	m := NewModel()
-	m, _ = press(t, m, "enter") // Add row -> template picker
+	m, _ = press(t, m, "enter") // Add row -> grouped picker (cursor 0 = DeepSeek)
 	for i := 0; i < len(Templates); i++ {
 		m, _ = press(t, m, "down") // walk to the synthetic Custom row
 	}
@@ -223,7 +223,7 @@ func TestAddFlowCustomIsBlank(t *testing.T) {
 
 func TestAddFormValidationBlocksEmptySubmit(t *testing.T) {
 	m := NewModel()
-	m, _ = press(t, m, "enter") // Add row -> template picker
+	m, _ = press(t, m, "enter") // Add row -> grouped picker (cursor 0 = DeepSeek)
 	for i := 0; i < len(Templates); i++ {
 		m, _ = press(t, m, "down") // Custom -> all fields empty
 	}
@@ -246,7 +246,7 @@ func TestAddFormValidationBlocksEmptySubmit(t *testing.T) {
 
 func TestAddFormTypingAndSubmitDispatches(t *testing.T) {
 	m := NewModel()
-	m, _ = press(t, m, "enter") // Add row -> template picker
+	m, _ = press(t, m, "enter") // Add row -> grouped picker (cursor 0 = DeepSeek)
 	m, _ = press(t, m, "enter") // choose Templates[0] -> form (prefilled)
 
 	// Focus the api_key field (index 3) and type a key.
@@ -391,8 +391,8 @@ func TestTemplatesSeedTable(t *testing.T) {
 func addFormOnDeepseek(t *testing.T) Model {
 	t.Helper()
 	m := NewModel()             // no vendors -> cursor 0 == Add row
-	m, _ = press(t, m, "enter") // template picker (cursor 0 = DeepSeek)
-	m, _ = press(t, m, "enter") // choose -> add form
+	m, _ = press(t, m, "enter") // +Add -> grouped picker (cursor 0 = DeepSeek)
+	m, _ = press(t, m, "enter") // choose DeepSeek -> add form
 	return m
 }
 
@@ -509,7 +509,7 @@ func TestModelPickerErrorFallsBackToManual(t *testing.T) {
 
 func TestModelPickerSkippedWhenNoEndpoint(t *testing.T) {
 	m := NewModel()
-	m, _ = press(t, m, "enter") // Add row -> template picker
+	m, _ = press(t, m, "enter") // Add row -> grouped picker (cursor 0 = DeepSeek)
 	for i := 0; i < len(Templates); i++ {
 		m, _ = press(t, m, "down") // walk to the synthetic Custom row
 	}

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -78,6 +78,10 @@ func TestAddPicker_CodexRowNoSourceGoesToConsent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())            // no ~/.codex
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no own login
 	m := NewModel()
+	// The blank config dir also reads as a fresh install with no tmux, so NewModel
+	// opens on the first-run setup nudge; this test exercises the picker, so start
+	// from the provider list.
+	m.screen, m.loading = screenList, true
 	m, _ = press(t, m, "enter")
 	m = pressN(t, m, "down", codexIdx()) // to the codex row
 	m, _ = press(t, m, "enter")

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -1,0 +1,278 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/userops"
+)
+
+// Flat-picker item indices (cursor walks the selectable rows across all groups).
+func firstOpenAIIdx() int { return len(Templates) + 1 } // after the Anthropic seeds + their Custom
+func codexIdx() int       { return len(Templates) + 1 + len(OAITemplates) + 1 }
+
+func pressN(t *testing.T, m Model, key string, n int) Model {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		m, _ = press(t, m, key)
+	}
+	return m
+}
+
+// The grouped picker is one screen: enter (or →) on a row opens its class's form,
+// with no intermediate class step.
+func TestAddPicker_RightKeyOpensForm(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter") // +Add -> grouped picker (cursor 0 = DeepSeek)
+	if m.screen != screenPickTemplate {
+		t.Fatalf("screen = %d, want screenPickTemplate", m.screen)
+	}
+	m, _ = press(t, m, "right") // → descends straight to the form (no class step)
+	if m.screen != screenForm || m.addProtocol != "" {
+		t.Fatalf("right on a row: screen=%d addProtocol=%q", m.screen, m.addProtocol)
+	}
+	if m.form.value("name") != Templates[0].Name {
+		t.Fatalf("form name = %q, want %q", m.form.value("name"), Templates[0].Name)
+	}
+}
+
+// Selecting an OpenAI row lands on the OpenAI add form with the protocol carried
+// and upstream_url prefilled.
+func TestAddPicker_OpenAIRowCarriesProtocol(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m = pressN(t, m, "down", firstOpenAIIdx()) // to the first OpenAI row (Responses)
+	m, _ = press(t, m, "enter")
+	if m.screen != screenForm || m.addProtocol != config.ProtocolOpenAIResponses {
+		t.Fatalf("screen=%d addProtocol=%q", m.screen, m.addProtocol)
+	}
+	if got := m.form.value("upstream_url"); got != "https://api.openai.com/v1" {
+		t.Fatalf("upstream_url prefill = %q", got)
+	}
+}
+
+func TestAddPicker_OpenAISubmitValidatesThenDispatches(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m = pressN(t, m, "down", firstOpenAIIdx())
+	m, _ = press(t, m, "enter") // OpenAI Responses form (key/model blank)
+
+	m = pressN(t, m, "down", len(m.form.fields)) // jump to submit
+	m, cmd := press(t, m, "enter")
+	if cmd != nil || m.form.err == "" {
+		t.Fatalf("incomplete OpenAI submit should block: cmd=%v err=%q", cmd, m.form.err)
+	}
+	m.form.setValue("api_key", "sk-openai-test")
+	m.form.setValue("default_model", "gpt-x")
+	m, cmd = press(t, m, "enter")
+	if cmd == nil || !m.loading {
+		t.Fatalf("complete OpenAI submit should dispatch: cmd=%v loading=%v", cmd, m.loading)
+	}
+}
+
+// With no usable codex source, the codex row routes to the consent screen; accept
+// moves to the device-code stage; esc cancels back to the provider list.
+func TestAddPicker_CodexRowNoSourceGoesToConsent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())            // no ~/.codex
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no own login
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m = pressN(t, m, "down", codexIdx()) // to the codex row
+	m, _ = press(t, m, "enter")
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent {
+		t.Fatalf("no-source codex: screen=%d stage=%d", m.screen, m.codexAuthStage)
+	}
+	m, cmd := press(t, m, "enter") // accept consent -> device stage
+	if m.codexAuthStage != codexAuthDevice || cmd == nil {
+		t.Fatalf("consent accept: stage=%d cmd=%v", m.codexAuthStage, cmd)
+	}
+	m, _ = press(t, m, "esc")
+	if m.screen != screenList {
+		t.Fatalf("esc from device stage: screen=%d, want screenList", m.screen)
+	}
+}
+
+// A codexAuthBegunMsg from a prior login attempt (esc then re-enter starts a new
+// epoch) is dropped, never installing a stale session or starting a poll.
+func TestCodexAuth_StaleEpochBegunDropped(t *testing.T) {
+	m := NewModel()
+	m.screen = screenCodexAuth
+	m.codexAuthStage = codexAuthDevice
+	m.codexAuthEpoch = 2 // the current attempt
+	nm, cmd := step(t, m, codexAuthBegunMsg{epoch: 1})
+	if cmd != nil {
+		t.Fatal("a begin from a stale epoch must be dropped (no poll scheduled)")
+	}
+	if nm.codexAuth != nil {
+		t.Fatalf("stale begin must not install a session: %v", nm.codexAuth)
+	}
+}
+
+// The codex form's source note renders inside the Note section (after the "Note"
+// header, before "Config"), wrapped to the pane — never as a banner above it.
+func TestCodexFormNoteInNoteSection(t *testing.T) {
+	f := newCodexAddForm("gpt-5.5", "reuses the codex CLI login (account …abc) — no key needed")
+	lines := f.viewLines(48)
+	noteHdr, cfgHdr, body := -1, -1, -1
+	for i, l := range lines {
+		switch {
+		case strings.Contains(l, "Note"):
+			noteHdr = i
+		case strings.Contains(l, "Config"):
+			cfgHdr = i
+		case strings.Contains(l, "reuses the codex CLI login"):
+			body = i
+		}
+	}
+	if noteHdr < 0 || cfgHdr < 0 || body < 0 {
+		t.Fatalf("missing section/body: note=%d config=%d body=%d", noteHdr, cfgHdr, body)
+	}
+	if !(noteHdr < body && body < cfgHdr) {
+		t.Fatalf("note body must sit between Note and Config: note=%d body=%d config=%d", noteHdr, body, cfgHdr)
+	}
+}
+
+// On the codex add form, enter on the default-model field opens the model picker
+// seeded with the static codex model list (no live endpoint to probe at add time).
+func TestCodexForm_DefaultOpensStaticModelPicker(t *testing.T) {
+	m := NewModel()
+	m.form = newCodexAddForm("gpt-5.5", "")
+	m.formMode = modeAdd
+	m.addProtocol = config.ProtocolCodexOAuth
+	m.screen = screenForm
+
+	m, _ = press(t, m, "down") // name -> default_model
+	if m.form.focusedKey() != "default_model" {
+		t.Fatalf("focus = %q, want default_model", m.form.focusedKey())
+	}
+	m, cmd := press(t, m, "enter")
+	if m.screen != screenModelPick {
+		t.Fatalf("screen = %d, want screenModelPick", m.screen)
+	}
+	if cmd != nil {
+		t.Fatal("static picker needs no fetch command")
+	}
+	if len(m.modelList) == 0 || m.modelList[0].ID != "gpt-5.5" {
+		t.Fatalf("model list = %v, want the static codex list", m.modelList)
+	}
+}
+
+func focusEditDefault(t *testing.T, m Model) Model {
+	t.Helper()
+	for i := 0; i < len(m.form.fields); i++ {
+		if m.form.focusedKey() == "default_model" {
+			return m
+		}
+		m, _ = press(t, m, "down")
+	}
+	t.Fatalf("could not focus default_model (fields: %d)", len(m.form.fields))
+	return m
+}
+
+// The edit-form model picker seeds from the static codex list for a codex
+// provider, and fetches the real endpoint for a non-codex one — driven by the
+// edited vendor's class (so a prior codex flow can't leak into a deepseek edit).
+func TestEditForm_ModelPickerSourceByClass(t *testing.T) {
+	deepseek := userops.VendorView{
+		Name: "deepseek", BaseURL: "https://api.deepseek.com/anthropic",
+		ModelsEndpoint: "https://api.deepseek.com/v1/models", DefaultModel: "x",
+		SecretBackend: "file", Protocol: "", Enabled: true,
+	}
+	codex := userops.VendorView{
+		Name: "codex", BaseURL: "http://127.0.0.1:17222/", ModelsEndpoint: "http://127.0.0.1:17222/v1/models",
+		DefaultModel: "gpt-5.5", SecretBackend: config.CodexOAuthBackend, Protocol: config.ProtocolCodexOAuth, Enabled: true,
+	}
+	m := withVendors(t, deepseek, codex) // class-sorted: deepseek (0), codex (1)
+
+	// editing codex -> static codex list, and no key-manager row.
+	mc := m
+	mc.screen = screenList
+	mc.vendorCursor = 1
+	mc, _ = press(t, mc, "enter")
+	if mc.addProtocol != config.ProtocolCodexOAuth {
+		t.Fatalf("edit codex addProtocol = %q", mc.addProtocol)
+	}
+	for _, fld := range mc.form.fields {
+		if fld.key == "manage_keys" {
+			t.Fatal("codex edit form must omit the key manager")
+		}
+	}
+	mc = focusEditDefault(t, mc)
+	mc, cmd := press(t, mc, "enter")
+	if mc.screen != screenModelPick || cmd != nil || len(mc.modelList) == 0 || mc.modelList[0].ID != "gpt-5.5" {
+		t.Fatalf("codex edit picker must be static: screen=%d cmd=%v list=%v", mc.screen, cmd, mc.modelList)
+	}
+
+	// editing deepseek -> fetch its own endpoint.
+	md := m
+	md.screen = screenList
+	md.vendorCursor = 0
+	md, _ = press(t, md, "enter")
+	if md.addProtocol != "" {
+		t.Fatalf("edit deepseek addProtocol = %q, want empty", md.addProtocol)
+	}
+	md = focusEditDefault(t, md)
+	md, cmd = press(t, md, "enter")
+	if md.screen != screenModelPick || cmd == nil || !md.loading || md.modelList != nil {
+		t.Fatalf("deepseek edit must fetch: cmd=%v loading=%v list=%v", cmd, md.loading, md.modelList)
+	}
+}
+
+// The providers list is grouped by wire class: Anthropic-protocol, then
+// OpenAI-protocol, then CLI auth (stable within a class).
+func TestProvidersList_GroupedByClass(t *testing.T) {
+	m := NewModel()
+	in := []userops.VendorView{
+		{Name: "codex", Protocol: config.ProtocolCodexOAuth},
+		{Name: "deepseek", Protocol: ""},
+		{Name: "groq", Protocol: config.ProtocolOpenAIChat},
+	}
+	m, _ = step(t, m, vendorsMsg{vendors: in})
+	got := []string{m.vendors[0].Name, m.vendors[1].Name, m.vendors[2].Name}
+	want := []string{"deepseek", "groq", "codex"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("class order = %v, want %v", got, want)
+		}
+	}
+}
+
+// The edit form's editable endpoint follows the class: openai edits upstream_url
+// (not the loopback base_url), codex edits neither, Anthropic-native edits base_url.
+func TestEditForm_FieldsByClass(t *testing.T) {
+	keys := func(f form) map[string]bool {
+		s := map[string]bool{}
+		for _, fld := range f.fields {
+			s[fld.key] = true
+		}
+		return s
+	}
+	oai := keys(newEditForm(userops.VendorView{Name: "openai", Protocol: config.ProtocolOpenAIResponses, UpstreamURL: "https://api.openai.com/v1", SecretBackend: "file"}))
+	if !oai["upstream_url"] || oai["base_url"] || !oai["manage_keys"] {
+		t.Fatalf("openai edit fields = %v (want upstream_url + keys, no base_url)", oai)
+	}
+	cdx := keys(newEditForm(userops.VendorView{Name: "codex", Protocol: config.ProtocolCodexOAuth, SecretBackend: config.CodexOAuthBackend}))
+	if cdx["base_url"] || cdx["models_endpoint"] || cdx["upstream_url"] || cdx["manage_keys"] {
+		t.Fatalf("codex edit fields = %v (want only default_model + enabled)", cdx)
+	}
+	ant := keys(newEditForm(userops.VendorView{Name: "deepseek", Protocol: "", SecretBackend: "file"}))
+	if !ant["base_url"] || ant["upstream_url"] {
+		t.Fatalf("anthropic edit fields = %v (want base_url, no upstream_url)", ant)
+	}
+}
+
+func TestCodexSourceNote(t *testing.T) {
+	if codexSourceNote(codexproxy.CredStatus{Active: "none"}) != "" {
+		t.Fatal("no source must yield an empty note")
+	}
+	ride := codexSourceNote(codexproxy.CredStatus{Active: "cli-ride", Account: "…abc"})
+	if !strings.Contains(ride, "codex CLI login") || !strings.Contains(ride, "…abc") {
+		t.Fatalf("cli-ride note = %q", ride)
+	}
+	own := codexSourceNote(codexproxy.CredStatus{Active: "own", Account: "…xyz"})
+	if !strings.Contains(own, "own codex login") {
+		t.Fatalf("own note = %q", own)
+	}
+}

--- a/internal/tui/screen_handlers.go
+++ b/internal/tui/screen_handlers.go
@@ -31,6 +31,7 @@ var handlers = map[screen]screenHandler{
 	screenKeys:          {update: Model.updateKeys, view: Model.viewKeys},
 	screenSetupTmux:     {update: Model.updateSetupTmux, view: Model.viewSetupTmux},
 	screenSetup:         {update: Model.updateSetup, view: Model.viewSetup},
+	screenCodexAuth:     {update: Model.updateCodexAuth, view: Model.viewCodexAuth},
 }
 
 // allScreens returns every screen constant defined in this package, in the
@@ -48,6 +49,7 @@ func allScreens() []screen {
 		screenKeys,
 		screenSetupTmux,
 		screenSetup,
+		screenCodexAuth,
 	}
 }
 

--- a/internal/tui/templates.go
+++ b/internal/tui/templates.go
@@ -1,5 +1,7 @@
 package tui
 
+import "github.com/ethanhq/cc-fleet/internal/config"
+
 // Template is a built-in vendor seed: prefill values for the add wizard so a
 // user picking "DeepSeek" doesn't have to type the base_url / models_endpoint
 // by hand. These are SEEDS — vendor URLs and model ids drift over time, so the
@@ -19,6 +21,43 @@ type Template struct {
 	ModelsEndpoint string // /v1/models URL used for the probe + refresh
 	DefaultModel   string // suggested default model id
 	Note           string // optional caveat shown in the picker preview
+}
+
+// OAITemplate seeds the OpenAI-protocol add form. base_url is the loopback
+// conversion-daemon URL (auto-assigned on add), so it is NOT a template field;
+// upstream_url is the real OpenAI-compatible endpoint and Protocol selects the
+// wire surface (Chat Completions vs Responses).
+type OAITemplate struct {
+	Label        string // picker label
+	Name         string // default provider id
+	Protocol     string // config.ProtocolOpenAIChat | config.ProtocolOpenAIResponses
+	UpstreamURL  string // real OpenAI-compatible base, usually ending in /v1
+	DefaultModel string // suggested default (blank → pick from the probed list)
+	Note         string
+}
+
+// OAITemplates seeds the OpenAI-protocol picker. A synthetic "Custom" entry is
+// appended by the picker, so it is intentionally NOT in this slice.
+var OAITemplates = []OAITemplate{
+	{
+		Label:       "OpenAI · Responses API (official)",
+		Name:        "openai",
+		Protocol:    config.ProtocolOpenAIResponses,
+		UpstreamURL: "https://api.openai.com/v1",
+		Note:        "High-fidelity reasoning surface; pick the default model from the probed list.",
+	},
+	{
+		Label:       "OpenAI · Chat Completions (official)",
+		Name:        "openai-chat",
+		Protocol:    config.ProtocolOpenAIChat,
+		UpstreamURL: "https://api.openai.com/v1",
+	},
+	{
+		Label:    "OpenAI-compatible · Chat (Groq / Together / Fireworks / vLLM …)",
+		Name:     "",
+		Protocol: config.ProtocolOpenAIChat,
+		Note:     "Set upstream_url to the vendor's base (often …/v1, e.g. https://api.groq.com/openai/v1).",
+	},
 }
 
 // Templates is the built-in seed table. Order is the display order in the

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/secrets"
 	"github.com/ethanhq/cc-fleet/internal/sessiontitle"
 	"github.com/ethanhq/cc-fleet/internal/subagent"
@@ -62,6 +63,8 @@ func (m Model) View() string {
 		return m.viewSetup()
 	case screenSetupTmux:
 		return m.viewSetupTmux()
+	case screenCodexAuth:
+		return m.viewCodexAuth()
 	}
 	return ""
 }
@@ -155,14 +158,13 @@ func (m Model) viewList() string {
 		}
 		right = state + " · " + vendorCacheFig(v)
 	}
-	var leftLines []string
-	for i, v := range m.vendors {
+	leftLines, cursorVisualLine := m.providerRail(m.vendorCursor, func(i int, v userops.VendorView) string {
 		marker := "  "
 		dot := okStyle.Render("●")
 		if !v.Enabled {
 			dot = faintStyle.Render("○")
 		}
-		name := trunc(v.Name, 24)
+		name := trunc(v.Name, 22)
 		switch {
 		case i == m.vendorCursor:
 			marker = cursorStyle.Render("❯ ")
@@ -172,8 +174,8 @@ func (m Model) viewList() string {
 		default:
 			name = faintStyle.Render(name)
 		}
-		leftLines = append(leftLines, marker+dot+" "+name)
-	}
+		return "  " + marker + dot + " " + name
+	})
 	if len(m.vendors) == 0 {
 		leftLines = append(leftLines, faintStyle.Render("  (none yet)"))
 	}
@@ -184,18 +186,20 @@ func (m Model) viewList() string {
 		addMarker = cursorStyle.Render("❯ ")
 		addLabel = selectedStyle.Render("+ Add provider…")
 	}
-	leftLines = append(leftLines, "  "+faintStyle.Render(strings.Repeat("─", 12)), addMarker+addLabel)
+	addLine := addMarker + addLabel
 	listTitle := fmt.Sprintf("Providers · %d", len(m.vendors))
+	// Size the rail to the rows + add line, then draw the divider to that width.
+	leftLines = append(leftLines, addLine)
 	leftW, rightW := m.paneWidths(leftWidth(listTitle, leftLines, m.boardInner()))
-	cardTitle := "add provider"
-	rightLines := []string{contentStyle.Render("Note"),
-		" " + contentStyle.Render("→/⏎ opens the add-provider wizard")}
+	leftLines = append(leftLines[:len(leftLines)-1], railSeparator(leftW), addLine)
+	cardTitle := "pick a provider"
+	rightLines := m.addPickerLines(-1) // read-only preview of the grouped list
 	if m.vendorCursor < addRow {
 		v := m.vendors[m.vendorCursor]
 		cardTitle = trunc(v.Name, 24)
 		rightLines = vendorDetailLines(v, rightW)
 	}
-	cursorLine := m.vendorCursor
+	cursorLine := cursorVisualLine
 	if m.vendorCursor >= addRow {
 		cursorLine = len(leftLines) - 1
 	}
@@ -222,10 +226,10 @@ func vendorCacheFig(v userops.VendorView) string {
 func vendorDetailLines(v userops.VendorView, rightW int) []string {
 	status := okStyle.Render("● enabled")
 	if !v.Enabled {
-		status = faintStyle.Render("○ disabled")
+		status = liveStyle.Render("○ disabled")
 	}
 	if v.DefaultModel != "" {
-		status += faintStyle.Render(" · " + trunc(v.DefaultModel, 28))
+		status += liveStyle.Render(" · " + trunc(v.DefaultModel, 28))
 	}
 	lines := []string{status, "", contentStyle.Render("Note"),
 		" " + contentStyle.Render("→/⏎ edit · d delete"), "", faintStyle.Render("Config")}
@@ -240,41 +244,82 @@ func vendorDetailLines(v userops.VendorView, rightW int) []string {
 	return lines
 }
 
+// railSeparator is the divider above "+ Add provider…": dashes spanning the rail
+// to one column shy of each edge, so it reads a touch longer than the widest
+// header/label with a small margin on each side.
+func railSeparator(leftW int) string {
+	n := leftW - 2
+	if n < 4 {
+		n = 4
+	}
+	return " " + faintStyle.Render(strings.Repeat("─", n))
+}
+
+// providerRail renders the provider list grouped by wire class (one header per
+// class, vendors indented under it). row(i, v) renders each vendor's line; the
+// returned int is the visual line index of the vendor at activeIdx (-1 if none),
+// for cursor windowing. Shared by the home list and the flow screens so their
+// rails stay identical.
+func (m Model) providerRail(activeIdx int, row func(i int, v userops.VendorView) string) ([]string, int) {
+	var lines []string
+	prevRank := -1
+	activeLine := -1
+	for i, v := range m.vendors {
+		if r := vendorClassRank(v.Protocol); r != prevRank {
+			if prevRank != -1 {
+				lines = append(lines, "")
+			}
+			lines = append(lines, "  "+faintStyle.Render(vendorClassHeader(v.Protocol)))
+			prevRank = r
+		}
+		if i == activeIdx {
+			activeLine = len(lines)
+		}
+		lines = append(lines, row(i, v))
+	}
+	return lines, activeLine
+}
+
 // vendorFlowView wraps a vendor flow (edit / add / model pick / keys / confirm / result)
 // in the hub chrome: the SAME master-detail box as the list, the inert provider rail on
 // the left keeping the spatial anchor, the flow's pane on the right. active highlights
 // the provider the flow concerns ("+" highlights the Add row, "" none); ctx/ctxRight fill
 // the header line; rightLines builds the pane content for its column budget.
 func (m Model) vendorFlowView(ctx, ctxRight, active, rightTitle, hint string, rightLines func(rightW int) []string) string {
-	var leftLines []string
-	for _, v := range m.vendors {
+	activeVendorIdx := -1
+	for i, v := range m.vendors {
+		if v.Name == active {
+			activeVendorIdx = i
+		}
+	}
+	leftLines, activeLine := m.providerRail(activeVendorIdx, func(i int, v userops.VendorView) string {
 		dot := okStyle.Render("●")
 		if !v.Enabled {
 			dot = faintStyle.Render("○")
 		}
-		name := trunc(v.Name, 24)
+		name := trunc(v.Name, 22)
 		if v.Name == active {
 			name = selectedStyle.Render(name)
 		} else {
 			name = faintStyle.Render(name)
 		}
-		leftLines = append(leftLines, "  "+dot+" "+name)
-	}
+		return "    " + dot + " " + name
+	})
 	addLabel := faintStyle.Render("+ Add provider…")
 	if active == "+" {
 		addLabel = selectedStyle.Render("+ Add provider…")
 	}
-	leftLines = append(leftLines, "  "+faintStyle.Render(strings.Repeat("─", 12)), "  "+addLabel)
+	addLine := "  " + addLabel
 	listTitle := fmt.Sprintf("Providers · %d", len(m.vendors))
+	leftLines = append(leftLines, addLine)
 	leftW, rightW := m.paneWidths(leftWidth(listTitle, leftLines, m.boardInner()))
+	leftLines = append(leftLines[:len(leftLines)-1], railSeparator(leftW), addLine)
 	bodyH := m.boardBodyHeight()
 	// Window the rail on the flow's provider (the Add row when none) so it stays
 	// visible past the box height.
-	activeIdx := len(leftLines) - 1
-	for i, v := range m.vendors {
-		if v.Name == active {
-			activeIdx = i
-		}
+	activeIdx := activeLine
+	if activeIdx < 0 {
+		activeIdx = len(leftLines) - 1
 	}
 	board := renderBoard(listTitle, windowLines(leftLines, activeIdx, bodyH), rightTitle, rightLines(rightW), leftW, rightW, bodyH, 0)
 	pad := strings.Repeat(" ", boardMargin)
@@ -291,7 +336,7 @@ func (m Model) viewForm() string {
 		active, rightTitle = m.editName, "edit "+trunc(m.editName, 20)
 	}
 	return m.vendorFlowView(m.form.title, "", active, rightTitle, m.form.intro,
-		func(rightW int) []string { return m.form.viewLines() })
+		func(rightW int) []string { return m.form.viewLines(rightW) })
 }
 
 // viewSpawn renders the Agents Board: a project-first master-detail. asMode re-roots
@@ -2660,40 +2705,118 @@ func shortJobID(id string) string {
 	return id
 }
 
-// viewPickTemplate renders the add flow's template picker in the hub box: template rows
-// above the highlighted template's seed-value preview, so the user sees what will be
-// prefilled before committing to the form.
+// viewPickTemplate renders the single grouped add picker: every provider class
+// with its seeds under one header (indented), one cursor over the flat selectable
+// rows, and a seed preview for the highlighted row.
 func (m Model) viewPickTemplate() string {
-	return m.vendorFlowView("Add provider · pick a template", "", "+", "templates",
-		"↑/↓ move · enter choose · esc cancel", func(rightW int) []string {
-			rows := make([]string, 0, len(Templates)+1)
-			for _, t := range Templates {
-				rows = append(rows, t.Label)
-			}
-			rows = append(rows, "Custom provider (fill everything manually)")
-			var lines []string
-			for i, label := range rows {
-				cursor := "  "
-				if i == m.tmplCursor {
-					cursor = cursorStyle.Render("❯ ")
-					label = selectedStyle.Render(label)
-				} else {
-					label = contentStyle.Render(label)
-				}
-				lines = append(lines, cursor+label)
-			}
+	return m.vendorFlowView("Add provider", "", "+", "pick a provider",
+		"↑/↓ move · enter/→ choose · esc cancel", func(rightW int) []string {
+			return m.addPickerLines(m.tmplCursor)
+		})
+}
+
+// addPickerLines renders the grouped provider list. cursor >= 0 highlights that
+// flat item index and appends its seed preview; cursor < 0 is a read-only preview
+// (used as the home list's "+ Add provider…" hover detail).
+func (m Model) addPickerLines(cursor int) []string {
+	var lines []string
+	idx := 0
+	for gi, g := range addGroups() {
+		if gi > 0 {
 			lines = append(lines, "")
-			if m.tmplCursor < len(Templates) {
-				t := Templates[m.tmplCursor]
-				lines = append(lines,
-					faintStyle.Render("  base_url        "+t.BaseURL),
-					faintStyle.Render("  models_endpoint "+t.ModelsEndpoint),
-					faintStyle.Render("  default_model   "+t.DefaultModel))
-				if t.Note != "" {
-					lines = append(lines, errStyle.Render("  note: "+t.Note))
+		}
+		lines = append(lines, faintStyle.Render(g.header))
+		for _, it := range g.items {
+			marker := "  "
+			label := contentStyle.Render(it.label)
+			if idx == cursor {
+				marker = cursorStyle.Render("❯ ")
+				label = selectedStyle.Render(it.label)
+			}
+			lines = append(lines, "  "+marker+label)
+			idx++
+		}
+	}
+	if cursor >= 0 {
+		lines = append(lines, "")
+		lines = append(lines, m.addItemDetail()...)
+	}
+	return lines
+}
+
+// addItemDetail is the seed/source preview for the highlighted picker row.
+func (m Model) addItemDetail() []string {
+	items := addItems()
+	if m.tmplCursor < 0 || m.tmplCursor >= len(items) {
+		return nil
+	}
+	switch it := items[m.tmplCursor]; it.class {
+	case addCatCLI:
+		if st := codexproxy.StatusReport(); st.Active != "none" {
+			return []string{faintStyle.Render("  reuses the codex login (" + st.Active + ", account " + st.Account + ") — no key needed")}
+		}
+		return []string{faintStyle.Render("  not logged in — you'll authorize next (or run: cc-fleet codex login)")}
+	case addCatOpenAI:
+		if it.oIdx < 0 {
+			return []string{faintStyle.Render("  protocol  openai-chat · fill upstream_url + key")}
+		}
+		t := OAITemplates[it.oIdx]
+		lines := []string{
+			faintStyle.Render("  protocol      " + t.Protocol),
+			faintStyle.Render("  upstream_url  " + t.UpstreamURL),
+		}
+		if t.Note != "" {
+			lines = append(lines, errStyle.Render("  note: "+t.Note))
+		}
+		return lines
+	default:
+		if it.tIdx < 0 {
+			return []string{faintStyle.Render("  all fields start blank")}
+		}
+		t := Templates[it.tIdx]
+		lines := []string{
+			faintStyle.Render("  base_url        " + t.BaseURL),
+			faintStyle.Render("  models_endpoint " + t.ModelsEndpoint),
+			faintStyle.Render("  default_model   " + t.DefaultModel),
+		}
+		if t.Note != "" {
+			lines = append(lines, errStyle.Render("  note: "+t.Note))
+		}
+		return lines
+	}
+}
+
+func (m Model) viewCodexAuth() string {
+	if m.codexAuthStage == codexAuthDevice {
+		return m.vendorFlowView("Add codex provider · authorize", "", "+", "device login",
+			"esc cancel", func(rightW int) []string {
+				var lines []string
+				if m.codexAuth != nil {
+					lines = append(lines,
+						contentStyle.Render("Open this URL and enter the code:"), "",
+						"  "+selectedStyle.Render(m.codexAuth.VerifyURL),
+						"  code: "+selectedStyle.Render(m.codexAuth.UserCode), "",
+						faintStyle.Render("  waiting for authorization…"))
+				} else {
+					lines = append(lines, faintStyle.Render("  starting device login…"))
 				}
-			} else {
-				lines = append(lines, faintStyle.Render("  all fields start blank"))
+				if m.codexAuthErr != "" {
+					lines = append(lines, "", errStyle.Render("  "+m.codexAuthErr))
+				}
+				return lines
+			})
+	}
+	return m.vendorFlowView("Add codex provider · consent", "", "+", "account risk",
+		"enter accept · esc cancel", func(rightW int) []string {
+			var lines []string
+			for _, seg := range strings.Split(codexproxy.RiskNotice, "\n") {
+				for _, w := range wrapTo(seg, rightW-2) {
+					lines = append(lines, contentStyle.Render(w))
+				}
+			}
+			lines = append(lines, "", faintStyle.Render("enter starts the device-code login · esc cancels"))
+			if m.codexAuthErr != "" {
+				lines = append(lines, "", errStyle.Render(m.codexAuthErr))
 			}
 			return lines
 		})

--- a/internal/userops/userops.go
+++ b/internal/userops/userops.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fileutil"
 	"github.com/ethanhq/cc-fleet/internal/models"
@@ -218,7 +219,9 @@ type AddResult struct {
 //  2. refuse to overwrite an existing entry (use Edit/Remove instead)
 //  3. if APIKey is set, write it to <SecretsDir>/<SecretRef> at 0600
 //  4. probe the vendor's /v1/models endpoint (3s) using the same secrets path
-//     keyget would — failures map to KEY_INVALID, VENDOR_UNREACHABLE, ADD_FAILED
+//     keyget would — failures map to KEY_INVALID, VENDOR_UNREACHABLE, ADD_FAILED.
+//     A codex-oauth vendor skips the probe (its models endpoint is a lazily-started
+//     loopback daemon) and seeds the static codex model list instead.
 //  5. commit vendors.toml + write profile JSON + populate the models cache
 //
 // On any failure after step 3, the file-backend secret is rolled back so the
@@ -296,16 +299,28 @@ func addLocked(req AddRequest) (*AddResult, error) {
 	}
 
 	// Synchronous probe so a bad key fails the add (not silently later). Failure
-	// here rolls back vendors.toml + the inline secret.
-	probeCtx, cancel := context.WithTimeout(context.Background(), probeTimeout)
-	defer cancel()
-	fetched, fetchErr := models.Fetch(probeCtx, v)
-	if fetchErr != nil {
-		// Roll back the staged vendor row before returning the typed error.
-		delete(cfg.Vendors, req.Name)
-		_ = config.Save(cfg)
-		_ = rollbackInlineSecret(req)
-		return nil, opErr(classifyAddErr(fetchErr), fetchErr)
+	// here rolls back vendors.toml + the inline secret. A codex provider skips it:
+	// its /v1/models is served by a lazily-started daemon, and starting that daemon
+	// under the vendors-config lock is forbidden (the proxy lock must not nest with
+	// it). Instead the cache is seeded with codex's static model list so a fresh
+	// entry carries the real models (not zero) and model resolution works at once.
+	var fetched []models.Model
+	if v.SecretBackend == codexproxy.SecretBackend {
+		for _, id := range codexproxy.StaticModels() {
+			fetched = append(fetched, models.Model{ID: id})
+		}
+	} else {
+		probeCtx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+		defer cancel()
+		f, fetchErr := models.Fetch(probeCtx, v)
+		if fetchErr != nil {
+			// Roll back the staged vendor row before returning the typed error.
+			delete(cfg.Vendors, req.Name)
+			_ = config.Save(cfg)
+			_ = rollbackInlineSecret(req)
+			return nil, opErr(classifyAddErr(fetchErr), fetchErr)
+		}
+		fetched = f
 	}
 
 	// All good — write the profile JSON and refresh the models cache so the
@@ -874,6 +889,13 @@ func Uninstall(req UninstallRequest) (*UninstallResult, error) {
 	} else {
 		res.Removed = append(res.Removed, histPath)
 	}
+
+	// 2d. Codex proxy daemon + its state files. Routed through codexproxy.Purge
+	// so the file names stay owned by that package; the daemon is stopped first.
+	// The login token chain is a credential, so it follows KeepSecrets.
+	cpRemoved, cpKept := codexproxy.Purge(req.KeepSecrets)
+	res.Removed = append(res.Removed, cpRemoved...)
+	res.Kept = append(res.Kept, cpKept...)
 
 	// 3. Secrets directory (or its contents, depending on KeepSecrets).
 	secretsDir, err := config.SecretsDir()

--- a/internal/userops/userops.go
+++ b/internal/userops/userops.go
@@ -201,6 +201,8 @@ type AddRequest struct {
 	DefaultModel   string
 	SecretBackend  string
 	SecretRef      string
+	Protocol       string // "" Anthropic-native | openai-chat | openai-responses | codex-oauth
+	UpstreamURL    string // real OpenAI base URL; required for openai-* protocols
 	APIKey         string // raw key bytes; only valid with SecretBackend=="file"
 	Enabled        bool   // defaults to true at the caller layer
 }
@@ -274,6 +276,8 @@ func addLocked(req AddRequest) (*AddResult, error) {
 		DefaultModel:   req.DefaultModel,
 		SecretBackend:  req.SecretBackend,
 		SecretRef:      req.SecretRef,
+		Protocol:       req.Protocol,
+		UpstreamURL:    req.UpstreamURL,
 		Enabled:        req.Enabled,
 		AddedAt:        time.Now().UTC(),
 	}
@@ -305,7 +309,7 @@ func addLocked(req AddRequest) (*AddResult, error) {
 	// it). Instead the cache is seeded with codex's static model list so a fresh
 	// entry carries the real models (not zero) and model resolution works at once.
 	var fetched []models.Model
-	if v.SecretBackend == codexproxy.SecretBackend {
+	if v.EffectiveProtocol() == config.ProtocolCodexOAuth {
 		for _, id := range codexproxy.StaticModels() {
 			fetched = append(fetched, models.Model{ID: id})
 		}
@@ -436,6 +440,7 @@ func updateModelsCache(vendor, endpoint string, fetched []models.Model) error {
 type EditRequest struct {
 	Name           string  // required
 	BaseURL        *string // nil = no change
+	UpstreamURL    *string // openai-* real upstream base
 	ModelsEndpoint *string
 	DefaultModel   *string
 	SecretBackend  *string
@@ -487,6 +492,9 @@ func editLocked(req EditRequest) (*EditResult, error) {
 	if req.BaseURL != nil && *req.BaseURL != v.BaseURL {
 		v.BaseURL = *req.BaseURL
 		baseURLChanged = true
+	}
+	if req.UpstreamURL != nil {
+		v.UpstreamURL = *req.UpstreamURL
 	}
 	if req.ModelsEndpoint != nil {
 		v.ModelsEndpoint = *req.ModelsEndpoint
@@ -679,6 +687,8 @@ type VendorView struct {
 	ModelsEndpoint string `json:"models_endpoint"`
 	SecretBackend  string `json:"secret_backend"`
 	SecretRef      string `json:"secret_ref"`
+	Protocol       string `json:"protocol"`     // resolved wire class: "" | openai-chat | openai-responses | codex-oauth
+	UpstreamURL    string `json:"upstream_url"` // real OpenAI base for openai-* (base_url is the loopback daemon)
 	Enabled        bool   `json:"enabled"`
 	ModelsCount    int    `json:"models_count"`
 	ModelsStale    bool   `json:"models_stale"`
@@ -719,6 +729,8 @@ func List() (*ListResult, error) {
 			ModelsEndpoint: v.ModelsEndpoint,
 			SecretBackend:  v.SecretBackend,
 			SecretRef:      v.SecretRef,
+			Protocol:       v.EffectiveProtocol(),
+			UpstreamURL:    v.UpstreamURL,
 			Enabled:        v.Enabled,
 		}
 		if vc, ok := cache.Vendors[name]; ok && vc != nil {

--- a/internal/vendorclass/signatures.go
+++ b/internal/vendorclass/signatures.go
@@ -5,10 +5,10 @@
 //   - internal/subagent parses claude's inner `is_error` result envelope.
 //
 // Both must map vendor noise into the same small vocabulary
-// (insufficient_balance / auth / rate_limit / api_error) with the same priority,
-// and a reachability probe (the spawn / subagent `--probe`) must classify a
-// models-endpoint result identically. Keeping both here stops the two copies
-// from drifting.
+// (insufficient_balance / cloudflare_blocked / auth / rate_limit / api_error) with
+// the same priority, and a reachability probe (the spawn / subagent `--probe`) must
+// classify a models-endpoint result identically. Keeping both here stops the two
+// copies from drifting.
 //
 // Imports are deliberately limited to config / models / secrets / neterr so this
 // package never forms an import cycle with spawn / teardown / subagent.
@@ -20,12 +20,13 @@ import "strings"
 // error_class vocabulary so the lead's mental model is identical across
 // `ps --check` (teammate) and `subagent` error codes:
 // auth↔KEY_INVALID, rate_limit↔RATE_LIMITED, insufficient_balance↔INSUFFICIENT_BALANCE,
-// api_error↔VENDOR_API_ERROR.
+// api_error↔VENDOR_API_ERROR, cloudflare_blocked↔CODEX_CLOUDFLARE_BLOCKED.
 const (
 	ClassInsufficientBalance = "insufficient_balance"
 	ClassAuth                = "auth"
 	ClassRateLimit           = "rate_limit"
 	ClassAPIError            = "api_error"
+	ClassCloudflareBlocked   = "cloudflare_blocked"
 )
 
 // Signature sets are matched against the lowercased input. We prefer specific
@@ -39,6 +40,12 @@ var (
 		"insufficient balance", "insufficient_quota", "insufficient quota",
 		"insufficient funds", "out of credits", "quota exceeded",
 		"exceeded your current quota",
+	}
+	// cloudflareSignatures must be matched BEFORE authSignatures: a Cloudflare
+	// edge block answers 403, so the generic "(403)" auth rule would otherwise
+	// misread an IP/client block as a bad key.
+	cloudflareSignatures = []string{
+		"blocked by cloudflare", "cf-mitigated",
 	}
 	authSignatures = []string{
 		"unauthorized", "invalid api key", "invalid_api_key",
@@ -58,16 +65,20 @@ var (
 // MatchClass classifies vendor error text into one of the Class* constants, or
 // "" when no signature matches.
 //
-// Priority: out-of-balance > auth > rate-limit > generic API error. A single
-// real-world line like "API Error: Request rejected (429) 余额不足无可用资源包"
-// carries several signals at once; the most actionable root cause wins — being
-// out of balance means a retry can't help (top up / switch vendor), whereas a
-// bare 429 might clear on its own, so balance must outrank the 429 symptom.
+// Priority: out-of-balance > cloudflare > auth > rate-limit > generic API
+// error. A single real-world line like "API Error: Request rejected (429)
+// 余额不足无可用资源包" carries several signals at once; the most actionable
+// root cause wins — being out of balance means a retry can't help (top up /
+// switch vendor), whereas a bare 429 might clear on its own, so balance must
+// outrank the 429 symptom. Cloudflare outranks auth because an edge block
+// answers 403, which the generic auth rule would misread as a bad key.
 func MatchClass(text string) string {
 	h := strings.ToLower(text)
 	switch {
 	case containsAny(h, balanceSignatures...):
 		return ClassInsufficientBalance
+	case containsAny(h, cloudflareSignatures...):
+		return ClassCloudflareBlocked
 	case containsAny(h, authSignatures...):
 		return ClassAuth
 	case containsAny(h, rateLimitSignatures...):

--- a/internal/vendorclass/vendorclass_test.go
+++ b/internal/vendorclass/vendorclass_test.go
@@ -22,6 +22,10 @@ func TestMatchClass(t *testing.T) {
 		{"auth word", "API Error: Unauthorized", ClassAuth},
 		{"auth invalid key", "invalid api key provided", ClassAuth},
 		{"auth paren 403", "request failed (403)", ClassAuth},
+		{"cloudflare marker", "API Error: blocked by Cloudflare (codex backend rejected this IP/client)", ClassCloudflareBlocked},
+		{"cloudflare header echo", "edge returned cf-mitigated: challenge", ClassCloudflareBlocked},
+		// A Cloudflare block answers 403 — it must beat the generic auth rule.
+		{"priority cloudflare over auth", "(403) blocked by cloudflare", ClassCloudflareBlocked},
 		{"rate phrase", "rate limit exceeded, retrying", ClassRateLimit},
 		{"rate 429 paren", "got (429) from upstream", ClassRateLimit},
 		{"generic api", "API Error: something unexpected happened", ClassAPIError},

--- a/internal/workflow/builtins.go
+++ b/internal/workflow/builtins.go
@@ -9,6 +9,7 @@ import (
 
 	"go.starlark.net/starlark"
 
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
@@ -310,6 +311,17 @@ func (e *engine) agent(thread *starlark.Thread, b *starlark.Builtin, args starla
 			e.emitLeaf("cached", phaseTag, label, vendor, model)
 			return v, nil
 		}
+	}
+
+	// For a codex provider, ensure the conversion daemon is up just before the leaf
+	// executes — AFTER the journal cache-hit return (a cached leaf needs no daemon)
+	// and after argument validation (an invalid call must not start one), but BEFORE
+	// the budget gate so the gate→reserve step stays GIL-atomic (runBlocking releases
+	// the GIL, which must not happen between gate and reserve). A no-op for non-codex.
+	var proxyErr error
+	e.sched.runBlocking(func() { proxyErr = codexproxy.EnsureForVendorName(vendor) })
+	if proxyErr != nil {
+		return nil, fmt.Errorf("agent(%s): codex proxy unavailable: %w", vendor, proxyErr)
 	}
 
 	// Budget gate: a real exec is about to spend, so refuse once a cap would be breached.

--- a/skills/cc-fleet/references/cli-reference.md
+++ b/skills/cc-fleet/references/cli-reference.md
@@ -40,6 +40,19 @@ cc-fleet run <vendor>                    Launch an INTERACTIVE claude REPL on th
                                          --dangerously-skip-permissions, -- <claude args>.
                                          HUMAN-ONLY — never run it yourself (not a --json
                                          command; it would block + replace your process).
+cc-fleet codex add [--name|--port|--model]
+                                         Register the ChatGPT-subscription provider: picks
+                                         the conversion daemon's loopback port and scans
+                                         ~/.codex/config.toml for the default model.
+cc-fleet codex login [--accept-risk]     Device-code OAuth login on cc-fleet's OWN token
+                                         chain (~/.codex auth is never read or written).
+                                         Shows an account-risk notice first — subscription
+                                         reuse outside the codex CLI is unofficial.
+cc-fleet codex logout                    Remove cc-fleet's codex login; stops the daemon.
+cc-fleet codex status                    Show whether cc-fleet has a codex login.
+cc-fleet codex-proxy status              Inspect / stop the local conversion daemon (it is
+cc-fleet codex-proxy stop                started lazily by spawn / subagent / run and
+                                         self-exits when no codex worker remains).
 ```
 
 `ccf` is a short alias (symlink) for `cc-fleet` — every command works as `ccf …` too. (Install creates it; `make uninstall` removes it. The apiKeyHelper a spawn writes always points at the real `cc-fleet` path regardless.)

--- a/skills/cc-fleet/references/subagent.md
+++ b/skills/cc-fleet/references/subagent.md
@@ -70,6 +70,8 @@ Useful flags:
 | `VENDOR_UNREACHABLE` | Transport failure (only with `--probe`). | `cc-fleet doctor`; if urgent, fall back to native `Agent`. |
 | `SUBAGENT_TIMEOUT` | Exceeded `--timeout`. | Real long task → raise `--timeout` (or use `--background`) and retry; suspected hang → switch vendor / fall back. |
 | `VENDOR_API_ERROR` | Other vendor failure (5xx / overloaded). | Retry once or switch vendor. |
+| `CODEX_PROXY_UNAVAILABLE` | The codex conversion daemon could not start (no login, or the loopback port is held). | Tell the user: `cc-fleet codex login`, or free / change the port (`cc-fleet codex add --port <n>`). |
+| `CODEX_CLOUDFLARE_BLOCKED` | The ChatGPT backend's edge blocked this IP/client — not a key problem. | Switch network/IP or retry later; don't rotate credentials. |
 | `SUBAGENT_FAILED` | claude exited with no parseable result (or turn/budget exhaustion). | Inspect; retry or switch vendor. |
 
 ## Batch fan-out example (parallel, each returns synchronously)

--- a/skills/cc-fleet/references/teammates.md
+++ b/skills/cc-fleet/references/teammates.md
@@ -168,5 +168,6 @@ Default seeds for the five built-in vendors. URLs may shift; always confirm via 
 | `glm` (智谱) | `https://open.bigmodel.cn/api/anthropic` | `glm-4.6`, `glm-4.5` | Domain Chinese, industry vertical. |
 | `qwen` (DashScope) | `https://dashscope.aliyuncs.com/...` | varies by region | Often needs OpenAI-format conversion; consult user docs if `refresh` fails. |
 | `minimax` | `https://api.minimaxi.com/v1/anthropic` | `MiniMax-M2`, `abab7-chat-preview` | — |
+| `codex` (ChatGPT subscription) | `http://127.0.0.1:<port>/` (local conversion daemon) | `gpt-5.5`, `gpt-5.3-codex` | Setup: `cc-fleet codex add` + `cc-fleet codex login` (user-run). Quota = the subscription; a 429 carries its reset time. |
 
 For a vendor not in this table, it works the same way — the user runs `cc-fleet add <vendor> --base-url <url> --models-endpoint <url> --default-model <id> --api-key-stdin <<<"$KEY"` first (use `--api-key-stdin` or `--api-key-file`; **never** put the raw key in argv).

--- a/skills/cc-fleet/references/troubleshooting.md
+++ b/skills/cc-fleet/references/troubleshooting.md
@@ -30,6 +30,8 @@ Dispatch on `error_code` — do **not** parse `error_msg` prose.
 | `PANE_CREATION_FAILED` | tmux `split-window` returned non-zero (in-tmux path). | Check tmux is running. If NOT inside tmux (`$TMUX` empty), spawn auto-builds an out-of-tmux swarm session instead — this error only fires on genuine in-tmux split failures. (If the team already has a live swarm under the same name, tear it down or use a fresh team name.) |
 | `UNKNOWN_VENDOR` | The vendor name isn't in `vendors.toml`. | `cc-fleet list --json` to see configured vendors; tell the user to `cc-fleet add <vendor>` first. Don't guess. |
 | `VENDOR_DISABLED` | The vendor row has `enabled = false`. | Pick a different vendor or tell the user to `cc-fleet edit <vendor> --enable`. |
+| `CODEX_PROXY_UNAVAILABLE` | The codex conversion daemon could not start or its loopback port is held by another process. | Tell the user: `cc-fleet codex login` if not logged in; otherwise free the port in the codex `base_url` (or re-add with `cc-fleet codex add --port <n>`). |
+| `CODEX_CLOUDFLARE_BLOCKED` | The ChatGPT backend's edge (Cloudflare) blocked this IP/client — NOT a bad key. | Switch network/IP or retry later; rotating credentials won't help. |
 | (rate-limit class) | Vendor returns 429 / rate-limit text in `error_msg`. | Wait 30–60s and retry once; if it persists, switch vendor. Don't loop tightly. |
 
 ## General rules


### PR DESCRIPTION
cc-fleet has driven only Anthropic-native vendors until now. This branch adds two more provider families behind the same teammate and subagent pipeline by routing them through a loopback conversion daemon (codexproxy) that translates between the Anthropic wire format Claude Code speaks and each upstream's own API.

It lands in two layers. The first reuses an existing ChatGPT subscription: `cc-fleet codex login` runs its own OAuth device-code chain and the daemon converts Claude Code's Anthropic requests to the Responses API, so a codex login serves as a real teammate while the bearer never leaves the daemon. The second generalizes that single case into three provider classes selected by a new orthogonal `Vendor.protocol` field alongside a `Vendor.upstream_url`:

- Anthropic-native — the existing vendors, unchanged (empty protocol).
- OpenAI-protocol — any OpenAI-compatible endpoint, through either Chat Completions (`openai-chat`) or the Responses API (`openai-responses`).
- CLI auth — a reused codex CLI login (`codex-oauth`), authenticating own-first: cc-fleet's own login is authoritative and it rides the codex CLI's `~/.codex` token read-only only when no own login exists.

The daemon becomes per-port — state, lock, lease, and readiness are keyed by port, with an identity-checked reuse so two providers never collide on one port — and exposes the three upstreams through a single `upstream` interface. Credentials stay off argv and the environment throughout: vendor auth flows only through the per-vendor apiKeyHelper, an OpenAI key arrives as `x-api-key` and is forwarded as the upstream Bearer rather than placed on a command line, logs and UI show only a masked key, and every OpenAI error surface is redacted so an echoed key cannot leak.

In the TUI, the "+ Add provider…" flow offers the three classes as one grouped picker, and codex is reached through a consent-gated device-code login screen rather than being pre-added.
