### PR TITLE
feat(codexproxy): honor Claude Code thinking effort and harden the OpenAI conversion

### DIFF
--- a/internal/codexproxy/convctx.go
+++ b/internal/codexproxy/convctx.go
@@ -1,0 +1,18 @@
+package codexproxy
+
+// convCtx is the per-request, immutable conversion context threaded through an
+// upstream's call (Anthropic -> upstream request) and convert (upstream SSE ->
+// Anthropic). It collapses the former (model, apiKey) parameters and carries the
+// tool-name map so a name sanitized on the way out is restored on the way back.
+// Built once per inbound /v1/messages request and only read afterwards, so it is
+// safe to share across the call/convert goroutines without a lock even though the
+// daemon serves requests concurrently.
+type convCtx struct {
+	model   string
+	apiKey  string       // presented upstream key (openai-*); "" for codex (OAuth bearer)
+	toolMap *toolNameMap // nil when every tool name already conforms
+}
+
+func newConvCtx(areq *anthropicRequest, apiKey string) *convCtx {
+	return &convCtx{model: areq.Model, apiKey: apiKey, toolMap: newToolNameMap(areq.Tools)}
+}

--- a/internal/codexproxy/conversion_align_test.go
+++ b/internal/codexproxy/conversion_align_test.go
@@ -1,0 +1,230 @@
+package codexproxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---- item 1: thinking-effort mapping ---------------------------------------
+
+func reasoningOf(t *testing.T, raw string) *reasoningOpt {
+	t.Helper()
+	a := parseReq(t, raw)
+	r, err := translateRequest(a, newConvCtx(a, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r.Reasoning
+}
+
+func TestEffort_OutputConfigMapping(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"low", "low"}, {"medium", "medium"}, {"high", "high"}, {"xhigh", "xhigh"}, {"max", "xhigh"},
+	} {
+		r := reasoningOf(t, `{"model":"gpt-5.5","thinking":{"type":"adaptive"},"output_config":{"effort":"`+c.in+`"},"messages":[{"role":"user","content":"hi"}]}`)
+		if r == nil || r.Effort != c.want {
+			t.Fatalf("output_config.effort %q -> %v, want effort %q", c.in, r, c.want)
+		}
+	}
+}
+
+func TestEffort_AbsentOmitsEffortButKeepsReasoning(t *testing.T) {
+	a := parseReq(t, `{"model":"gpt-5.5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"hi"}]}`)
+	r, _ := translateRequest(a, newConvCtx(a, ""))
+	if r.Reasoning == nil {
+		t.Fatal("adaptive thinking must still request reasoning (summary + encrypted_content)")
+	}
+	if r.Reasoning.Effort != "" {
+		t.Fatalf("absent effort must be empty (backend default), got %q", r.Reasoning.Effort)
+	}
+	if b, _ := json.Marshal(r); strings.Contains(string(b), `"effort"`) {
+		t.Fatalf("absent effort must be OMITTED on the wire: %s", b)
+	}
+}
+
+func TestEffort_LegacyBudgetFallback(t *testing.T) {
+	r := reasoningOf(t, `{"model":"m","thinking":{"type":"enabled","budget_tokens":20000},"messages":[{"role":"user","content":"hi"}]}`)
+	if r == nil || r.Effort != "high" {
+		t.Fatalf("legacy budget 20000 must bucket to high, got %v", r)
+	}
+}
+
+// The openai-responses lane steps xhigh down to high (not every api.openai.com model
+// accepts xhigh); the shared translator emits the canonical xhigh, the upstream clamps.
+func TestEffort_OpenAIResponsesClampsXhigh(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"))
+	}))
+	defer srv.Close()
+	u := newOpenAIResponsesUpstream(srv.URL + "/v1")
+	a := parseReq(t, `{"model":"gpt-x","thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"},"messages":[{"role":"user","content":"hi"}]}`)
+	body, err := u.call(context.Background(), a, newConvCtx(a, "sk-1"))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	body.Close()
+	reasoning, _ := gotBody["reasoning"].(map[string]any)
+	if reasoning == nil || reasoning["effort"] != "high" {
+		t.Fatalf("openai-responses must clamp xhigh -> high, got reasoning=%v", reasoning)
+	}
+}
+
+// ---- item 2: prompt-cache stability (billing header strip) -----------------
+
+func TestSystemText_StripsBillingHeader(t *testing.T) {
+	sys := `[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.37; cch=ABC123;"},{"type":"text","text":"real system prompt"}]`
+	a := parseReq(t, `{"model":"m","system":`+sys+`,"messages":[{"role":"user","content":"hi"}]}`)
+	r, _ := translateRequest(a, newConvCtx(a, ""))
+	if strings.Contains(r.Instructions, "billing-header") || strings.Contains(r.Instructions, "cch=") {
+		t.Fatalf("the volatile billing header must be stripped: %q", r.Instructions)
+	}
+	if r.Instructions != "real system prompt" {
+		t.Fatalf("the real system prompt must survive intact: %q", r.Instructions)
+	}
+}
+
+// ---- item 4: tool_result.is_error ------------------------------------------
+
+func TestToolResult_IsErrorPrefixed(t *testing.T) {
+	const content = `[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]`
+	items, _ := translateMessage(anthropicMessage{Role: "user", Content: json.RawMessage(content)}, &convCtx{})
+	if out := items[0].(map[string]any)["output"].(string); !strings.HasPrefix(out, "[tool error]") {
+		t.Fatalf("Responses is_error result must be prefixed, got %q", out)
+	}
+	citems, _ := translateChatMessage(anthropicMessage{Role: "user", Content: json.RawMessage(content)}, &convCtx{})
+	if out := citems[0].(map[string]any)["content"].(string); !strings.HasPrefix(out, "[tool error]") {
+		t.Fatalf("Chat is_error result must be prefixed, got %q", out)
+	}
+	// a non-error result is unprefixed
+	ok, _ := translateMessage(anthropicMessage{Role: "user", Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"t1","content":"fine"}]`)}, &convCtx{})
+	if out := ok[0].(map[string]any)["output"].(string); out != "fine" {
+		t.Fatalf("a successful tool_result must be unprefixed, got %q", out)
+	}
+}
+
+// ---- item 5: tool_choice none on the Responses lane ------------------------
+
+func TestToolChoice_NoneResponses(t *testing.T) {
+	a := parseReq(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"tool_choice":{"type":"none"}}`)
+	r, _ := translateRequest(a, newConvCtx(a, ""))
+	if r.ToolChoice != "none" {
+		t.Fatalf("tool_choice none must map to none (not auto), got %v", r.ToolChoice)
+	}
+}
+
+// ---- item 3: tool-name sanitize + restore ----------------------------------
+
+func TestToolNames_SanitizeRequestRestoreResponse(t *testing.T) {
+	const orig = "mcp.server.do-it" // dotted -> non-conforming
+	a := parseReq(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"tools":[{"name":"`+orig+`","input_schema":{"type":"object"}}]}`)
+	cc := newConvCtx(a, "")
+	r, _ := translateRequest(a, cc)
+	sent := r.Tools[0].Name
+	if sent == orig || !conformingToolName(sent) {
+		t.Fatalf("a non-conforming tool name must be sanitized to a conforming form, got %q", sent)
+	}
+	if cc.toolMap.restore(sent) != orig {
+		t.Fatalf("restore must recover the original name, got %q", cc.toolMap.restore(sent))
+	}
+	// the response tool_use carries the sanitized name; the converter restores it.
+	sse := `data: {"type":"response.output_item.added","item":{"id":"f1","type":"function_call","call_id":"c1","name":"` + sent + `"}}` + "\n\n" +
+		`data: {"type":"response.output_item.done","item":{"id":"f1","type":"function_call"}}` + "\n\n" +
+		`data: {"type":"response.completed","response":{"status":"completed"}}` + "\n\n"
+	sink := &recSink{}
+	if err := newStreamConverter(sink, cc).Convert(strings.NewReader(sse)); err != nil {
+		t.Fatal(err)
+	}
+	var name any
+	for i, ev := range sink.events {
+		if ev != "content_block_start" {
+			continue
+		}
+		if cb, _ := sink.payloads[i].(map[string]any)["content_block"].(map[string]any); cb != nil && cb["type"] == "tool_use" {
+			name = cb["name"]
+		}
+	}
+	if name != orig {
+		t.Fatalf("response tool_use name must be restored to %q, got %v", orig, name)
+	}
+}
+
+func TestToolNames_ConformingYieldsNilMap(t *testing.T) {
+	a := parseReq(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"tools":[{"name":"mcp__plugin__do_it","input_schema":{"type":"object"}}]}`)
+	if cc := newConvCtx(a, ""); cc.toolMap != nil {
+		t.Fatal("an all-conforming tool set must yield a nil toolMap (nothing rewritten)")
+	}
+}
+
+// "foo.bar" (non-conforming) sanitizes to "foo_bar", which is ALSO a real conforming
+// tool — the rewritten one must be suffixed so restore stays 1:1 and routes correctly.
+func TestToolNames_NoCollisionWithConforming(t *testing.T) {
+	a := parseReq(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"tools":[{"name":"foo.bar","input_schema":{"type":"object"}},{"name":"foo_bar","input_schema":{"type":"object"}}]}`)
+	cc := newConvCtx(a, "")
+	dotted := cc.toolMap.sanitize("foo.bar")
+	if dotted == "foo_bar" {
+		t.Fatalf("a sanitized name must not collide with a real conforming tool, got %q", dotted)
+	}
+	if cc.toolMap.restore("foo_bar") != "foo_bar" {
+		t.Fatalf("the conforming tool must restore to itself, got %q", cc.toolMap.restore("foo_bar"))
+	}
+	if cc.toolMap.restore(dotted) != "foo.bar" {
+		t.Fatalf("the sanitized name must restore to foo.bar, got %q", cc.toolMap.restore(dotted))
+	}
+}
+
+// a forced tool_choice naming a non-conforming tool must carry the SAME sanitized name
+// as the tool def, or the backend can't match it.
+func TestToolChoice_ForcedToolNameSanitized(t *testing.T) {
+	a := parseReq(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"tools":[{"name":"mcp.do","input_schema":{"type":"object"}}],"tool_choice":{"type":"tool","name":"mcp.do"}}`)
+	cc := newConvCtx(a, "")
+	r, _ := translateRequest(a, cc)
+	defName := r.Tools[0].Name
+	if defName == "mcp.do" {
+		t.Fatalf("the non-conforming tool def name should have been sanitized, got %q", defName)
+	}
+	tcMap, _ := r.ToolChoice.(map[string]any)
+	if tcMap == nil || tcMap["name"] != defName {
+		t.Fatalf("forced tool_choice name %v must equal the sanitized tool def name %q", r.ToolChoice, defName)
+	}
+}
+
+// The codex lane presents no key (cc.apiKey == ""), so the Responses converter
+// installs NO redactor — its canonical upstream errors pass through verbatim, even a
+// key-shaped token (contrast the openai-* redaction test). Pins that the per-key redact
+// seam never mangles a codex error.
+func TestCodexLane_CanonicalErrorNotRedacted(t *testing.T) {
+	const token = "sk-proj-CANON123" // key-shaped; codex has no key so it must NOT be masked
+	sse := `data: {"type":"response.failed","response":{"error":{"message":"backend said ` + token + `"}}}` + "\n\n"
+	sink := &recSink{}
+	if err := newStreamConverter(sink, ccTest("gpt-5.5")).Convert(strings.NewReader(sse)); err != nil {
+		t.Fatal(err)
+	}
+	if msg := errMessage(sink); !strings.Contains(msg, token) {
+		t.Fatalf("codex lane must not redact (no key presented); canonical error was mangled: %q", msg)
+	}
+}
+
+// ---- item 7: openai-chat cached-token split --------------------------------
+
+func TestChatUsage_CachedSplit(t *testing.T) {
+	sse := `data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}` + "\n\n" +
+		`data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":60}}}` + "\n\n" +
+		`data: [DONE]` + "\n\n"
+	sink := &recSink{}
+	if err := newChatStreamConverter(sink, ccTest("m")).Convert(strings.NewReader(sse)); err != nil {
+		t.Fatal(err)
+	}
+	usage, _ := sink.payload("message_delta", 0)["usage"].(map[string]any)
+	if usage["input_tokens"] != 40 || usage["cache_read_input_tokens"] != 60 {
+		t.Fatalf("chat cached split: input=%v cache_read=%v, want 40/60", usage["input_tokens"], usage["cache_read_input_tokens"])
+	}
+}

--- a/internal/codexproxy/fixture_test.go
+++ b/internal/codexproxy/fixture_test.go
@@ -9,6 +9,12 @@ import (
 	"testing"
 )
 
+// ccTest / ccKey build a minimal per-request convCtx for converter + translation
+// tests (a nil toolMap makes sanitize/restore no-ops; an empty apiKey installs no
+// redactor, matching the codex lane).
+func ccTest(model string) *convCtx        { return &convCtx{model: model} }
+func ccKey(model, apiKey string) *convCtx { return &convCtx{model: model, apiKey: apiKey} }
+
 // Fixture replay: live-captured (sanitized) Responses SSE streams from the
 // ChatGPT codex backend, run through the converter and held to the full
 // Anthropic stream grammar. These pin the converter against the real wire
@@ -21,7 +27,7 @@ func replayFixture(t *testing.T, name string) *recSink {
 		t.Fatal(err)
 	}
 	sink := &recSink{}
-	c := newStreamConverter(sink, "gpt-5.5")
+	c := newStreamConverter(sink, ccTest("gpt-5.5"))
 	if err := c.Convert(bytes.NewReader(b)); err != nil {
 		t.Fatalf("convert %s: %v", name, err)
 	}

--- a/internal/codexproxy/openai_chat.go
+++ b/internal/codexproxy/openai_chat.go
@@ -30,18 +30,16 @@ func newOpenAIChatUpstream(baseURL string) *openaiChatUpstream {
 // models_endpoint (probed directly with the key), never from this daemon.
 func (u *openaiChatUpstream) models() []string { return nil }
 
-func (u *openaiChatUpstream) convert(body io.Reader, sink sseSink, model, apiKey string) error {
-	c := newChatStreamConverter(sink, model)
-	c.redact = func(s string) string { return redactKey(s, apiKey) }
-	return c.Convert(body)
+func (u *openaiChatUpstream) convert(body io.Reader, sink sseSink, cc *convCtx) error {
+	return newChatStreamConverter(sink, cc).Convert(body)
 }
 
 // call translates the Anthropic request to a Chat Completions request, sends it
 // with Authorization: Bearer <apiKey>, and returns the streaming body. On a
 // non-2xx the response body is redacted (an arbitrary endpoint may echo the key)
 // before it becomes a classified *upstreamError.
-func (u *openaiChatUpstream) call(ctx context.Context, areq *anthropicRequest, apiKey string) (io.ReadCloser, error) {
-	creq, err := translateChatRequest(areq)
+func (u *openaiChatUpstream) call(ctx context.Context, areq *anthropicRequest, cc *convCtx) (io.ReadCloser, error) {
+	creq, err := translateChatRequest(areq, cc)
 	if err != nil {
 		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, err.Error()}
 	}
@@ -51,17 +49,17 @@ func (u *openaiChatUpstream) call(ctx context.Context, areq *anthropicRequest, a
 		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, "invalid upstream url"}
 	}
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer "+cc.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := u.http.Do(req)
 	if err != nil {
-		return nil, &upstreamError{upTransient, http.StatusBadGateway, "openai upstream: " + redactKey(err.Error(), apiKey)}
+		return nil, &upstreamError{upTransient, http.StatusBadGateway, "openai upstream: " + redactKey(err.Error(), cc.apiKey)}
 	}
 	if resp.StatusCode/100 == 2 {
 		return resp.Body, nil
 	}
-	return nil, classifyOpenAI(resp, apiKey)
+	return nil, classifyOpenAI(resp, cc.apiKey)
 }
 
 // classifyOpenAI maps a non-2xx Chat/Responses status to an upstreamError. Unlike
@@ -121,7 +119,7 @@ type chatFunction struct {
 // translateChatRequest maps an Anthropic Messages request to a Chat Completions
 // request. thinking is dropped (most compatible endpoints don't accept it); the
 // usage chunk is requested via stream_options.include_usage.
-func translateChatRequest(a *anthropicRequest) (*chatRequest, error) {
+func translateChatRequest(a *anthropicRequest, cc *convCtx) (*chatRequest, error) {
 	r := &chatRequest{
 		Model:         a.Model,
 		MaxTokens:     a.MaxTokens,
@@ -132,7 +130,7 @@ func translateChatRequest(a *anthropicRequest) (*chatRequest, error) {
 		r.Messages = append(r.Messages, map[string]any{"role": "system", "content": sys})
 	}
 	for _, m := range a.Messages {
-		items, err := translateChatMessage(m)
+		items, err := translateChatMessage(m, cc)
 		if err != nil {
 			return nil, err
 		}
@@ -140,10 +138,10 @@ func translateChatRequest(a *anthropicRequest) (*chatRequest, error) {
 	}
 	for _, t := range a.Tools {
 		r.Tools = append(r.Tools, chatTool{Type: "function", Function: chatFunction{
-			Name: t.Name, Description: t.Description, Parameters: t.InputSchema,
+			Name: cc.toolMap.sanitize(t.Name), Description: t.Description, Parameters: t.InputSchema,
 		}})
 	}
-	r.ToolChoice, r.ParallelToolCalls = translateChatToolChoice(a.ToolChoice)
+	r.ToolChoice, r.ParallelToolCalls = translateChatToolChoice(a.ToolChoice, cc)
 	return r, nil
 }
 
@@ -151,7 +149,7 @@ func translateChatRequest(a *anthropicRequest) (*chatRequest, error) {
 // tool_result blocks become role:"tool" messages emitted FIRST (Chat requires a
 // tool result to immediately follow the assistant turn that called it); text +
 // images form the message content; assistant tool_use blocks become tool_calls.
-func translateChatMessage(m anthropicMessage) ([]any, error) {
+func translateChatMessage(m anthropicMessage, cc *convCtx) ([]any, error) {
 	if s := stringContent(m.Content); s != nil {
 		return []any{map[string]any{"role": m.Role, "content": *s}}, nil
 	}
@@ -180,11 +178,11 @@ func translateChatMessage(m anthropicMessage) ([]any, error) {
 		case "tool_use":
 			toolCalls = append(toolCalls, map[string]any{
 				"id": b.ID, "type": "function",
-				"function": map[string]any{"name": b.Name, "arguments": string(rawOrEmptyObject(b.Input))},
+				"function": map[string]any{"name": cc.toolMap.sanitize(b.Name), "arguments": string(rawOrEmptyObject(b.Input))},
 			})
 		case "tool_result":
 			toolMsgs = append(toolMsgs, map[string]any{
-				"role": "tool", "tool_call_id": b.ToolUseID, "content": toolResultText(b.Content),
+				"role": "tool", "tool_call_id": b.ToolUseID, "content": toolResultOutput(b),
 			})
 		case "thinking":
 			// dropped — Chat Completions has no thinking input channel.
@@ -227,7 +225,7 @@ func stringContent(raw json.RawMessage) *string {
 // translateChatToolChoice maps Anthropic tool_choice to the Chat form plus the
 // parallel-tool-calls flag (set only when explicitly disabled). auto->auto,
 // any->required, {type:tool,name}->{type:function,function:{name}}, none->none.
-func translateChatToolChoice(raw json.RawMessage) (choice any, parallel *bool) {
+func translateChatToolChoice(raw json.RawMessage, cc *convCtx) (choice any, parallel *bool) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
@@ -247,7 +245,7 @@ func translateChatToolChoice(raw json.RawMessage) (choice any, parallel *bool) {
 	case "any":
 		return "required", parallel
 	case "tool":
-		return map[string]any{"type": "function", "function": map[string]any{"name": tc.Name}}, parallel
+		return map[string]any{"type": "function", "function": map[string]any{"name": cc.toolMap.sanitize(tc.Name)}}, parallel
 	case "none":
 		return "none", parallel
 	default:

--- a/internal/codexproxy/openai_chat_stream.go
+++ b/internal/codexproxy/openai_chat_stream.go
@@ -16,8 +16,9 @@ import (
 // transport read error ends on an Anthropic error event with open blocks closed,
 // never a clean message_stop.
 type chatStreamConverter struct {
-	out   sseSink
-	model string
+	out     sseSink
+	model   string
+	toolMap *toolNameMap // restores a sanitized tool name onto the response tool_use block
 	// redact masks a streaming error message before it reaches the client (set by
 	// the openai-chat upstream to scrub an echoed key, exact + pattern). When nil
 	// it falls back to the generic key-pattern mask.
@@ -32,16 +33,21 @@ type chatStreamConverter struct {
 	tools     map[int]int  // chat tool_calls index -> Anthropic block index
 	toolOpen  map[int]bool // chat tool_calls index -> open
 
-	stopReason string
-	inTokens   int
-	outTokens  int
+	stopReason      string
+	inTokens        int
+	outTokens       int
+	cacheReadTokens int
 }
 
-func newChatStreamConverter(out sseSink, model string) *chatStreamConverter {
-	return &chatStreamConverter{
-		out: out, model: model, textIndex: -1,
+func newChatStreamConverter(out sseSink, cc *convCtx) *chatStreamConverter {
+	c := &chatStreamConverter{
+		out: out, model: cc.model, toolMap: cc.toolMap, textIndex: -1,
 		tools: map[int]int{}, toolOpen: map[int]bool{}, stopReason: "end_turn",
 	}
+	if cc.apiKey != "" {
+		c.redact = func(s string) string { return redactKey(s, cc.apiKey) }
+	}
+	return c
 }
 
 type chatChunk struct {
@@ -73,8 +79,11 @@ type chatToolCallDelta struct {
 }
 
 type chatUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	PromptTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
 }
 
 type chatError struct {
@@ -123,7 +132,14 @@ func (c *chatStreamConverter) Convert(body io.Reader) error {
 func (c *chatStreamConverter) handle(ev *chatChunk) error {
 	if ev.Usage != nil {
 		if ev.Usage.PromptTokens > 0 {
-			c.inTokens = ev.Usage.PromptTokens
+			// OpenAI prompt_tokens INCLUDES the cached prefix; Anthropic's input_tokens
+			// excludes cache reads, so split the cached count into cache_read_input_tokens.
+			cached := ev.Usage.PromptTokensDetails.CachedTokens
+			if cached < 0 || cached > ev.Usage.PromptTokens {
+				cached = 0
+			}
+			c.inTokens = ev.Usage.PromptTokens - cached
+			c.cacheReadTokens = cached
 		}
 		if ev.Usage.CompletionTokens > 0 {
 			c.outTokens = ev.Usage.CompletionTokens
@@ -194,7 +210,7 @@ func (c *chatStreamConverter) toolDelta(tc chatToolCallDelta) error {
 		c.stopReason = "tool_use"
 		if err := c.out.event("content_block_start", map[string]any{
 			"type": "content_block_start", "index": idx,
-			"content_block": map[string]any{"type": "tool_use", "id": tc.ID, "name": tc.Function.Name, "input": map[string]any{}},
+			"content_block": map[string]any{"type": "tool_use", "id": tc.ID, "name": c.toolMap.restore(tc.Function.Name), "input": map[string]any{}},
 		}); err != nil {
 			return err
 		}
@@ -246,7 +262,11 @@ func (c *chatStreamConverter) finish() {
 	_ = c.out.event("message_delta", map[string]any{
 		"type":  "message_delta",
 		"delta": map[string]any{"stop_reason": c.stopReason, "stop_sequence": nil},
-		"usage": map[string]any{"input_tokens": c.inTokens, "output_tokens": c.outTokens},
+		"usage": map[string]any{
+			"input_tokens":            c.inTokens,
+			"output_tokens":           c.outTokens,
+			"cache_read_input_tokens": c.cacheReadTokens,
+		},
 	})
 	_ = c.out.event("message_stop", map[string]any{"type": "message_stop"})
 }

--- a/internal/codexproxy/openai_chat_test.go
+++ b/internal/codexproxy/openai_chat_test.go
@@ -34,7 +34,7 @@ func asMap(t *testing.T, v any) map[string]any {
 
 func TestChatTranslate_SystemAndText(t *testing.T) {
 	a := parseReq(t, `{"model":"m","max_tokens":10,"system":"be brief","messages":[{"role":"user","content":"hi"}]}`)
-	r, err := translateChatRequest(a)
+	r, err := translateChatRequest(a, newConvCtx(a, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestChatTranslate_SystemAndText(t *testing.T) {
 func TestChatTranslate_AssistantTextAndToolUse(t *testing.T) {
 	content := `[{"type":"text","text":"let me check"},{"type":"tool_use","id":"t1","name":"lookup","input":{"k":"v"}}]`
 	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":`+content+`}]}`)
-	r, _ := translateChatRequest(a)
+	r, _ := translateChatRequest(a, newConvCtx(a, ""))
 	if len(r.Messages) != 1 {
 		t.Fatalf("a text+tool_use assistant turn must be ONE message, got %d", len(r.Messages))
 	}
@@ -81,7 +81,7 @@ func TestChatTranslate_AssistantTextAndToolUse(t *testing.T) {
 func TestChatTranslate_ToolResultOrderedFirst(t *testing.T) {
 	content := `[{"type":"tool_result","tool_use_id":"t1","content":"the result"},{"type":"text","text":"thanks"}]`
 	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":`+content+`}]}`)
-	r, _ := translateChatRequest(a)
+	r, _ := translateChatRequest(a, newConvCtx(a, ""))
 	if len(r.Messages) != 2 {
 		t.Fatalf("messages = %d, want tool then user", len(r.Messages))
 	}
@@ -99,7 +99,7 @@ func TestChatTranslate_ToolChoiceAndTools(t *testing.T) {
 	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":"hi"}],
 		"tools":[{"name":"lookup","description":"d","input_schema":{"type":"object"}}],
 		"tool_choice":{"type":"any","disable_parallel_tool_use":true}}`)
-	r, _ := translateChatRequest(a)
+	r, _ := translateChatRequest(a, newConvCtx(a, ""))
 	if len(r.Tools) != 1 || r.Tools[0].Function.Name != "lookup" {
 		t.Fatalf("tools = %#v", r.Tools)
 	}
@@ -114,7 +114,7 @@ func TestChatTranslate_ToolChoiceAndTools(t *testing.T) {
 func TestChatTranslate_Image(t *testing.T) {
 	content := `[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}},{"type":"text","text":"see"}]`
 	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":`+content+`}]}`)
-	r, _ := translateChatRequest(a)
+	r, _ := translateChatRequest(a, newConvCtx(a, ""))
 	m := asMap(t, r.Messages[0])
 	parts, ok := m["content"].([]map[string]any)
 	if !ok || len(parts) != 2 {
@@ -135,7 +135,7 @@ func replayChat(t *testing.T, name string) *recSink {
 		t.Fatal(err)
 	}
 	sink := &recSink{}
-	if err := newChatStreamConverter(sink, "gpt-x").Convert(bytes.NewReader(b)); err != nil {
+	if err := newChatStreamConverter(sink, ccTest("gpt-x")).Convert(bytes.NewReader(b)); err != nil {
 		t.Fatalf("convert %s: %v", name, err)
 	}
 	return sink
@@ -213,12 +213,12 @@ func TestOpenAIChatUpstream_CallConvertAndRedact(t *testing.T) {
 	defer ok.Close()
 	u := newOpenAIChatUpstream(ok.URL + "/v1")
 	a := parseReq(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`)
-	body, err := u.call(context.Background(), a, key)
+	body, err := u.call(context.Background(), a, newConvCtx(a, key))
 	if err != nil {
 		t.Fatalf("call: %v", err)
 	}
 	sink := &recSink{}
-	_ = u.convert(body, sink, "m", key)
+	_ = u.convert(body, sink, ccKey("m", key))
 	body.Close()
 	if got := collectDeltas(sink, "text_delta", "text"); got != "hi" {
 		t.Fatalf("converted text = %q", got)
@@ -229,7 +229,7 @@ func TestOpenAIChatUpstream_CallConvertAndRedact(t *testing.T) {
 		_, _ = w.Write([]byte("invalid key " + key + " rejected"))
 	}))
 	defer bad.Close()
-	_, err = newOpenAIChatUpstream(bad.URL+"/v1").call(context.Background(), a, key)
+	_, err = newOpenAIChatUpstream(bad.URL+"/v1").call(context.Background(), a, newConvCtx(a, key))
 	ue, ok2 := err.(*upstreamError)
 	if !ok2 || ue.kind != upAuth {
 		t.Fatalf("want upAuth upstreamError, got %v", err)

--- a/internal/codexproxy/openai_responses.go
+++ b/internal/codexproxy/openai_responses.go
@@ -26,23 +26,28 @@ func newOpenAIResponsesUpstream(baseURL string) *openaiResponsesUpstream {
 // models is empty: the model list comes from the real upstream models_endpoint.
 func (u *openaiResponsesUpstream) models() []string { return nil }
 
-func (u *openaiResponsesUpstream) convert(body io.Reader, sink sseSink, model, apiKey string) error {
-	c := newStreamConverter(sink, model)
-	c.redact = func(s string) string { return redactKey(s, apiKey) }
-	return c.Convert(body)
+func (u *openaiResponsesUpstream) convert(body io.Reader, sink sseSink, cc *convCtx) error {
+	return newStreamConverter(sink, cc).Convert(body)
 }
 
 // call translates the Anthropic request with the shared Responses translator,
 // adds the max_output_tokens cap (a billed account honors it), and sends it with
 // Authorization: Bearer <apiKey> — no codex headers, no OAuth refresh, no
 // Cloudflare path. A non-2xx body is redacted before becoming an upstreamError.
-func (u *openaiResponsesUpstream) call(ctx context.Context, areq *anthropicRequest, apiKey string) (io.ReadCloser, error) {
-	rreq, err := translateRequest(areq)
+func (u *openaiResponsesUpstream) call(ctx context.Context, areq *anthropicRequest, cc *convCtx) (io.ReadCloser, error) {
+	rreq, err := translateRequest(areq, cc)
 	if err != nil {
 		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, err.Error()}
 	}
 	if areq.MaxTokens > 0 {
 		rreq.MaxOutputTokens = areq.MaxTokens
+	}
+	// Clamp the reasoning effort to what a generic api.openai.com model accepts:
+	// translateRequest emits the canonical effort (xhigh for a Claude xhigh/max), but
+	// not every Responses model supports xhigh, so step it down to high here. The codex
+	// lane keeps xhigh (gpt-5.5 supports it; the backend coerces an unsupported level).
+	if rreq.Reasoning != nil && rreq.Reasoning.Effort == "xhigh" {
+		rreq.Reasoning.Effort = "high"
 	}
 	body, _ := json.Marshal(rreq)
 	endpoint, err := url.JoinPath(u.baseURL, "responses")
@@ -50,15 +55,15 @@ func (u *openaiResponsesUpstream) call(ctx context.Context, areq *anthropicReque
 		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, "invalid upstream url"}
 	}
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer "+cc.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := u.http.Do(req)
 	if err != nil {
-		return nil, &upstreamError{upTransient, http.StatusBadGateway, "openai upstream: " + redactKey(err.Error(), apiKey)}
+		return nil, &upstreamError{upTransient, http.StatusBadGateway, "openai upstream: " + redactKey(err.Error(), cc.apiKey)}
 	}
 	if resp.StatusCode/100 == 2 {
 		return resp.Body, nil
 	}
-	return nil, classifyOpenAI(resp, apiKey)
+	return nil, classifyOpenAI(resp, cc.apiKey)
 }

--- a/internal/codexproxy/openai_responses_test.go
+++ b/internal/codexproxy/openai_responses_test.go
@@ -35,12 +35,12 @@ data: {"type":"response.completed","response":{"status":"completed","usage":{"in
 
 	u := newOpenAIResponsesUpstream(srv.URL + "/v1")
 	a := parseReq(t, `{"model":"gpt-x","max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`)
-	body, err := u.call(context.Background(), a, "sk-billed-123")
+	body, err := u.call(context.Background(), a, newConvCtx(a, "sk-billed-123"))
 	if err != nil {
 		t.Fatalf("call: %v", err)
 	}
 	sink := &recSink{}
-	_ = u.convert(body, sink, "gpt-x", "sk-billed-123")
+	_ = u.convert(body, sink, ccKey("gpt-x", "sk-billed-123"))
 	body.Close()
 
 	if gotPath != "/v1/responses" {
@@ -64,7 +64,7 @@ data: {"type":"response.completed","response":{"status":"completed","usage":{"in
 // backend 400s on it, so omitempty must drop it.
 func TestResponsesTranslate_CodexOmitsMaxOutput(t *testing.T) {
 	a := parseReq(t, `{"model":"m","max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`)
-	r, _ := translateRequest(a)
+	r, _ := translateRequest(a, newConvCtx(a, ""))
 	b, _ := json.Marshal(r)
 	if strings.Contains(string(b), "max_output_tokens") {
 		t.Fatalf("codex request must omit max_output_tokens: %s", b)
@@ -79,14 +79,14 @@ func TestOpenAIConvert_RedactsStreamingErrorKey(t *testing.T) {
 
 	chatBody := `data: {"error":{"message":"upstream rejected ` + key + ` here"}}` + "\n\n"
 	csink := &recSink{}
-	_ = newOpenAIChatUpstream("https://x/v1").convert(strings.NewReader(chatBody), csink, "m", key)
+	_ = newOpenAIChatUpstream("https://x/v1").convert(strings.NewReader(chatBody), csink, ccKey("m", key))
 	if msg := errMessage(csink); strings.Contains(msg, key) {
 		t.Fatalf("chat streaming error leaked the key: %q", msg)
 	}
 
 	respBody := `data: {"type":"response.failed","response":{"error":{"message":"bad ` + key + ` token"}}}` + "\n\n"
 	rsink := &recSink{}
-	_ = newOpenAIResponsesUpstream("https://x/v1").convert(strings.NewReader(respBody), rsink, "m", key)
+	_ = newOpenAIResponsesUpstream("https://x/v1").convert(strings.NewReader(respBody), rsink, ccKey("m", key))
 	if msg := errMessage(rsink); strings.Contains(msg, key) {
 		t.Fatalf("responses streaming error leaked the key: %q", msg)
 	}

--- a/internal/codexproxy/server.go
+++ b/internal/codexproxy/server.go
@@ -89,7 +89,10 @@ func (s *server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := s.up.call(r.Context(), &areq, upstreamKey)
+	// One per-request conversion context (model + upstream key + tool-name map),
+	// shared read-only by call and convert.
+	cc := newConvCtx(&areq, upstreamKey)
+	body, err := s.up.call(r.Context(), &areq, cc)
 	if err != nil {
 		ue, _ := err.(*upstreamError)
 		status, etype, msg := anthropicErrorFor(ue)
@@ -105,7 +108,7 @@ func (s *server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// convert already emitted the client-visible terminal event (a clean
 	// message_stop, or an error event on a failed-upstream / read-error stream),
 	// so its returned error needs no further handling on the wire.
-	_ = s.up.convert(body, sink, areq.Model, upstreamKey)
+	_ = s.up.convert(body, sink, cc)
 }
 
 // httpSSE writes Anthropic SSE events to the response and flushes each one.

--- a/internal/codexproxy/server_test.go
+++ b/internal/codexproxy/server_test.go
@@ -24,14 +24,14 @@ type stubUpstream struct {
 	gotKey string
 }
 
-func (s *stubUpstream) call(_ context.Context, _ *anthropicRequest, apiKey string) (io.ReadCloser, error) {
+func (s *stubUpstream) call(_ context.Context, _ *anthropicRequest, cc *convCtx) (io.ReadCloser, error) {
 	s.mu.Lock()
-	s.gotKey = apiKey
+	s.gotKey = cc.apiKey
 	s.mu.Unlock()
 	return io.NopCloser(strings.NewReader("")), nil
 }
 
-func (s *stubUpstream) convert(_ io.Reader, sink sseSink, _, _ string) error {
+func (s *stubUpstream) convert(_ io.Reader, sink sseSink, _ *convCtx) error {
 	return sink.event("message_stop", map[string]any{"type": "message_stop"})
 }
 

--- a/internal/codexproxy/stream.go
+++ b/internal/codexproxy/stream.go
@@ -35,11 +35,12 @@ type blockState struct {
 // transport read error instead ends on an Anthropic error event (open blocks
 // closed first), never a clean message_stop.
 type streamConverter struct {
-	out   sseSink
-	model string
-	// redact masks a streaming error message before it reaches the client (set by
-	// the openai-responses upstream to scrub an echoed key); nil for codex, whose
-	// upstream error messages are canonical.
+	out     sseSink
+	model   string
+	toolMap *toolNameMap // restores a sanitized tool name onto the response tool_use block
+	// redact masks a streaming error message before it reaches the client (set when a
+	// real key is presented — openai-* — to scrub an echoed key); nil for codex, whose
+	// upstream error messages are canonical (no key).
 	redact func(string) string
 
 	started         bool
@@ -52,8 +53,14 @@ type streamConverter struct {
 	cacheReadTokens int
 }
 
-func newStreamConverter(out sseSink, model string) *streamConverter {
-	return &streamConverter{out: out, model: model, blocks: map[string]*blockState{}, stopReason: "end_turn"}
+func newStreamConverter(out sseSink, cc *convCtx) *streamConverter {
+	c := &streamConverter{out: out, model: cc.model, toolMap: cc.toolMap, blocks: map[string]*blockState{}, stopReason: "end_turn"}
+	if cc.apiKey != "" {
+		// openai-* presents a real key — scrub it (exact + pattern) from any error chunk.
+		// codex has none (cc.apiKey == "") so redact stays nil and its errors pass through.
+		c.redact = func(s string) string { return redactKey(s, cc.apiKey) }
+	}
+	return c
 }
 
 // responsesEvent is the union of Responses streaming event fields we read.
@@ -223,7 +230,7 @@ func (c *streamConverter) openBlock(ev *responsesEvent) error {
 	case "function_call":
 		kind = blockToolUse
 		c.stopReason = "tool_use"
-		cb = map[string]any{"type": "tool_use", "id": ev.Item.CallID, "name": ev.Item.Name, "input": map[string]any{}}
+		cb = map[string]any{"type": "tool_use", "id": ev.Item.CallID, "name": c.toolMap.restore(ev.Item.Name), "input": map[string]any{}}
 	case "reasoning":
 		kind = blockThinking
 		cb = map[string]any{"type": "thinking", "thinking": "", "signature": ""}

--- a/internal/codexproxy/stream_test.go
+++ b/internal/codexproxy/stream_test.go
@@ -38,7 +38,7 @@ func (r *recSink) payload(name string, i int) map[string]any {
 func runConvert(t *testing.T, sse string) *recSink {
 	t.Helper()
 	sink := &recSink{}
-	c := newStreamConverter(sink, "gpt-5.5")
+	c := newStreamConverter(sink, ccTest("gpt-5.5"))
 	if err := c.Convert(strings.NewReader(sse)); err != nil {
 		t.Fatalf("convert: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestConvert_ReadErrorEmitsErrorNotCleanStop(t *testing.T) {
 		"", // ensure the last data line is newline-terminated for the scanner
 	}, "\n\n")
 	sink := &recSink{}
-	c := newStreamConverter(sink, "gpt-5.5")
+	c := newStreamConverter(sink, ccTest("gpt-5.5"))
 	err := c.Convert(&errAfterReader{data: data})
 	if err == nil {
 		t.Fatal("Convert must return the read error, not swallow it")

--- a/internal/codexproxy/toolnames.go
+++ b/internal/codexproxy/toolnames.go
@@ -1,0 +1,113 @@
+package codexproxy
+
+import "strconv"
+
+// toolNameMap rewrites Anthropic tool names that fall outside the OpenAI
+// function-name charset (^[A-Za-z0-9_-]{1,64}$) on the way out and restores the
+// original on the way back, so a non-conforming MCP name (a dotted server.tool, or
+// one longer than 64 chars) does not 400 a strict endpoint while the model's
+// tool_use still carries the name claude expects. Only NON-conforming names are
+// rewritten — a conforming name passes through untouched, so a genuinely malformed
+// name is the only thing that ever changes (it is never masked silently for a
+// well-formed tool). Built once per request and read-only afterwards, so no lock.
+type toolNameMap struct {
+	out map[string]string // original -> sanitized (only the names that changed)
+	in  map[string]string // sanitized -> original
+}
+
+// newToolNameMap returns nil when every tool name already conforms (the common
+// case), so the sanitize/restore calls are no-ops with zero allocation.
+func newToolNameMap(tools []anthropicTool) *toolNameMap {
+	m := &toolNameMap{out: map[string]string{}, in: map[string]string{}}
+	// Reserve conforming names first (they pass through unchanged): a sanitized
+	// non-conforming name must never collide with a real conforming one, or restore
+	// would map the model's call to the wrong tool.
+	for _, t := range tools {
+		if t.Name != "" && conformingToolName(t.Name) {
+			m.in[t.Name] = t.Name
+		}
+	}
+	for _, t := range tools {
+		if t.Name == "" || conformingToolName(t.Name) {
+			continue
+		}
+		s := uniqueSanitized(m, t.Name)
+		m.out[t.Name] = s
+		m.in[s] = t.Name
+	}
+	if len(m.out) == 0 {
+		return nil
+	}
+	return m
+}
+
+func (m *toolNameMap) sanitize(name string) string {
+	if m == nil {
+		return name
+	}
+	if s, ok := m.out[name]; ok {
+		return s
+	}
+	return name
+}
+
+func (m *toolNameMap) restore(name string) string {
+	if m == nil {
+		return name
+	}
+	if orig, ok := m.in[name]; ok {
+		return orig
+	}
+	return name
+}
+
+func conformingToolName(s string) bool {
+	if len(s) == 0 || len(s) > 64 {
+		return false
+	}
+	for _, r := range s {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+// uniqueSanitized maps name into the charset, truncates to 64, and appends a numeric
+// suffix if that collides with a DIFFERENT original already mapped (so in stays 1:1).
+func uniqueSanitized(m *toolNameMap, name string) string {
+	base := truncateName(sanitizeChars(name), 64)
+	if base == "" {
+		base = "tool"
+	}
+	s := base
+	for n := 2; ; n++ {
+		if orig, taken := m.in[s]; !taken || orig == name {
+			return s
+		}
+		suf := "_" + strconv.Itoa(n)
+		s = truncateName(base, 64-len(suf)) + suf
+	}
+}
+
+func sanitizeChars(s string) string {
+	b := make([]byte, 0, len(s))
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			b = append(b, byte(r))
+		} else {
+			b = append(b, '_')
+		}
+	}
+	return string(b)
+}
+
+func truncateName(s string, n int) string {
+	if n < 0 {
+		n = 0
+	}
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/internal/codexproxy/translate.go
+++ b/internal/codexproxy/translate.go
@@ -3,6 +3,7 @@ package codexproxy
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // anthropicRequest is the subset of the Anthropic Messages request that the claude
@@ -19,6 +20,12 @@ type anthropicRequest struct {
 	Metadata   struct {
 		UserID string `json:"user_id"`
 	} `json:"metadata"`
+	// OutputConfig.Effort is the modern thinking-strength control
+	// (low|medium|high|xhigh|max); adaptive thinking + this superseded the deprecated
+	// thinking.budget_tokens, so a modern claude sends it and no budget.
+	OutputConfig struct {
+		Effort string `json:"effort"`
+	} `json:"output_config"`
 }
 
 type anthropicThinking struct {
@@ -48,6 +55,7 @@ type contentBlock struct {
 	Source    *imageSource    `json:"source"`      // image
 	Thinking  string          `json:"thinking"`    // thinking block text
 	Signature string          `json:"signature"`   // thinking block signature = the replayed encrypted_content
+	IsError   bool            `json:"is_error"`    // tool_result: the tool call failed
 }
 
 type imageSource struct {
@@ -77,7 +85,7 @@ type responsesRequest struct {
 }
 
 type reasoningOpt struct {
-	Effort  string `json:"effort"`
+	Effort  string `json:"effort,omitempty"`
 	Summary string `json:"summary"`
 }
 
@@ -92,8 +100,8 @@ type responsesTool struct {
 // max_tokens and temperature are intentionally omitted (the ChatGPT backend 400s
 // on them). store is forced false. The claude session id inside metadata.user_id
 // becomes prompt_cache_key so the backend's prompt cache follows the conversation.
-func translateRequest(a *anthropicRequest) (*responsesRequest, error) {
-	choice, parallel := translateToolChoice(a.ToolChoice)
+func translateRequest(a *anthropicRequest, cc *convCtx) (*responsesRequest, error) {
+	choice, parallel := translateToolChoice(a.ToolChoice, cc)
 	r := &responsesRequest{
 		Model:             a.Model,
 		Instructions:      systemText(a.System),
@@ -104,7 +112,7 @@ func translateRequest(a *anthropicRequest) (*responsesRequest, error) {
 		PromptCacheKey:    a.Metadata.UserID,
 	}
 	for _, m := range a.Messages {
-		items, err := translateMessage(m)
+		items, err := translateMessage(m, cc)
 		if err != nil {
 			return nil, err
 		}
@@ -112,14 +120,16 @@ func translateRequest(a *anthropicRequest) (*responsesRequest, error) {
 	}
 	for _, t := range a.Tools {
 		r.Tools = append(r.Tools, responsesTool{
-			Type: "function", Name: t.Name, Description: t.Description, Parameters: t.InputSchema,
+			Type: "function", Name: cc.toolMap.sanitize(t.Name), Description: t.Description, Parameters: t.InputSchema,
 		})
 	}
-	// "enabled" carries a budget; "adaptive" (claude's default-on mode) has none
-	// and lands in the low bucket. Either way the model reasons — requesting the
-	// summary + encrypted_content keeps that reasoning replayable across turns.
+	// With thinking enabled (legacy budget) or adaptive (claude's default-on mode) the
+	// model reasons; requesting the summary + encrypted_content keeps that reasoning
+	// replayable across turns.
 	if a.Thinking != nil && (a.Thinking.Type == "enabled" || a.Thinking.Type == "adaptive") {
-		r.Reasoning = &reasoningOpt{Effort: effortBucket(a.Thinking.BudgetTokens), Summary: "auto"}
+		// effortFor reads the modern output_config.effort; absent → "" so the field is
+		// omitted and the backend uses its own default rather than us forcing a level.
+		r.Reasoning = &reasoningOpt{Effort: effortFor(a), Summary: "auto"}
 		r.Include = []string{"reasoning.encrypted_content"}
 	}
 	return r, nil
@@ -139,16 +149,26 @@ func systemText(raw json.RawMessage) string {
 	if json.Unmarshal(raw, &blocks) == nil {
 		out := ""
 		for _, b := range blocks {
-			if b.Type == "text" {
-				if out != "" {
-					out += "\n"
-				}
-				out += b.Text
+			// Drop Claude Code's volatile attribution header
+			// (x-anthropic-billing-header: …cch=…): its per-request value would lead the
+			// instructions prefix and bust the upstream prompt cache every call.
+			if b.Type != "text" || isBillingHeaderBlock(b.Text) {
+				continue
 			}
+			if out != "" {
+				out += "\n"
+			}
+			out += b.Text
 		}
 		return out
 	}
 	return ""
+}
+
+// isBillingHeaderBlock reports whether a system text block is Claude Code's volatile
+// attribution header (x-anthropic-billing-header: …); see systemText.
+func isBillingHeaderBlock(text string) bool {
+	return strings.HasPrefix(strings.TrimSpace(text), "x-anthropic-billing-header:")
 }
 
 // translateToolChoice maps Anthropic tool_choice to the Responses form plus the
@@ -156,7 +176,7 @@ func systemText(raw json.RawMessage) string {
 // {type:function,name}; nil/absent -> auto. It is NOT hard-forced to auto (that
 // would break forced-tool / StructuredOutput paths). disable_parallel_tool_use
 // flips parallel_tool_calls off.
-func translateToolChoice(raw json.RawMessage) (choice any, parallel bool) {
+func translateToolChoice(raw json.RawMessage, cc *convCtx) (choice any, parallel bool) {
 	if len(raw) == 0 {
 		return "auto", true
 	}
@@ -173,13 +193,42 @@ func translateToolChoice(raw json.RawMessage) (choice any, parallel bool) {
 	case "any":
 		return "required", parallel
 	case "tool":
-		return map[string]any{"type": "function", "name": tc.Name}, parallel
+		return map[string]any{"type": "function", "name": cc.toolMap.sanitize(tc.Name)}, parallel
+	case "none":
+		return "none", parallel
 	default:
 		return "auto", parallel
 	}
 }
 
-// effortBucket maps an Anthropic thinking budget to a Responses reasoning effort.
+// effortFor resolves the Responses reasoning effort from the Anthropic request: the
+// modern top-level output_config.effort wins, then a legacy thinking.budget_tokens
+// bucket, else "" (omit the field; the backend uses its own default).
+func effortFor(a *anthropicRequest) string {
+	if e := mapEffort(a.OutputConfig.Effort); e != "" {
+		return e
+	}
+	if a.Thinking != nil && a.Thinking.Type == "enabled" && a.Thinking.BudgetTokens > 0 {
+		return effortBucket(a.Thinking.BudgetTokens)
+	}
+	return ""
+}
+
+// mapEffort maps an Anthropic effort to a Responses effort: low/medium/high/xhigh
+// pass through (gpt-5.5 supports xhigh), Anthropic-only "max" clamps to xhigh (its
+// ceiling), and an unset/unknown value yields "" so the caller omits the field.
+func mapEffort(e string) string {
+	switch e {
+	case "low", "medium", "high", "xhigh":
+		return e
+	case "max":
+		return "xhigh"
+	default:
+		return ""
+	}
+}
+
+// effortBucket maps a legacy Anthropic thinking budget to a Responses reasoning effort.
 func effortBucket(budget int) string {
 	switch {
 	case budget <= 0:
@@ -192,7 +241,7 @@ func effortBucket(budget int) string {
 }
 
 // translateMessage maps one Anthropic message to one or more Responses input items.
-func translateMessage(m anthropicMessage) ([]any, error) {
+func translateMessage(m anthropicMessage, cc *convCtx) ([]any, error) {
 	// claude -p sends mid-conversation system-role messages (e.g. the skills
 	// listing); the codex backend rejects role "system" in input, so they ride
 	// as "developer" (same authority tier in the Responses role hierarchy).
@@ -227,9 +276,10 @@ func translateMessage(m anthropicMessage) ([]any, error) {
 			}
 		case "thinking":
 			// Reasoning continuity: the block's signature carries the Responses
-			// encrypted_content the stream converter emitted; replay it as a
-			// reasoning item WITHOUT an id (store:false rejects replayed ids).
-			// A signature-less thinking block has nothing replayable — skip it.
+			// encrypted_content the stream converter emitted; replay it as a reasoning
+			// item WITHOUT an id (codex's store:false backend rejects a replayed id).
+			// (The openai-responses lane may need different replay-id handling; this is
+			// where it would branch.) A signature-less block is unreplayable — skip.
 			if b.Signature == "" {
 				continue
 			}
@@ -244,13 +294,13 @@ func translateMessage(m anthropicMessage) ([]any, error) {
 		case "tool_use":
 			flushText()
 			items = append(items, map[string]any{
-				"type": "function_call", "call_id": b.ID, "name": b.Name,
+				"type": "function_call", "call_id": b.ID, "name": cc.toolMap.sanitize(b.Name),
 				"arguments": string(rawOrEmptyObject(b.Input)),
 			})
 		case "tool_result":
 			flushText()
 			items = append(items, map[string]any{
-				"type": "function_call_output", "call_id": b.ToolUseID, "output": toolResultText(b.Content),
+				"type": "function_call_output", "call_id": b.ToolUseID, "output": toolResultOutput(b),
 			})
 		}
 	}
@@ -289,6 +339,16 @@ func rawOrEmptyObject(raw json.RawMessage) json.RawMessage {
 		return json.RawMessage("{}")
 	}
 	return raw
+}
+
+// toolResultOutput renders a tool_result for the upstream, prefixing a failed result
+// so the model sees the error (the OpenAI tool-output channel has no is_error flag).
+func toolResultOutput(b contentBlock) string {
+	out := toolResultText(b.Content)
+	if b.IsError {
+		return "[tool error] " + out
+	}
+	return out
 }
 
 // toolResultText flattens an Anthropic tool_result content (string OR []block) to

--- a/internal/codexproxy/translate_test.go
+++ b/internal/codexproxy/translate_test.go
@@ -37,7 +37,7 @@ func TestTranslateToolChoice(t *testing.T) {
 		{`{"type":"auto","disable_parallel_tool_use":true}`, "auto", false},
 	}
 	for _, c := range cases {
-		got, parallel := translateToolChoice(json.RawMessage(c.raw))
+		got, parallel := translateToolChoice(json.RawMessage(c.raw), &convCtx{})
 		if parallel != c.wantParallel {
 			t.Fatalf("toolChoice(%s) parallel=%v want %v", c.raw, parallel, c.wantParallel)
 		}
@@ -75,7 +75,7 @@ func TestTranslateRequest_OmitsForbiddenFieldsAndForcesStore(t *testing.T) {
 		},
 	}
 	a.Metadata.UserID = "user_abc_session_123"
-	r, err := translateRequest(a)
+	r, err := translateRequest(a, newConvCtx(a, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestTranslateMessage_SystemRoleRidesAsDeveloper(t *testing.T) {
 	items, err := translateMessage(anthropicMessage{
 		Role:    "system",
 		Content: json.RawMessage(`"The following skills are available"`),
-	})
+	}, &convCtx{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestTranslateMessage_ThinkingReplaysEncryptedReasoning(t *testing.T) {
 			{"type":"thinking","thinking":"no signature -> skipped"},
 			{"type":"text","text":"answer"}
 		]`),
-	})
+	}, &convCtx{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestTranslateMessage_ToolUseAndResult(t *testing.T) {
 	items, err := translateMessage(anthropicMessage{
 		Role:    "assistant",
 		Content: json.RawMessage(`[{"type":"tool_use","id":"toolu_1","name":"grep","input":{"q":"x"}}]`),
-	})
+	}, &convCtx{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestTranslateMessage_ToolUseAndResult(t *testing.T) {
 	items, _ = translateMessage(anthropicMessage{
 		Role:    "user",
 		Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"toolu_1","content":"42"}]`),
-	})
+	}, &convCtx{})
 	m = items[0].(map[string]any)
 	if m["type"] != "function_call_output" || m["call_id"] != "toolu_1" || m["output"] != "42" {
 		t.Fatalf("bad function_call_output item: %v", m)

--- a/internal/codexproxy/upstream.go
+++ b/internal/codexproxy/upstream.go
@@ -46,17 +46,18 @@ func newCodexUpstream(source tokenSource) *codexUpstream {
 
 func (u *codexUpstream) models() []string { return append([]string(nil), codexModels...) }
 
-func (u *codexUpstream) convert(body io.Reader, sink sseSink, model, _ string) error {
-	// codex's upstream errors are canonical (no key), so no redactor is needed.
-	return newStreamConverter(sink, model).Convert(body)
+func (u *codexUpstream) convert(body io.Reader, sink sseSink, cc *convCtx) error {
+	// codex's upstream errors are canonical (no key), so newStreamConverter installs
+	// no redactor (cc.apiKey is "").
+	return newStreamConverter(sink, cc).Convert(body)
 }
 
 // call translates the Anthropic request to a Responses request, sends it, and
-// returns the streaming body on success (the caller owns it). apiKey is ignored —
+// returns the streaming body on success (the caller owns it). cc.apiKey is unused —
 // codex authenticates with its OAuth bearer. On failure it returns a classified
 // *upstreamError; a 401 triggers one refresh+retry.
-func (u *codexUpstream) call(ctx context.Context, areq *anthropicRequest, _ string) (io.ReadCloser, error) {
-	rreq, err := translateRequest(areq)
+func (u *codexUpstream) call(ctx context.Context, areq *anthropicRequest, cc *convCtx) (io.ReadCloser, error) {
+	rreq, err := translateRequest(areq, cc)
 	if err != nil {
 		return nil, &upstreamError{upBadRequest, http.StatusBadRequest, err.Error()}
 	}

--- a/internal/codexproxy/upstream_iface.go
+++ b/internal/codexproxy/upstream_iface.go
@@ -15,11 +15,11 @@ import (
 // /v1/models list (static for codex, unused for openai — its models come from the
 // real upstream's models_endpoint, not this daemon).
 type upstream interface {
-	call(ctx context.Context, areq *anthropicRequest, apiKey string) (io.ReadCloser, error)
-	// convert runs the upstream's SSE→Anthropic converter. apiKey is the presented
-	// key (openai-*) so a streaming error chunk that echoes it is redacted before
-	// it reaches the client; codex ignores it (its bearer is OAuth, not the key).
-	convert(body io.Reader, sink sseSink, model, apiKey string) error
+	call(ctx context.Context, areq *anthropicRequest, cc *convCtx) (io.ReadCloser, error)
+	// convert runs the upstream's SSE→Anthropic converter. cc carries the model, the
+	// presented key (openai-*, so a streaming error chunk that echoes it is redacted —
+	// codex has none), and the per-request tool-name map (sanitized→original restore).
+	convert(body io.Reader, sink sseSink, cc *convCtx) error
 	models() []string
 }
 


### PR DESCRIPTION
The codexproxy daemon converts between the Anthropic Messages format Claude Code speaks and the OpenAI Responses and Chat APIs the provider classes drive. This audits that conversion against the real OpenAI wire (and the cc-switch / hermes-agent references) and closes seven gaps, all threaded through one per-request, immutable conversion context shared by the request translation and the response converter.

The headline fix is thinking effort. Modern Claude Code sends adaptive thinking plus a top-level `output_config.effort` (low/medium/high/xhigh/max) and no `budget_tokens`, so the old budget-only mapping pinned every codex request to the lowest effort and silently dropped the user's explicit choice. The daemon now maps `output_config.effort` to the codex reasoning effort — low/medium/high/xhigh pass through (gpt-5.5 supports xhigh), the Anthropic-only `max` clamps to xhigh, and an unset effort is omitted so the backend uses its own default rather than a forced level — while the openai-responses lane steps xhigh down to high for models that lack it, and the legacy `budget_tokens` bucketing stays as a fallback.

The remaining fixes:

- Prompt-cache stability — Claude Code prepends a volatile `x-anthropic-billing-header` block to the system prompt whose value changes per request; it is now stripped so the multi-thousand-token system prefix stays cacheable upstream.
- Tool names — a name outside the OpenAI function-name charset (a dotted or over-64-character MCP name) is sanitized on the way out and restored on the response tool_use, with conforming names reserved first so a rewrite never collides with a real one.
- `tool_result.is_error` — a failed tool result is prefixed so the model sees the failure (the OpenAI tool-output channel has no error flag).
- `tool_choice` "none" is mapped on the Responses lane (it previously fell through to auto).
- openai-chat usage splits `prompt_tokens_details.cached_tokens` into `cache_read_input_tokens` so the board's metering matches the Responses lane.

The codex-oauth lane (the live-verified path) is behavior-preserving apart from the effort change: its canonical errors stay unredacted while the openai-* lanes still redact an echoed key. The openai-chat and openai-responses live lanes, and the contested encrypted-reasoning replay-id behavior on api.openai.com, are not yet exercised end to end — they need a real OpenAI key — so the replay-id handling keeps the proven codex behavior behind a per-protocol seam.
