### PR TITLE
feat(provider): per-provider model configuration and per-codex logins

### DIFF
--- a/cmd/cc-fleet/add.go
+++ b/cmd/cc-fleet/add.go
@@ -67,6 +67,10 @@ func newAddCmd() *cobra.Command {
 		baseURL        string
 		modelsEndpoint string
 		defaultModel   string
+		strongModel    string
+		fastModel      string
+		effort         string
+		defaultPerm    string
 		secretBackend  string
 		secretRef      string
 		apiKey         string
@@ -150,6 +154,10 @@ when stdin is a tty; otherwise the command exits 1 with a usage error.`,
 				BaseURL:        baseURL,
 				ModelsEndpoint: modelsEndpoint,
 				DefaultModel:   defaultModel,
+				StrongModel:    strongModel,
+				FastModel:      fastModel,
+				Effort:         effort,
+				DefaultPerm:    defaultPerm,
 				SecretBackend:  secretBackend,
 				SecretRef:      secretRef,
 				APIKey:         apiKey,
@@ -186,6 +194,14 @@ when stdin is a tty; otherwise the command exits 1 with a usage error.`,
 		"Vendor /v1/models URL used for probe + cc-fleet refresh (required)")
 	cmd.Flags().StringVar(&defaultModel, "default-model", "",
 		"Model id passed to spawn when --model is omitted (required)")
+	cmd.Flags().StringVar(&strongModel, "strong-model", "",
+		"Optional model id for the 'strong' slot (blank → follows --default-model)")
+	cmd.Flags().StringVar(&fastModel, "fast-model", "",
+		"Optional model id for the 'fast'/background slot (blank → follows --default-model)")
+	cmd.Flags().StringVar(&effort, "effort", "",
+		"Optional reasoning-effort level (low|medium|high|xhigh|max); needs provider support")
+	cmd.Flags().StringVar(&defaultPerm, "default-permission", "",
+		"Optional default permission mode for `cc-fleet run` (default|acceptEdits|plan|auto|bypassPermissions)")
 	cmd.Flags().StringVar(&secretBackend, "secret-backend", "file",
 		"Where to fetch the API key (file|pass|1password|vault|keyring; default: file)")
 	cmd.Flags().StringVar(&secretRef, "secret-ref", "",

--- a/cmd/cc-fleet/codex.go
+++ b/cmd/cc-fleet/codex.go
@@ -11,8 +11,25 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
+
+// codexCredentialRef picks the secret_ref for a new codex provider: the default
+// (cli-ride-capable) credential if no existing codex already holds it, otherwise the
+// provider's own name — mirroring the TUI so the first codex reuses ~/.codex in both.
+func codexCredentialRef(name string) (string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	for _, v := range cfg.Vendors {
+		if v.EffectiveProtocol() == config.ProtocolCodexOAuth && codexproxy.IsDefaultCredentialRef(v.SecretRef) {
+			return name, nil
+		}
+	}
+	return codexproxy.SecretRef, nil
+}
 
 // newCodexCmd builds `cc-fleet codex {login,logout,status,add}` — cc-fleet's own
 // OAuth login for reusing a ChatGPT subscription, kept on an independent token
@@ -23,7 +40,12 @@ func newCodexCmd() *cobra.Command {
 		Short: "Reuse a ChatGPT subscription as a cc-fleet provider",
 	}
 
-	var acceptRisk bool
+	var (
+		acceptRisk bool
+		loginCred  string
+		logoutCred string
+		statusCred string
+	)
 	login := &cobra.Command{
 		Use:           "login",
 		Short:         "Authorize cc-fleet against your ChatGPT subscription (device code)",
@@ -35,31 +57,34 @@ func newCodexCmd() *cobra.Command {
 					return err
 				}
 			}
-			return codexproxy.Login(cmd.Context(), cmd.OutOrStdout())
+			return codexproxy.Login(cmd.Context(), cmd.OutOrStdout(), loginCred)
 		},
 	}
 	login.Flags().BoolVar(&acceptRisk, "accept-risk", false, "skip the account-risk confirmation prompt")
+	login.Flags().StringVar(&loginCred, "credential", "", "credential ref to log in (a codex provider's secret_ref; default: the legacy single credential)")
 	cmd.AddCommand(login)
 
-	cmd.AddCommand(&cobra.Command{
+	logout := &cobra.Command{
 		Use:           "logout",
-		Short:         "Remove cc-fleet's codex login and stop the daemon",
+		Short:         "Remove a codex login and stop its daemon",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := codexproxy.Logout(); err != nil {
+			if err := codexproxy.Logout(logoutCred); err != nil {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "logged out")
 			return nil
 		},
-	})
+	}
+	logout.Flags().StringVar(&logoutCred, "credential", "", "credential ref to log out (default: the legacy single credential)")
+	cmd.AddCommand(logout)
 
-	cmd.AddCommand(&cobra.Command{
+	status := &cobra.Command{
 		Use:   "status",
 		Short: "Show codex credential sources (the codex CLI login and cc-fleet's own)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			st := codexproxy.StatusReport()
+			st := codexproxy.StatusReport(statusCred)
 			out := cmd.OutOrStdout()
 			ride := "unavailable"
 			if st.CLIRide {
@@ -72,13 +97,15 @@ func newCodexCmd() *cobra.Command {
 			fmt.Fprintf(out, "cli-ride:  %s\n", ride)
 			fmt.Fprintf(out, "own-login: %s\n", own)
 			if st.Active == "none" {
-				fmt.Fprintln(out, "active:    none — log in with the codex CLI, or run: cc-fleet codex login")
+				fmt.Fprintf(out, "active:    none — log in with the codex CLI, or run: %s\n", codexproxy.LoginHint(statusCred))
 			} else {
 				fmt.Fprintf(out, "active:    %s (account %s)\n", st.Active, st.Account)
 			}
 			return nil
 		},
-	})
+	}
+	status.Flags().StringVar(&statusCred, "credential", "", "credential ref to inspect (default: the legacy single credential)")
+	cmd.AddCommand(status)
 
 	var (
 		name  string
@@ -99,21 +126,32 @@ func newCodexCmd() *cobra.Command {
 				model = codexproxy.ScanDefaultModel("gpt-5.5")
 			}
 			base := fmt.Sprintf("http://127.0.0.1:%d/", chosen)
+			// The first codex claims the default (cli-ride-capable) credential so it can
+			// reuse ~/.codex; a later one gets its own login keyed on its name. secret_ref
+			// carries that credential id.
+			ref, err := codexCredentialRef(name)
+			if err != nil {
+				return err
+			}
 			res, err := userops.Add(userops.AddRequest{
 				Name:           name,
 				BaseURL:        base,
 				ModelsEndpoint: base + "v1/models",
 				DefaultModel:   model,
 				SecretBackend:  codexproxy.SecretBackend,
-				SecretRef:      codexproxy.SecretRef,
+				SecretRef:      ref,
 				Enabled:        true,
 			})
 			if err != nil {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "added provider %s (port %d, model %s)\n", res.Vendor, chosen, model)
-			if loggedIn, _ := codexproxy.LoginStatus(); !loggedIn {
-				fmt.Fprintln(cmd.OutOrStdout(), "next: cc-fleet codex login")
+			if loggedIn, _ := codexproxy.LoginStatus(ref); !loggedIn {
+				if codexproxy.IsDefaultCredentialRef(ref) {
+					fmt.Fprintln(cmd.OutOrStdout(), "next: cc-fleet codex login")
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "next: cc-fleet codex login --credential %s\n", ref)
+				}
 			}
 			return nil
 		},

--- a/cmd/cc-fleet/codexproxy.go
+++ b/cmd/cc-fleet/codexproxy.go
@@ -20,6 +20,7 @@ func newCodexProxyCmd() *cobra.Command {
 		port        int
 		protocol    string
 		upstreamURL string
+		credential  string
 	)
 	serve := &cobra.Command{
 		Use:           "serve",
@@ -30,12 +31,13 @@ func newCodexProxyCmd() *cobra.Command {
 			if port <= 0 {
 				return fmt.Errorf("--port is required")
 			}
-			return codexproxy.Serve(port, protocol, upstreamURL)
+			return codexproxy.Serve(port, protocol, upstreamURL, credential)
 		},
 	}
 	serve.Flags().IntVar(&port, "port", 0, "loopback port to bind")
 	serve.Flags().StringVar(&protocol, "protocol", "", "wire protocol (default: codex-oauth)")
 	serve.Flags().StringVar(&upstreamURL, "upstream-url", "", "real upstream base URL (openai-* protocols)")
+	serve.Flags().StringVar(&credential, "credential", "", "codex credential ref (default: the legacy single credential)")
 	cmd.AddCommand(serve)
 	cmd.AddCommand(&cobra.Command{
 		Use:   "stop",

--- a/cmd/cc-fleet/edit.go
+++ b/cmd/cc-fleet/edit.go
@@ -18,6 +18,10 @@ type editVendorView struct {
 	Name           string `json:"name"`
 	BaseURL        string `json:"base_url"`
 	DefaultModel   string `json:"default_model"`
+	StrongModel    string `json:"strong_model,omitempty"`
+	FastModel      string `json:"fast_model,omitempty"`
+	Effort         string `json:"effort,omitempty"`
+	DefaultPerm    string `json:"default_permission,omitempty"`
 	ModelsEndpoint string `json:"models_endpoint"`
 	SecretBackend  string `json:"secret_backend"`
 	SecretRef      string `json:"secret_ref"`
@@ -39,6 +43,10 @@ func newEditCmd() *cobra.Command {
 		baseURL        string
 		modelsEndpoint string
 		defaultModel   string
+		strongModel    string
+		fastModel      string
+		effort         string
+		defaultPerm    string
 		secretBackend  string
 		secretRef      string
 		apiKey         string
@@ -125,6 +133,18 @@ changing a URL or key to revalidate.`,
 			if cmdHasFlag(defaultModel) {
 				req.DefaultModel = &defaultModel
 			}
+			if cmdHasFlag(strongModel) {
+				req.StrongModel = &strongModel
+			}
+			if cmdHasFlag(fastModel) {
+				req.FastModel = &fastModel
+			}
+			if cmdHasFlag(effort) {
+				req.Effort = &effort
+			}
+			if cmdHasFlag(defaultPerm) {
+				req.DefaultPerm = &defaultPerm
+			}
 			if cmdHasFlag(secretBackend) {
 				req.SecretBackend = &secretBackend
 			}
@@ -157,6 +177,10 @@ changing a URL or key to revalidate.`,
 						Name:           res.Vendor.Name,
 						BaseURL:        res.Vendor.BaseURL,
 						DefaultModel:   res.Vendor.DefaultModel,
+						StrongModel:    res.Vendor.StrongModel,
+						FastModel:      res.Vendor.FastModel,
+						Effort:         res.Vendor.Effort,
+						DefaultPerm:    res.Vendor.DefaultPermission,
 						ModelsEndpoint: res.Vendor.ModelsEndpoint,
 						SecretBackend:  res.Vendor.SecretBackend,
 						SecretRef:      res.Vendor.SecretRef,
@@ -169,6 +193,18 @@ changing a URL or key to revalidate.`,
 			fmt.Printf("updated vendor %s\n", res.Vendor.Name)
 			fmt.Printf("  base_url         = %s\n", res.Vendor.BaseURL)
 			fmt.Printf("  default_model    = %s\n", res.Vendor.DefaultModel)
+			if res.Vendor.StrongModel != "" {
+				fmt.Printf("  strong_model     = %s\n", res.Vendor.StrongModel)
+			}
+			if res.Vendor.FastModel != "" {
+				fmt.Printf("  fast_model       = %s\n", res.Vendor.FastModel)
+			}
+			if res.Vendor.Effort != "" {
+				fmt.Printf("  effort           = %s\n", res.Vendor.Effort)
+			}
+			if res.Vendor.DefaultPermission != "" {
+				fmt.Printf("  default_perm     = %s\n", res.Vendor.DefaultPermission)
+			}
 			fmt.Printf("  models_endpoint  = %s\n", res.Vendor.ModelsEndpoint)
 			fmt.Printf("  secret_backend   = %s\n", res.Vendor.SecretBackend)
 			fmt.Printf("  secret_ref       = %s\n", res.Vendor.SecretRef)
@@ -186,6 +222,14 @@ changing a URL or key to revalidate.`,
 		"New /v1/models URL")
 	cmd.Flags().StringVar(&defaultModel, "default-model", "",
 		"New default model id")
+	cmd.Flags().StringVar(&strongModel, "strong-model", "",
+		"New 'strong' slot model id (empty arg = no change; clear it in the TUI)")
+	cmd.Flags().StringVar(&fastModel, "fast-model", "",
+		"New 'fast'/background slot model id (empty arg = no change; clear it in the TUI)")
+	cmd.Flags().StringVar(&effort, "effort", "",
+		"New reasoning-effort level (low|medium|high|xhigh|max; empty arg = no change)")
+	cmd.Flags().StringVar(&defaultPerm, "default-permission", "",
+		"New default permission mode for `cc-fleet run` (empty arg = no change)")
 	cmd.Flags().StringVar(&secretBackend, "secret-backend", "",
 		"New secret backend (file|pass|1password|vault|keyring)")
 	cmd.Flags().StringVar(&secretRef, "secret-ref", "",

--- a/cmd/cc-fleet/models.go
+++ b/cmd/cc-fleet/models.go
@@ -4,35 +4,39 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"text/tabwriter"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/ethanhq/cc-fleet/internal/models"
+	"github.com/ethanhq/cc-fleet/internal/config"
 )
 
-// modelsEnvelope is the JSON shape `cc-fleet models <vendor> --json` emits.
-// Models is always serialized (even when empty) so skill code can iterate
-// without a presence check.
+// modelRole is one configured capability slot of a provider's roster.
+type modelRole struct {
+	Role string `json:"role"` // default | strong | fast
+	ID   string `json:"id"`   // the model id passed to claude (may carry the [1m] marker)
+}
+
+// modelsEnvelope is the JSON shape `cc-fleet models <provider> --json` emits: the
+// provider's configured capability roster (default/strong/fast), NOT the full
+// upstream catalog. The full /v1/models list stays in the cache for the TUI model
+// picker; the agent-facing command shows only the few configured slots so a
+// provider with a large catalog can't flood the orchestrator. Models is always
+// serialized (even when empty) so skill code can iterate without a presence check.
 type modelsEnvelope struct {
-	OK         bool           `json:"ok"`
-	Vendor     string         `json:"vendor"`
-	Endpoint   string         `json:"endpoint,omitempty"`
-	FetchedAt  time.Time      `json:"fetched_at,omitempty"`
-	Stale      bool           `json:"stale"`
-	Models     []models.Model `json:"models"`
-	Error      string         `json:"error,omitempty"`
-	ErrorCode  string         `json:"error_code,omitempty"`
-	Suggestion string         `json:"suggestion,omitempty"`
+	OK         bool        `json:"ok"`
+	Vendor     string      `json:"vendor"`
+	Models     []modelRole `json:"models"`
+	Error      string      `json:"error,omitempty"`
+	ErrorCode  string      `json:"error_code,omitempty"`
+	Suggestion string      `json:"suggestion,omitempty"`
 }
 
 // Error codes for `cc-fleet models <vendor>` — kept stable so the skill can
 // dispatch on them without prose parsing.
 const (
-	codeModelsVendorNotInCache = "VENDOR_NOT_IN_CACHE"
-	codeModelsCacheLoadFailed  = "CACHE_LOAD_FAILED"
+	codeModelsVendorUnknown    = "VENDOR_UNKNOWN"
+	codeModelsConfigLoadFailed = "CONFIG_LOAD_FAILED"
 )
 
 func newModelsCmd() *cobra.Command {
@@ -40,15 +44,15 @@ func newModelsCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "models <vendor>",
-		Short: "List cached models for a vendor",
-		Long: `List models in the local cache for <vendor>.
+		Short: "List a provider's configured model roster (default/strong/fast)",
+		Long: `List the configured capability roster for <vendor>: the default, strong, and
+fast model slots from vendors.toml (a blank strong/fast slot follows the
+default). This is intentionally NOT the full ` + "`/v1/models`" + ` catalog — that
+list is only used by the TUI model picker; ` + "`cc-fleet models`" + ` shows just the
+few configured slots so a provider with a large catalog can't flood an agent.
 
-The cache is populated by ` + "`cc-fleet refresh <vendor>`" + `. If <vendor>
-is not in the cache, the command reports an error and tells the user to
-run refresh. Cache entries older than ~/.config/cc-fleet/models-cache.json's
-7-day window are flagged (stale=true in --json; "(stale)" in pretty output).
-
-Use --json for skill consumption.`,
+Use ` + "`--model default|strong|fast`" + ` (or a literal id) on spawn/subagent/run to
+select a slot. Use --json for skill consumption.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -64,33 +68,28 @@ Use --json for skill consumption.`,
 }
 
 func runModels(vendor string, asJSON bool) error {
-	cache, err := models.Load()
+	cfg, err := config.Load()
 	if err != nil {
-		return reportModelsErr(asJSON, vendor, codeModelsCacheLoadFailed,
-			fmt.Errorf("load cache: %w", err),
-			"check ~/.config/cc-fleet/models-cache.json")
+		return reportModelsErr(asJSON, vendor, codeModelsConfigLoadFailed,
+			fmt.Errorf("load vendors.toml: %w", err),
+			"check ~/.config/cc-fleet/vendors.toml")
 	}
 
-	vc, ok := cache.Vendors[vendor]
+	v, ok := cfg.Vendors[vendor]
 	if !ok {
-		return reportModelsErr(asJSON, vendor, codeModelsVendorNotInCache,
-			fmt.Errorf("vendor not in cache (run: cc-fleet refresh %s)", vendor),
-			fmt.Sprintf("cc-fleet refresh %s", vendor))
+		return reportModelsErr(asJSON, vendor, codeModelsVendorUnknown,
+			fmt.Errorf("vendor %q not in vendors.toml (run: cc-fleet list)", vendor),
+			"cc-fleet list")
 	}
 
-	stale := models.IsStale(vc)
+	roster := []modelRole{
+		{Role: config.ModelSlotDefault, ID: v.DefaultModel},
+		{Role: config.ModelSlotStrong, ID: v.StrongModelOrDefault()},
+		{Role: config.ModelSlotFast, ID: v.FastModelOrDefault()},
+	}
+
 	if asJSON {
-		env := modelsEnvelope{
-			OK:        true,
-			Vendor:    vc.Vendor,
-			Endpoint:  vc.Endpoint,
-			FetchedAt: vc.FetchedAt,
-			Stale:     stale,
-			Models:    vc.Models,
-		}
-		if env.Models == nil {
-			env.Models = []models.Model{}
-		}
+		env := modelsEnvelope{OK: true, Vendor: v.Name, Models: roster}
 		data, mErr := json.Marshal(env)
 		if mErr != nil {
 			fmt.Fprintln(os.Stderr, "models: marshal:", mErr)
@@ -100,28 +99,11 @@ func runModels(vendor string, asJSON bool) error {
 		return nil
 	}
 
-	// Pretty mode: header line + table.
-	staleTag := ""
-	if stale {
-		staleTag = " (stale)"
-	}
-	fmt.Printf("vendor %s — %d model(s), fetched %s%s\n",
-		vc.Vendor, len(vc.Models),
-		vc.FetchedAt.Format(time.RFC3339), staleTag)
-
-	if len(vc.Models) == 0 {
-		fmt.Println("(no models — try cc-fleet refresh", vendor+")")
-		return nil
-	}
-
-	// Stable, alphabetical order so successive runs diff cleanly.
-	sorted := append([]models.Model(nil), vc.Models...)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
-
+	fmt.Printf("provider %s — configured model roster:\n", v.Name)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tOWNED_BY")
-	for _, m := range sorted {
-		fmt.Fprintf(w, "%s\t%s\n", m.ID, m.OwnedBy)
+	fmt.Fprintln(w, "ROLE\tMODEL")
+	for _, m := range roster {
+		fmt.Fprintf(w, "%s\t%s\n", m.Role, m.ID)
 	}
 	return w.Flush()
 }
@@ -135,8 +117,7 @@ func reportModelsErr(asJSON bool, vendor, code string, err error, suggestion str
 		env := modelsEnvelope{
 			OK:         false,
 			Vendor:     vendor,
-			Stale:      false,
-			Models:     []models.Model{},
+			Models:     []modelRole{},
 			Error:      err.Error(),
 			ErrorCode:  code,
 			Suggestion: suggestion,

--- a/cmd/cc-fleet/remove.go
+++ b/cmd/cc-fleet/remove.go
@@ -28,12 +28,13 @@ func newRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove <vendor>",
 		Short: "Delete a vendor and its profile (and optionally its secret)",
-		Long: `Delete <vendor> from vendors.toml, remove its profile JSON, and (for
-file-backend vendors) delete its secret file unless --keep-secret is set.
+		Long: `Delete <vendor> from vendors.toml, remove its profile JSON, and (unless
+--keep-secret is set) the credential it owns: a file-backend secret file, or
+a codex provider's own cc-fleet login token plus its daemon.
 
-Non-file backends (pass, 1password, vault, keyring) keep their secrets
-untouched — remove the secret with the backend's own CLI if you no longer
-want it.
+Other external backends (pass, 1password, vault, keyring) and ~/.codex keep
+their secrets untouched — remove those with the backend's own CLI if you no
+longer want them.
 
 Remove is idempotent at the filesystem level: a missing profile or secret
 file is not an error. Removing a non-existent vendor IS an error
@@ -66,7 +67,7 @@ file is not an error. Removing a non-existent vendor IS an error
 	}
 
 	cmd.Flags().BoolVar(&keepSecret, "keep-secret", false,
-		"Don't delete the file-backend secret (no-op for non-file backends)")
+		"Preserve the credential cc-fleet would delete (a file-backend secret or a codex own-login)")
 	cmd.Flags().BoolVar(&asJSON, "json", false,
 		"Emit a machine-readable JSON envelope (for skill consumption)")
 

--- a/internal/childenv/childenv.go
+++ b/internal/childenv/childenv.go
@@ -6,21 +6,45 @@ package childenv
 
 import "strings"
 
+// ModelEnvKeys are the model/effort-selection vars the provider profile owns. A
+// child must not inherit any of these from the launching shell, or an operator's
+// exported value would override the profile (these env vars outrank the profile's
+// settings effortLevel, and ANTHROPIC_MODEL would shadow --model). The subagent /
+// run path strips them here; the spawn teammate path unsets the SAME set in its
+// `env -u` prefix — one exported list so the two launchers can't drift on the
+// policy. The profile then re-injects the per-provider values.
+var ModelEnvKeys = []string{
+	"ANTHROPIC_MODEL",
+	"ANTHROPIC_DEFAULT_OPUS_MODEL",
+	"ANTHROPIC_DEFAULT_SONNET_MODEL",
+	"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	"CLAUDE_CODE_SUBAGENT_MODEL",
+	"CLAUDE_CODE_EFFORT_LEVEL",
+}
+
 // dropList is the variables Clean removes. Key-safety boundary: unexported so no
 // other package can mutate the scrub set, and shared (not duplicated) by subagent
-// and run.
-var dropList = map[string]bool{
-	// Key-safety: never let the lead's subscription creds reach the vendor call;
-	// vendor auth must come solely from the profile's apiKeyHelper.
-	"ANTHROPIC_API_KEY":    true,
-	"ANTHROPIC_AUTH_TOKEN": true,
-	// Nested-CC / teams markers. A child launched from inside the lead's session
-	// inherits these via os.Environ(); leaving CLAUDECODE=1 marks the child as
-	// "nested in CC" (alters/refuses the run), and the teams trigger would make a
-	// non-teammate behave like one. We never re-apply them.
-	"CLAUDECODE":                           true,
-	"CLAUDE_CODE_ENTRYPOINT":               true,
-	"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": true,
+// and run. Built from the credential + nested-CC/teams markers plus ModelEnvKeys.
+var dropList = buildDropList()
+
+func buildDropList() map[string]bool {
+	d := map[string]bool{
+		// Key-safety: never let the lead's subscription creds reach the vendor call;
+		// vendor auth must come solely from the profile's apiKeyHelper.
+		"ANTHROPIC_API_KEY":    true,
+		"ANTHROPIC_AUTH_TOKEN": true,
+		// Nested-CC / teams markers. A child launched from inside the lead's session
+		// inherits these via os.Environ(); leaving CLAUDECODE=1 marks the child as
+		// "nested in CC" (alters/refuses the run), and the teams trigger would make a
+		// non-teammate behave like one. We never re-apply them.
+		"CLAUDECODE":                           true,
+		"CLAUDE_CODE_ENTRYPOINT":               true,
+		"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": true,
+	}
+	for _, k := range ModelEnvKeys {
+		d[k] = true
+	}
+	return d
 }
 
 // Clean returns environ (os.Environ() form) with dropList entries removed. It

--- a/internal/childenv/childenv_test.go
+++ b/internal/childenv/childenv_test.go
@@ -46,6 +46,28 @@ func TestClean_StripsTheLoadBearingVars(t *testing.T) {
 	}
 }
 
+// TestClean_StripsModelEnvKeys: a model/effort var exported in the launching
+// shell must not reach the child — the provider profile is the sole authority, so
+// every ModelEnvKeys entry is stripped while unrelated vars survive.
+func TestClean_StripsModelEnvKeys(t *testing.T) {
+	var in []string
+	for _, k := range ModelEnvKeys {
+		in = append(in, k+"=leaked")
+	}
+	in = append(in, "PATH=/usr/bin")
+	out := Clean(in)
+	for _, k := range ModelEnvKeys {
+		for _, kv := range out {
+			if strings.HasPrefix(kv, k+"=") {
+				t.Fatalf("Clean leaked model env %q: %q", k, kv)
+			}
+		}
+	}
+	if !containsLine(out, "PATH=/usr/bin") {
+		t.Fatalf("Clean dropped an unrelated var: %v", out)
+	}
+}
+
 func containsLine(env []string, want string) bool {
 	for _, kv := range env {
 		if kv == want {

--- a/internal/codexproxy/cliride.go
+++ b/internal/codexproxy/cliride.go
@@ -36,25 +36,31 @@ func codexCLIAuthPath() (string, error) {
 // latest token for free, without cc-fleet ever refreshing that chain itself.
 type cliRideStore struct {
 	own *ownStore
+	// rideAllowed gates the ~/.codex fallback: only the DEFAULT credential may ride
+	// the single CLI file. A named credential must have its own login, else two
+	// named providers would collapse onto the one CLI identity.
+	rideAllowed bool
 }
 
-func newCLIRideStore() (*cliRideStore, error) {
-	own, err := newOwnStore()
+func newCLIRideStore(ref string) (*cliRideStore, error) {
+	own, err := newOwnStore(ref)
 	if err != nil {
 		return nil, err
 	}
-	return &cliRideStore{own: own}, nil
+	return &cliRideStore{own: own, rideAllowed: isDefaultCredential(ref)}, nil
 }
 
 func (s *cliRideStore) token(ctx context.Context) (bearer, error) {
 	// cc-fleet's own login is authoritative: an explicit `cc-fleet codex login`
-	// wins. Ride the codex CLI's ~/.codex only when there is no own login; with
-	// neither, the own store returns ErrReauth.
+	// wins. Ride the codex CLI's ~/.codex only for the default credential and only
+	// when there is no own login; with neither, the own store returns ErrReauth.
 	if s.own.loggedIn() {
 		return s.own.token(ctx)
 	}
-	if b, ok := readCLIRideToken(); ok {
-		return b, nil
+	if s.rideAllowed {
+		if b, ok := readCLIRideToken(); ok {
+			return b, nil
+		}
 	}
 	return s.own.token(ctx)
 }
@@ -110,20 +116,23 @@ type CredStatus struct {
 	Account  string // masked account id of the active source, if any
 }
 
-// StatusReport summarizes both codex credential sources without any refresh or
-// network call (it only reads what is already on disk).
-func StatusReport() CredStatus {
+// StatusReport summarizes a credential's sources without any refresh or network
+// call (it only reads what is already on disk). The CLI-ride source is reported only
+// for the default credential, which is the only ref allowed to ride ~/.codex.
+func StatusReport(ref string) CredStatus {
 	var st CredStatus
-	if loggedIn, account := LoginStatus(); loggedIn {
+	if loggedIn, account := LoginStatus(ref); loggedIn {
 		st.OwnLogin = true
 		st.Active = "own"
 		st.Account = account
 	}
-	if b, ok := readCLIRideToken(); ok {
-		st.CLIRide = true
-		if st.Active == "" {
-			st.Active = "cli-ride"
-			st.Account = redactAccount(b.accountID)
+	if isDefaultCredential(ref) {
+		if b, ok := readCLIRideToken(); ok {
+			st.CLIRide = true
+			if st.Active == "" {
+				st.Active = "cli-ride"
+				st.Account = redactAccount(b.accountID)
+			}
 		}
 	}
 	if st.Active == "" {

--- a/internal/codexproxy/cliride_test.go
+++ b/internal/codexproxy/cliride_test.go
@@ -49,12 +49,12 @@ func writeCLIAuth(t *testing.T, home, access string) []byte {
 
 func rideStore(t *testing.T, rec *recordRT) *cliRideStore {
 	t.Helper()
-	own, err := newOwnStore()
+	own, err := newOwnStore("")
 	if err != nil {
 		t.Fatal(err)
 	}
 	own.oauth = &oauthClient{http: &http.Client{Transport: rec}}
-	return &cliRideStore{own: own}
+	return &cliRideStore{own: own, rideAllowed: true}
 }
 
 func authBytes(t *testing.T, home string) []byte {
@@ -141,7 +141,7 @@ func TestCLIRide_OwnLoginTakesPriority(t *testing.T) {
 	t.Cleanup(srv.Close)
 	target, _ := url.Parse(srv.URL)
 
-	p, err := storePath()
+	p, err := storePath("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,12 +152,12 @@ func TestCLIRide_OwnLoginTakesPriority(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	own, err := newOwnStore()
+	own, err := newOwnStore("")
 	if err != nil {
 		t.Fatal(err)
 	}
 	own.oauth = &oauthClient{http: &http.Client{Transport: rewriteRT{target}}}
-	s := &cliRideStore{own: own}
+	s := &cliRideStore{own: own, rideAllowed: true}
 
 	b, err := s.token(context.Background())
 	if err != nil {
@@ -173,13 +173,13 @@ func TestCLIRide_OwnLoginTakesPriority(t *testing.T) {
 func TestCLIRide_InvalidateGenDomain(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	own, err := newOwnStore()
+	own, err := newOwnStore("")
 	if err != nil {
 		t.Fatal(err)
 	}
 	own.gen = 5
 	own.expiry = time.Now().Add(time.Hour)
-	s := &cliRideStore{own: own}
+	s := &cliRideStore{own: own, rideAllowed: true}
 
 	s.invalidate(0)
 	if own.expiry.IsZero() {
@@ -197,7 +197,7 @@ func TestStatusReport(t *testing.T) {
 	}
 	writeOwn := func(t *testing.T) {
 		t.Helper()
-		p, err := storePath()
+		p, err := storePath("")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -212,7 +212,7 @@ func TestStatusReport(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-		st := StatusReport()
+		st := StatusReport("")
 		if st.CLIRide || st.OwnLogin || st.Active != "none" {
 			t.Fatalf("none: %+v", st)
 		}
@@ -222,7 +222,7 @@ func TestStatusReport(t *testing.T) {
 		t.Setenv("HOME", home)
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		writeCLIAuth(t, home, unexpired())
-		st := StatusReport()
+		st := StatusReport("")
 		if !st.CLIRide || st.OwnLogin || st.Active != "cli-ride" || st.Account == "" {
 			t.Fatalf("ride only: %+v", st)
 		}
@@ -231,7 +231,7 @@ func TestStatusReport(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		writeOwn(t)
-		st := StatusReport()
+		st := StatusReport("")
 		if st.CLIRide || !st.OwnLogin || st.Active != "own" {
 			t.Fatalf("own only: %+v", st)
 		}
@@ -242,7 +242,7 @@ func TestStatusReport(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		writeCLIAuth(t, home, unexpired())
 		writeOwn(t)
-		st := StatusReport()
+		st := StatusReport("")
 		if !st.CLIRide || !st.OwnLogin || st.Active != "own" {
 			t.Fatalf("both: %+v", st)
 		}

--- a/internal/codexproxy/credential_test.go
+++ b/internal/codexproxy/credential_test.go
@@ -1,0 +1,236 @@
+package codexproxy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// setLogin skips the token write (and returns the context error) when its context is
+// already cancelled — so a cancelled/abandoned login never persists an orphan token.
+func TestSetLogin_SkipsOnCancelledContext(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	s, err := newOwnStore("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.setLogin(ctx, &tokens{RefreshToken: "rt", AccountID: "acc"}); err == nil {
+		t.Fatal("setLogin must return the context error when cancelled")
+	}
+	p, err := storePath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Fatalf("setLogin must not write the token file when cancelled, stat err = %v", err)
+	}
+}
+
+// The default credential (empty ref or the legacy sentinel) maps to the unsuffixed
+// legacy filenames; a named credential gets a "-<ref>" suffix on both the token file
+// and its flock, and the two never name-diverge.
+func TestCredentialFilenameMapping(t *testing.T) {
+	for _, ref := range []string{"", SecretRef} {
+		if got := tokenStoreFileFor(ref); got != "codex_oauth.json" {
+			t.Fatalf("tokenStoreFileFor(%q) = %q, want legacy codex_oauth.json", ref, got)
+		}
+		if got := tokenLockFileFor(ref); got != ".cc-fleet-codex-token.lock" {
+			t.Fatalf("tokenLockFileFor(%q) = %q, want legacy lock", ref, got)
+		}
+		if !IsDefaultCredentialRef(ref) {
+			t.Fatalf("IsDefaultCredentialRef(%q) = false, want true", ref)
+		}
+	}
+	if got := tokenStoreFileFor("work"); got != "codex_oauth-work.json" {
+		t.Fatalf("named token file = %q", got)
+	}
+	if got := tokenLockFileFor("work"); got != ".cc-fleet-codex-token-work.lock" {
+		t.Fatalf("named token lock = %q", got)
+	}
+	if IsDefaultCredentialRef("work") {
+		t.Fatal("a named ref must not classify as the default credential")
+	}
+}
+
+// A non-default ref that is not a path-safe identifier is rejected before it can
+// become a token-file / flock name (so a CLI --credential can't escape the dir).
+func TestValidateRef(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	for _, bad := range []string{"../escape", "a/b", "x\x00y", "a b"} {
+		if _, err := newOwnStore(bad); err == nil {
+			t.Fatalf("newOwnStore(%q) should reject a path-unsafe ref", bad)
+		}
+		if err := withTokenLock(bad, func() error { return nil }); err == nil {
+			t.Fatalf("withTokenLock(%q) should reject a path-unsafe ref", bad)
+		}
+	}
+	// The default forms and a plain identifier are accepted.
+	for _, ok := range []string{"", SecretRef, "codex-work"} {
+		if _, err := newOwnStore(ok); err != nil {
+			t.Fatalf("newOwnStore(%q) should accept, got %v", ok, err)
+		}
+	}
+}
+
+// sameCredential treats every default form as one credential (so a daemon recorded
+// before multi-credential, with no Credential field, still matches the default), and
+// keeps distinct names distinct.
+func TestSameCredential(t *testing.T) {
+	if !sameCredential("", SecretRef) {
+		t.Fatal("empty and the sentinel are the same default credential")
+	}
+	if !sameCredential("work", "work") {
+		t.Fatal("equal named refs match")
+	}
+	if sameCredential("", "work") || sameCredential(SecretRef, "work") {
+		t.Fatal("the default credential must not match a named one")
+	}
+	if sameCredential("work", "other") {
+		t.Fatal("two different named refs must not match")
+	}
+}
+
+// writeStore drops a minimal own-store file for ref so LoginStatus/Logout can act on it.
+func writeStore(t *testing.T, ref, account string) string {
+	t.Helper()
+	p, err := storePath(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"refresh_token":"rt","account_id":"`+account+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// Two credentials persist to independent files; a login under one is invisible to the
+// other, and Logout(ref) removes only that ref's file.
+func TestPerCredentialIsolationAndLogout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no ~/.codex
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	defPath := writeStore(t, SecretRef, "acc-default")
+	workPath := writeStore(t, "work", "acc-work")
+	if defPath == workPath {
+		t.Fatal("default and named credentials must use different files")
+	}
+
+	if ok, _ := LoginStatus(SecretRef); !ok {
+		t.Fatal("default credential should read as logged in")
+	}
+	if ok, _ := LoginStatus("work"); !ok {
+		t.Fatal("named credential should read as logged in")
+	}
+
+	if err := Logout("work"); err != nil {
+		t.Fatalf("logout work: %v", err)
+	}
+	if _, err := os.Stat(workPath); !os.IsNotExist(err) {
+		t.Fatal("logout(work) must remove the work token file")
+	}
+	if ok, _ := LoginStatus(SecretRef); !ok {
+		t.Fatal("logout(work) must leave the default credential intact")
+	}
+}
+
+// LogoutIfUnreferenced keeps a credential still claimed by a codex provider (the
+// delete↔re-add race guard) and removes one no longer referenced.
+func TestLogoutIfUnreferenced(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfg := &config.Config{Version: config.SchemaVersion, Vendors: map[string]*config.Vendor{
+		"codex": {
+			Name: "codex", BaseURL: "http://127.0.0.1:17222/",
+			ModelsEndpoint: "http://127.0.0.1:17222/v1/models", DefaultModel: "gpt-5.5",
+			SecretBackend: config.CodexOAuthBackend, SecretRef: config.CodexOAuthBackend,
+			Protocol: config.ProtocolCodexOAuth, Enabled: true,
+		},
+	}}
+	if err := config.Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+	tok := writeStore(t, SecretRef, "acc")
+
+	if err := LogoutIfUnreferenced(SecretRef); err != nil {
+		t.Fatalf("referenced: %v", err)
+	}
+	if _, err := os.Stat(tok); err != nil {
+		t.Fatalf("a still-referenced credential must be kept: %v", err)
+	}
+
+	delete(cfg.Vendors, "codex")
+	if err := config.Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := LogoutIfUnreferenced(SecretRef); err != nil {
+		t.Fatalf("unreferenced: %v", err)
+	}
+	if _, err := os.Stat(tok); !os.IsNotExist(err) {
+		t.Fatalf("an unreferenced credential must be removed, stat err = %v", err)
+	}
+}
+
+// CLI-ride is offered only to the default credential; a named credential with no own
+// login reports no active source even when ~/.codex is present.
+func TestStatusReport_CLIRideDefaultOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeCLIAuth(t, home, fakeJWT(map[string]any{"exp": float64(time.Now().Add(time.Hour).Unix())}))
+
+	if st := StatusReport(SecretRef); !st.CLIRide || st.Active != "cli-ride" {
+		t.Fatalf("default credential should ride ~/.codex: %+v", st)
+	}
+	if st := StatusReport("work"); st.CLIRide || st.Active != "none" {
+		t.Fatalf("named credential must not ride ~/.codex: %+v", st)
+	}
+}
+
+// Purge clears both the legacy and the per-credential token files + locks; under
+// keepToken the token files survive (a login credential) while the locks still go.
+func TestPurge_LegacyAndNamedTokenFiles(t *testing.T) {
+	run := func(t *testing.T, keepToken bool) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		defTok := writeStore(t, SecretRef, "acc")
+		workTok := writeStore(t, "work", "acc")
+		defLock, _ := joinConfig(tokenLockFileFor(SecretRef))
+		workLock, _ := joinConfig(tokenLockFileFor("work"))
+		for _, p := range []string{defLock, workLock} {
+			if err := os.WriteFile(p, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		Purge(keepToken)
+
+		for _, lock := range []string{defLock, workLock} {
+			if _, err := os.Stat(lock); !os.IsNotExist(err) {
+				t.Fatalf("token lock %s must always be purged", filepath.Base(lock))
+			}
+		}
+		for _, tok := range []string{defTok, workTok} {
+			_, err := os.Stat(tok)
+			if keepToken && os.IsNotExist(err) {
+				t.Fatalf("keepToken must retain %s", filepath.Base(tok))
+			}
+			if !keepToken && !os.IsNotExist(err) {
+				t.Fatalf("purge must remove %s", filepath.Base(tok))
+			}
+		}
+	}
+	t.Run("remove", func(t *testing.T) { run(t, false) })
+	t.Run("keep", func(t *testing.T) { run(t, true) })
+}

--- a/internal/codexproxy/daemon.go
+++ b/internal/codexproxy/daemon.go
@@ -30,8 +30,8 @@ const (
 
 // Daemon state is per-port: a state file, a start/exit lock, and a lease dir keyed
 // by port, so a codex daemon and an openai daemon (or two openai daemons) coexist
-// without overwriting each other. The handshake secret + its create-once lock and
-// the token lock stay GLOBAL (one per install), shared by all codex daemons.
+// without overwriting each other. The handshake secret + its create-once lock stay
+// GLOBAL (one per install); the token lock is per credential (see tokenstore.go).
 func statePath(port int) (string, error) {
 	return joinConfig(fmt.Sprintf("codex-proxy-%d.json", port))
 }
@@ -53,14 +53,17 @@ func joinConfig(name string) (string, error) {
 }
 
 // proxyState is the persisted daemon descriptor: pid + procStart guard against PID
-// reuse; the bound port; and the identity (protocol + upstream URL) a reuse check
-// matches against so a daemon left from a different vendor is never reused.
+// reuse; the bound port; and the identity (protocol + upstream URL + codex credential
+// ref) a reuse check matches against so a daemon left from a different vendor — or a
+// different codex account on a recycled port — is never reused. Credential is omitempty
+// so a state file written before multi-credential reads back as the default credential.
 type proxyState struct {
 	Port        int    `json:"port"`
 	PID         int    `json:"pid"`
 	ProcStart   string `json:"proc_start"`
 	Protocol    string `json:"protocol"`
 	UpstreamURL string `json:"upstream_url,omitempty"`
+	Credential  string `json:"credential,omitempty"`
 }
 
 // withProxyLock serializes a single port's daemon start / exit decisions. It is a
@@ -160,12 +163,16 @@ func EnsureForVendor(v *config.Vendor) error {
 	}
 	// codex also serves its models_endpoint from the daemon, and a probe sends the
 	// handshake secret there, so it too must stay loopback.
-	if v.EffectiveProtocol() == config.ProtocolCodexOAuth && v.ModelsEndpoint != "" {
-		if _, err := config.ParseLoopbackURL(v.ModelsEndpoint); err != nil {
-			return fmt.Errorf("codex models_endpoint %w", err)
+	ref := ""
+	if v.EffectiveProtocol() == config.ProtocolCodexOAuth {
+		ref = v.SecretRef // the per-provider credential id (a codex row always has one)
+		if v.ModelsEndpoint != "" {
+			if _, err := config.ParseLoopbackURL(v.ModelsEndpoint); err != nil {
+				return fmt.Errorf("codex models_endpoint %w", err)
+			}
 		}
 	}
-	return EnsureDaemon(port, v.EffectiveProtocol(), v.UpstreamURL)
+	return EnsureDaemon(port, v.EffectiveProtocol(), v.UpstreamURL, ref)
 }
 
 // EnsureDaemon makes the proxy daemon for (port, protocol, upstreamURL) reachable,
@@ -174,16 +181,16 @@ func EnsureForVendor(v *config.Vendor) error {
 // visible. A live daemon is reused only if its persisted identity matches; a
 // mismatch is torn down and restarted. Slot it after the fingerprint gate and
 // before the profile-write side effect.
-func EnsureDaemon(port int, protocol, upstreamURL string) error {
+func EnsureDaemon(port int, protocol, upstreamURL, ref string) error {
 	if protocol == config.ProtocolCodexOAuth {
 		if err := withSecretLock(func() error { _, e := loadOrCreateSecret(); return e }); err != nil {
 			return err
 		}
 	}
 	return withProxyLock(port, func() error {
-		if !healthy(port, protocol, upstreamURL) {
+		if !healthy(port, protocol, upstreamURL, ref) {
 			stopStaleDaemon(port)
-			if err := startDetached(port, protocol, upstreamURL); err != nil {
+			if err := startDetached(port, protocol, upstreamURL, ref); err != nil {
 				return err
 			}
 			if err := waitReady(port); err != nil {
@@ -199,12 +206,17 @@ func EnsureDaemon(port int, protocol, upstreamURL string) error {
 // unresponsive port all return false. Readiness is the upstream-independent
 // /healthz: an openai daemon's /v1/models returns an empty list (its models come
 // from the real upstream), so it is no readiness signal.
-func healthy(port int, protocol, upstreamURL string) bool {
+func healthy(port int, protocol, upstreamURL, ref string) bool {
 	st, err := readState(port)
 	if err != nil || st.Port != port || st.PID <= 0 || !pidAlive(st.PID, st.ProcStart) {
 		return false
 	}
 	if st.Protocol != protocol || st.UpstreamURL != upstreamURL {
+		return false
+	}
+	// A recycled port (remove+add landing on the same port) must never reuse a codex
+	// daemon bound to a different credential — that would serve the wrong account.
+	if protocol == config.ProtocolCodexOAuth && !sameCredential(st.Credential, ref) {
 		return false
 	}
 	return portResponds(port)
@@ -239,7 +251,7 @@ func portResponds(port int) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-func startDetached(port int, protocol, upstreamURL string) error {
+func startDetached(port int, protocol, upstreamURL, ref string) error {
 	if held := whoHoldsPort(port); held {
 		return fmt.Errorf("port %d is held by another process; free it or set a different base_url port", port)
 	}
@@ -250,6 +262,11 @@ func startDetached(port int, protocol, upstreamURL string) error {
 	args := []string{"codex-proxy", "serve", "--port", strconv.Itoa(port), "--protocol", protocol}
 	if upstreamURL != "" {
 		args = append(args, "--upstream-url", upstreamURL)
+	}
+	// The codex credential the daemon binds to (omitted for the default / non-codex,
+	// which keeps the launch argv byte-stable for existing single-codex installs).
+	if !isDefaultCredential(ref) {
+		args = append(args, "--credential", ref)
 	}
 	cmd := exec.Command(bin, args...)
 	cmd.Stdout, cmd.Stderr = nil, nil

--- a/internal/codexproxy/login.go
+++ b/internal/codexproxy/login.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
 )
 
 // RiskNotice is the consent text shown before a device-code login (CLI and TUI):
@@ -20,8 +22,8 @@ the codex CLI's token), but that does not remove the account-level risk.`
 // Login runs an interactive OAuth device-code login and persists an independent
 // token chain to cc-fleet's own store (never touching ~/.codex). It prints the
 // verification URL + user code to out and polls until the user authorizes.
-func Login(ctx context.Context, out io.Writer) error {
-	store, err := newOwnStore()
+func Login(ctx context.Context, out io.Writer, ref string) error {
+	store, err := newOwnStore(ref)
 	if err != nil {
 		return err
 	}
@@ -46,7 +48,7 @@ func Login(ctx context.Context, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		if err := store.setLogin(tk); err != nil {
+		if err := store.setLogin(ctx, tk); err != nil {
 			return err
 		}
 		fmt.Fprintf(out, "Logged in (account %s).\n", redactAccount(tk.AccountID))
@@ -70,8 +72,8 @@ type LoginSession struct {
 
 // BeginDeviceLogin starts a device-code flow and returns the session to display +
 // poll. The caller must have already obtained consent (subscription reuse risk).
-func BeginDeviceLogin(ctx context.Context) (*LoginSession, error) {
-	store, err := newOwnStore()
+func BeginDeviceLogin(ctx context.Context, ref string) (*LoginSession, error) {
+	store, err := newOwnStore(ref)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +99,7 @@ func (s *LoginSession) Poll(ctx context.Context) (done bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	if err := s.store.setLogin(tk); err != nil {
+	if err := s.store.setLogin(ctx, tk); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -106,20 +108,21 @@ func (s *LoginSession) Poll(ctx context.Context) (done bool, err error) {
 // Interval is the minimum delay between Poll calls.
 func (s *LoginSession) Interval() time.Duration { return s.dc.interval }
 
-// LoginStatus reports whether cc-fleet has an independent codex login.
-func LoginStatus() (loggedIn bool, account string) {
-	store, err := newOwnStore()
+// LoginStatus reports whether cc-fleet has an independent codex login for ref.
+func LoginStatus(ref string) (loggedIn bool, account string) {
+	store, err := newOwnStore(ref)
 	if err != nil {
 		return false, ""
 	}
 	return store.loggedIn(), redactAccount(store.data.AccountID)
 }
 
-// Logout removes cc-fleet's own token chain and stops the daemon (whose
-// in-memory access token dies with it). ~/.codex is untouched.
-func Logout() error {
-	if err := withTokenLock(func() error {
-		p, err := storePath()
+// Logout removes a credential's own token chain and stops only the daemons bound to
+// that credential (whose in-memory access token dies with them) — other credentials'
+// daemons keep running. ~/.codex is untouched.
+func Logout(ref string) error {
+	if err := withTokenLock(ref, func() error {
+		p, err := storePath(ref)
 		if err != nil {
 			return err
 		}
@@ -130,7 +133,65 @@ func Logout() error {
 	}); err != nil {
 		return err
 	}
-	return StopDaemon()
+	return stopDaemonsForCredential(ref)
+}
+
+// LogoutIfUnreferenced is the delete-path logout: it drops the credential's login +
+// daemon ONLY when no codex provider in the current config still claims it (the
+// referenced-check + unlink run together under the token lock). The TUI add-login flow
+// commits its provider row before persisting the login token, so a token it wrote
+// implies a committed row this check observes and keeps; a delete racing such an add may
+// remove the row and token together (the delete wins) but never leaves a provider whose
+// just-written login was unlinked. A still-referenced credential is left intact (its
+// daemon too).
+func LogoutIfUnreferenced(ref string) error {
+	skip := false
+	if err := withTokenLock(ref, func() error {
+		if codexCredentialReferenced(ref) {
+			skip = true
+			return nil
+		}
+		p, err := storePath(ref)
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if skip {
+		return nil
+	}
+	return stopDaemonsForCredential(ref)
+}
+
+// codexCredentialReferenced reports whether any codex provider in the config still
+// uses credential ref. On a load error it returns true (fail safe: keep the login
+// rather than delete one that may still be in use).
+func codexCredentialReferenced(ref string) bool {
+	cfg, err := config.Load()
+	if err != nil {
+		return true
+	}
+	for _, v := range cfg.Vendors {
+		if v.EffectiveProtocol() == config.ProtocolCodexOAuth && sameCredential(v.SecretRef, ref) {
+			return true
+		}
+	}
+	return false
+}
+
+// LoginHint is the `cc-fleet codex login` command that authorizes credential ref —
+// bare for the default credential, with `--credential <ref>` for a named one (which
+// cannot ride ~/.codex). Shown in re-login prompts and the status output.
+func LoginHint(ref string) string {
+	if isDefaultCredential(ref) {
+		return "cc-fleet codex login"
+	}
+	return "cc-fleet codex login --credential " + ref
 }
 
 // redactAccount masks an account id for display (it is an identifier, not a secret,

--- a/internal/codexproxy/serve.go
+++ b/internal/codexproxy/serve.go
@@ -19,11 +19,11 @@ import (
 // builds the protocol's upstream, records its state, serves the conversion
 // handler, and self-exits once no matching worker and no launch lease remain
 // (re-checked under the port's proxy lock; a scan error keeps it alive).
-func Serve(port int, protocol, upstreamURL string) error {
+func Serve(port int, protocol, upstreamURL, ref string) error {
 	if protocol == "" {
 		protocol = config.ProtocolCodexOAuth
 	}
-	up, err := buildUpstream(protocol, upstreamURL)
+	up, err := buildUpstream(protocol, upstreamURL, ref)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func Serve(port int, protocol, upstreamURL string) error {
 		return fmt.Errorf("bind 127.0.0.1:%d: %w", port, err)
 	}
 	start, _ := procintrospect.ProcStart(os.Getpid())
-	if err := writeState(proxyState{Port: port, PID: os.Getpid(), ProcStart: start, Protocol: protocol, UpstreamURL: upstreamURL}); err != nil {
+	if err := writeState(proxyState{Port: port, PID: os.Getpid(), ProcStart: start, Protocol: protocol, UpstreamURL: upstreamURL, Credential: ref}); err != nil {
 		ln.Close()
 		return err
 	}
@@ -131,6 +131,35 @@ func StopDaemon() error {
 	return nil
 }
 
+// stopDaemonsForCredential stops only the codex daemons bound to credential ref, so
+// a logout / re-login of one credential leaves other credentials' daemons running.
+// Each port is stopped under its own proxy lock, re-checking the credential there.
+func stopDaemonsForCredential(ref string) error {
+	for _, st := range listStates() {
+		if st.Protocol != config.ProtocolCodexOAuth || !sameCredential(st.Credential, ref) {
+			continue
+		}
+		port := st.Port
+		_ = withProxyLock(port, func() error {
+			cur, err := readState(port)
+			// Re-check protocol too: a recycled port may now hold an openai daemon
+			// (empty credential, which sameCredential treats as the default) — never
+			// stop it on a codex logout.
+			if err != nil || cur.Protocol != config.ProtocolCodexOAuth || !sameCredential(cur.Credential, ref) {
+				return nil
+			}
+			if cur.PID > 0 && pidAlive(cur.PID, cur.ProcStart) {
+				if proc, e := os.FindProcess(cur.PID); e == nil {
+					_ = proc.Signal(os.Interrupt)
+				}
+			}
+			clearState(port)
+			return nil
+		})
+	}
+	return nil
+}
+
 // DaemonInfo describes a running proxy daemon for `codex-proxy status`.
 type DaemonInfo struct {
 	Port     int
@@ -179,22 +208,23 @@ func Purge(keepToken bool) (removed, kept []string) {
 				rm(full)
 			case strings.HasPrefix(name, ".cc-fleet-codex-proxy-") && strings.HasSuffix(name, ".lock"):
 				rm(full)
-			case name == "codex-proxy-secret",
-				name == ".cc-fleet-codex-secret.lock",
-				name == ".cc-fleet-codex-token.lock":
+			// Per-credential token locks AND the legacy unsuffixed lock (the "-<ref>"
+			// glob alone would miss codex_oauth.json's `.cc-fleet-codex-token.lock`).
+			case name == ".cc-fleet-codex-token.lock",
+				strings.HasPrefix(name, ".cc-fleet-codex-token-") && strings.HasSuffix(name, ".lock"):
 				rm(full)
+			case name == "codex-proxy-secret", name == ".cc-fleet-codex-secret.lock":
+				rm(full)
+			// Per-credential token files (codex_oauth-<ref>.json) AND the legacy
+			// codex_oauth.json. Each is a login credential: kept under KeepSecrets.
+			case name == "codex_oauth.json",
+				strings.HasPrefix(name, "codex_oauth-") && strings.HasSuffix(name, ".json"):
+				if keepToken {
+					kept = append(kept, full)
+				} else {
+					rm(full)
+				}
 			}
-		}
-	}
-
-	tokenPath, terr := storePath()
-	if terr == nil {
-		if keepToken {
-			if _, err := os.Stat(tokenPath); err == nil {
-				kept = append(kept, tokenPath)
-			}
-		} else {
-			rm(tokenPath)
 		}
 	}
 	return removed, kept

--- a/internal/codexproxy/server_test.go
+++ b/internal/codexproxy/server_test.go
@@ -140,13 +140,17 @@ func TestHealthyReusesOnlyOnIdentityMatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !healthy(port, config.ProtocolCodexOAuth, "") {
+	if !healthy(port, config.ProtocolCodexOAuth, "", "") {
 		t.Fatal("matching identity must be reused")
 	}
-	if healthy(port, config.ProtocolOpenAIChat, "") {
+	if healthy(port, config.ProtocolOpenAIChat, "", "") {
 		t.Fatal("a different protocol must not be reused")
 	}
-	if healthy(port, config.ProtocolCodexOAuth, "https://api.openai.com/v1") {
+	if healthy(port, config.ProtocolCodexOAuth, "https://api.openai.com/v1", "") {
 		t.Fatal("a different upstream_url must not be reused")
+	}
+	// A default-credential daemon must not be reused by a named credential.
+	if healthy(port, config.ProtocolCodexOAuth, "", "codex-work") {
+		t.Fatal("a different codex credential must not be reused")
 	}
 }

--- a/internal/codexproxy/tokenstore.go
+++ b/internal/codexproxy/tokenstore.go
@@ -11,10 +11,59 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fileutil"
+	"github.com/ethanhq/cc-fleet/internal/ids"
 )
 
-// tokenStoreFile is cc-fleet's own credential store, independent of ~/.codex.
-const tokenStoreFile = "codex_oauth.json"
+// isDefaultCredential reports whether ref names the DEFAULT codex credential: an
+// empty ref or the legacy "codex-oauth" sentinel (SecretRef) — both map to the
+// unsuffixed legacy filenames so a shipped pre-multi login keeps working.
+func isDefaultCredential(ref string) bool { return ref == "" || ref == SecretRef }
+
+// IsDefaultCredentialRef is the exported classifier: whether a vendor's secret_ref
+// claims the default credential (the cli-ride-capable one). The TUI uses it to route
+// the first codex onto the default credential and additional ones onto their own.
+func IsDefaultCredentialRef(ref string) bool { return isDefaultCredential(ref) }
+
+// validateRef guards a non-default credential ref before it becomes a token-file /
+// flock name component, so a CLI `--credential ../x` or an unvalidated form name can
+// never escape the config dir. Config load applies the same grammar to secret_ref;
+// this is the defense at the codexproxy boundary for refs that arrive ahead of it.
+func validateRef(ref string) error {
+	if isDefaultCredential(ref) {
+		return nil
+	}
+	return ids.ValidateVendorName(ref)
+}
+
+// sameCredential reports whether two refs name the same credential, treating every
+// default form (empty, the sentinel, a legacy state file's missing field) as one —
+// so a daemon recorded before this change still matches the default credential.
+func sameCredential(a, b string) bool {
+	if isDefaultCredential(a) && isDefaultCredential(b) {
+		return true
+	}
+	return a == b
+}
+
+// tokenStoreFileFor / tokenLockFileFor derive the per-credential own-store file and
+// its flock from a ref. The default credential keeps the legacy unsuffixed names; a
+// named credential gets a "-<ref>" suffix. BOTH apply isDefaultCredential identically
+// so the token file and its lock can never name-diverge (a divergence would break the
+// reuse-detection double-check in refreshLocked). The ref is config-load-validated as
+// a path/flock-safe identifier (config.validateWire) before it reaches here.
+func tokenStoreFileFor(ref string) string {
+	if isDefaultCredential(ref) {
+		return "codex_oauth.json"
+	}
+	return "codex_oauth-" + ref + ".json"
+}
+
+func tokenLockFileFor(ref string) string {
+	if isDefaultCredential(ref) {
+		return ".cc-fleet-codex-token.lock"
+	}
+	return ".cc-fleet-codex-token-" + ref + ".lock"
+}
 
 // storeData is the on-disk shape (0600). The access token is NOT persisted — only
 // the durable refresh chain + account id.
@@ -46,6 +95,7 @@ type tokenSource interface {
 // login process and the daemon's refresher cannot clobber each other's rotation
 // (the in-process mutex alone cannot serialize two processes).
 type ownStore struct {
+	ref   string // credential ref this store is bound to (drives path + token lock)
 	path  string
 	oauth *oauthClient
 
@@ -57,32 +107,40 @@ type ownStore struct {
 	poisoned bool // a refresh succeeded but its rotated token failed to persist
 }
 
-func storePath() (string, error) {
+func storePath(ref string) (string, error) {
 	dir, err := config.ConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, tokenStoreFile), nil
+	return filepath.Join(dir, tokenStoreFileFor(ref)), nil
 }
 
-// withTokenLock serializes token-store read/refresh/persist across processes.
-// Standalone — held with none of the other flock scopes, so no ordering cycle.
-func withTokenLock(fn func() error) error {
-	p, err := joinConfig(".cc-fleet-codex-token.lock")
+// withTokenLock serializes one credential's token-store read/refresh/persist across
+// processes. Per-credential so a refresh of credential A doesn't serialize against B
+// and the reuse-detection double-check guards the CORRECT file. Standalone — held
+// with none of the other flock scopes, so no ordering cycle.
+func withTokenLock(ref string, fn func() error) error {
+	if err := validateRef(ref); err != nil {
+		return err
+	}
+	p, err := joinConfig(tokenLockFileFor(ref))
 	if err != nil {
 		return err
 	}
 	return config.WithFlock(p, fn)
 }
 
-func newOwnStore() (*ownStore, error) {
-	p, err := storePath()
+func newOwnStore(ref string) (*ownStore, error) {
+	if err := validateRef(ref); err != nil {
+		return nil, err
+	}
+	p, err := storePath(ref)
 	if err != nil {
 		return nil, err
 	}
 	// gen starts at 1 so an own-chain bearer is never generation 0, which the
 	// cliRideStore reserves for its read-only CLI-ride token.
-	s := &ownStore{path: p, oauth: newOAuthClient(), gen: 1}
+	s := &ownStore{ref: ref, path: p, oauth: newOAuthClient(), gen: 1}
 	if err := s.load(); err != nil {
 		return nil, err
 	}
@@ -111,10 +169,16 @@ func (s *ownStore) save() error {
 
 // setLogin records a fresh chain from a completed device login and persists it
 // under the token lock (a concurrently-refreshing daemon must not interleave).
-func (s *ownStore) setLogin(tk *tokens) error {
+func (s *ownStore) setLogin(ctx context.Context, tk *tokens) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := withTokenLock(func() error {
+	if err := withTokenLock(s.ref, func() error {
+		// Re-check cancellation under the lock: if the login was cancelled (e.g. a TUI
+		// add abandoned) while we waited for it, skip the write so the cancelled add
+		// leaves no orphan token — even when this races the delete-path unlink.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		s.data = storeData{RefreshToken: tk.RefreshToken, AccountID: tk.AccountID, IDToken: tk.IDToken}
 		return s.save()
 	}); err != nil {
@@ -138,7 +202,7 @@ func (s *ownStore) token(ctx context.Context) (bearer, error) {
 	if s.access != "" && time.Now().Before(s.expiry.Add(-refreshSkew)) {
 		return bearer{s.access, s.data.AccountID, s.gen}, nil
 	}
-	if err := withTokenLock(func() error { return s.refreshLocked(ctx) }); err != nil {
+	if err := withTokenLock(s.ref, func() error { return s.refreshLocked(ctx) }); err != nil {
 		return bearer{}, err
 	}
 	return bearer{s.access, s.data.AccountID, s.gen}, nil

--- a/internal/codexproxy/tokenstore_test.go
+++ b/internal/codexproxy/tokenstore_test.go
@@ -56,7 +56,7 @@ func TestOwnStore_RefreshReloadsRotatedChainFromDisk(t *testing.T) {
 	t.Cleanup(srv.Close)
 	target, _ := url.Parse(srv.URL)
 
-	p, err := storePath()
+	p, err := storePath("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestOwnStore_RefreshReloadsRotatedChainFromDisk(t *testing.T) {
 	}
 
 	mk := func() *ownStore {
-		s, err := newOwnStore()
+		s, err := newOwnStore("")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/codexproxy/upstream.go
+++ b/internal/codexproxy/upstream.go
@@ -38,10 +38,11 @@ const (
 type codexUpstream struct {
 	http   *http.Client
 	source tokenSource
+	ref    string // credential this daemon serves; shapes the re-login hint
 }
 
-func newCodexUpstream(source tokenSource) *codexUpstream {
-	return &codexUpstream{http: &http.Client{Timeout: 0}, source: source}
+func newCodexUpstream(source tokenSource, ref string) *codexUpstream {
+	return &codexUpstream{http: &http.Client{Timeout: 0}, source: source, ref: ref}
 }
 
 func (u *codexUpstream) models() []string { return append([]string(nil), codexModels...) }
@@ -94,7 +95,7 @@ func (u *codexUpstream) do(ctx context.Context, body []byte) (*http.Response, ui
 	bear, err := u.source.token(ctx)
 	if err != nil {
 		if errors.Is(err, ErrReauth) {
-			return nil, 0, &upstreamError{upAuth, http.StatusUnauthorized, "codex login required (run: cc-fleet codex login)"}
+			return nil, 0, &upstreamError{upAuth, http.StatusUnauthorized, "codex login required (run: " + LoginHint(u.ref) + ")"}
 		}
 		return nil, 0, &upstreamError{upTransient, http.StatusBadGateway, "codex token: " + err.Error()}
 	}

--- a/internal/codexproxy/upstream_iface.go
+++ b/internal/codexproxy/upstream_iface.go
@@ -24,16 +24,17 @@ type upstream interface {
 }
 
 // buildUpstream selects the upstream implementation for a daemon's protocol.
-// codex builds its own OAuth token source; openai-* carries the real key per
-// request (apiKey passed to call), so it only needs the upstream base URL.
-func buildUpstream(protocol, upstreamURL string) (upstream, error) {
+// codex builds its own OAuth token source bound to the daemon's credential ref;
+// openai-* carries the real key per request (apiKey passed to call), so it only
+// needs the upstream base URL and ignores ref.
+func buildUpstream(protocol, upstreamURL, ref string) (upstream, error) {
 	switch protocol {
 	case config.ProtocolCodexOAuth:
-		source, err := newCLIRideStore()
+		source, err := newCLIRideStore(ref)
 		if err != nil {
 			return nil, err
 		}
-		return newCodexUpstream(source), nil
+		return newCodexUpstream(source, ref), nil
 	case config.ProtocolOpenAIChat:
 		return newOpenAIChatUpstream(upstreamURL), nil
 	case config.ProtocolOpenAIResponses:

--- a/internal/config/protocol_test.go
+++ b/internal/config/protocol_test.go
@@ -99,6 +99,26 @@ func TestValidateWire(t *testing.T) {
 			t.Fatalf("codex must reject upstream_url, got %v", err)
 		}
 	})
+	// secret_ref is the per-credential id and becomes a token-file/flock name; a named
+	// ref must be a path-safe identifier, an unsafe one is rejected at load.
+	codexVendor := func(ref string) *Vendor {
+		v := validVendor("c")
+		v.SecretBackend = CodexOAuthBackend
+		v.SecretRef = ref
+		v.BaseURL = "http://127.0.0.1:17222/"
+		v.ModelsEndpoint = "http://127.0.0.1:17222/v1/models"
+		return v
+	}
+	t.Run("codex named secret_ref ok", func(t *testing.T) {
+		if err := codexVendor("codex-work").validate("c"); err != nil {
+			t.Fatalf("a path-safe named secret_ref must pass, got %v", err)
+		}
+	})
+	t.Run("codex path-unsafe secret_ref", func(t *testing.T) {
+		if err := codexVendor("../../etc/passwd").validate("c"); err == nil || !strings.Contains(err.Error(), "secret_ref") {
+			t.Fatalf("a path-unsafe secret_ref must be rejected, got %v", err)
+		}
+	})
 
 	// Anthropic-native must not carry upstream_url.
 	t.Run("anthropic with upstream_url", func(t *testing.T) {
@@ -108,6 +128,45 @@ func TestValidateWire(t *testing.T) {
 			t.Fatalf("anthropic-native must reject upstream_url, got %v", err)
 		}
 	})
+}
+
+// Two codex providers must not resolve to the same login credential: the default
+// (sentinel/empty) is single, and named credentials must be distinct.
+func TestValidate_CodexCredentialUniqueness(t *testing.T) {
+	codex := func(name, ref string) *Vendor {
+		v := validVendor(name)
+		v.Protocol = ProtocolCodexOAuth
+		v.SecretBackend = CodexOAuthBackend
+		v.SecretRef = ref
+		v.BaseURL = "http://127.0.0.1:17222/"
+		v.ModelsEndpoint = "http://127.0.0.1:17222/v1/models"
+		return v
+	}
+	cfg := func(vs ...*Vendor) *Config {
+		c := &Config{Version: SchemaVersion, Vendors: map[string]*Vendor{}}
+		for _, v := range vs {
+			c.Vendors[v.Name] = v
+		}
+		return c
+	}
+
+	// One default + one named is fine.
+	if err := cfg(codex("codex", CodexOAuthBackend), codex("codex-work", "codex-work")).Validate(); err != nil {
+		t.Fatalf("distinct codex credentials must pass, got %v", err)
+	}
+	// Two rows on the default (sentinel) credential → collision.
+	if err := cfg(codex("a", CodexOAuthBackend), codex("b", CodexOAuthBackend)).Validate(); err == nil || !strings.Contains(err.Error(), "share credential") {
+		t.Fatalf("two default-credential codex rows must be rejected, got %v", err)
+	}
+	// Two rows with the same named ref → collision.
+	if err := cfg(codex("a", "shared"), codex("b", "shared")).Validate(); err == nil || !strings.Contains(err.Error(), "share credential") {
+		t.Fatalf("two codex rows sharing a named credential must be rejected, got %v", err)
+	}
+	// A second codex whose secret_ref is literally the sentinel collapses onto the
+	// default credential — must be rejected, not silently share it.
+	if err := cfg(codex("first", CodexOAuthBackend), codex("codex-oauth", CodexOAuthBackend)).Validate(); err == nil || !strings.Contains(err.Error(), "share credential") {
+		t.Fatalf("a sentinel-named second codex must be rejected, got %v", err)
+	}
 }
 
 func TestValidateUpstreamURL(t *testing.T) {

--- a/internal/config/provider_model_test.go
+++ b/internal/config/provider_model_test.go
@@ -1,0 +1,110 @@
+package config
+
+import "testing"
+
+func TestResolveModel(t *testing.T) {
+	v := &Vendor{DefaultModel: "d", StrongModel: "s", FastModel: "f"}
+	cases := map[string]string{
+		"":            "d", // empty → default
+		"default":     "d",
+		"strong":      "s",
+		"fast":        "f",
+		"literal-foo": "literal-foo", // any other value is a literal id
+	}
+	for in, want := range cases {
+		if got := v.ResolveModel(in); got != want {
+			t.Errorf("ResolveModel(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	// Blank strong/fast slots fall back to the default via the keywords.
+	blank := &Vendor{DefaultModel: "d"}
+	if got := blank.ResolveModel("strong"); got != "d" {
+		t.Errorf("blank strong slot: ResolveModel(strong) = %q, want d", got)
+	}
+	if got := blank.ResolveModel("fast"); got != "d" {
+		t.Errorf("blank fast slot: ResolveModel(fast) = %q, want d", got)
+	}
+}
+
+func TestStrongFastModelOrDefault(t *testing.T) {
+	set := &Vendor{DefaultModel: "d", StrongModel: "s", FastModel: "f"}
+	if set.StrongModelOrDefault() != "s" || set.FastModelOrDefault() != "f" {
+		t.Errorf("set slots: strong=%q fast=%q", set.StrongModelOrDefault(), set.FastModelOrDefault())
+	}
+	blank := &Vendor{DefaultModel: "d"}
+	if blank.StrongModelOrDefault() != "d" || blank.FastModelOrDefault() != "d" {
+		t.Errorf("blank slots should follow default: strong=%q fast=%q",
+			blank.StrongModelOrDefault(), blank.FastModelOrDefault())
+	}
+}
+
+func TestContextMarker1M(t *testing.T) {
+	if got := With1M("m"); got != "m[1m]" {
+		t.Errorf("With1M(m) = %q, want m[1m]", got)
+	}
+	if got := With1M("m[1m]"); got != "m[1m]" { // idempotent
+		t.Errorf("With1M is not idempotent: %q", got)
+	}
+	if got := With1M(""); got != "" {
+		t.Errorf("With1M(\"\") = %q, want \"\"", got)
+	}
+	if got := Strip1M("m[1m]"); got != "m" {
+		t.Errorf("Strip1M(m[1m]) = %q, want m", got)
+	}
+	if got := Strip1M("m"); got != "m" { // no-op when absent
+		t.Errorf("Strip1M(m) = %q, want m", got)
+	}
+	if got := Strip1M("a[1m]b"); got != "a[1m]b" { // only a TRAILING marker is stripped
+		t.Errorf("Strip1M(a[1m]b) = %q, want a[1m]b", got)
+	}
+	if !Has1M("m[1m]") || Has1M("m") {
+		t.Errorf("Has1M mismatch: m[1m]=%v m=%v", Has1M("m[1m]"), Has1M("m"))
+	}
+}
+
+func TestEffortLevels(t *testing.T) {
+	got := EffortLevels()
+	want := []string{"low", "medium", "high", "xhigh", "max"}
+	if len(got) != len(want) {
+		t.Fatalf("EffortLevels() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("EffortLevels()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestValidate_EffortAndPermission verifies the config-strict gate rejects an
+// invalid effort or default_permission and accepts the empty (unset) value.
+func TestValidate_EffortAndPermission(t *testing.T) {
+	base := func() *Vendor {
+		return &Vendor{
+			Name: "v", BaseURL: "https://x/anthropic", DefaultModel: "d",
+			ModelsEndpoint: "https://x/v1/models", SecretBackend: "file", SecretRef: "v.key",
+		}
+	}
+	cases := []struct {
+		name    string
+		mutate  func(*Vendor)
+		wantErr bool
+	}{
+		{"effort empty ok", func(v *Vendor) { v.Effort = "" }, false},
+		{"effort max ok", func(v *Vendor) { v.Effort = "max" }, false},
+		{"effort bad", func(v *Vendor) { v.Effort = "ultra" }, true},
+		{"perm empty ok", func(v *Vendor) { v.DefaultPermission = "" }, false},
+		{"perm acceptEdits ok", func(v *Vendor) { v.DefaultPermission = "acceptEdits" }, false},
+		{"perm bad", func(v *Vendor) { v.DefaultPermission = "yolo" }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := base()
+			tc.mutate(v)
+			err := v.validate("v")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validate err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/vendor.go
+++ b/internal/config/vendor.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/fileutil"
 	"github.com/ethanhq/cc-fleet/internal/ids"
+	"github.com/ethanhq/cc-fleet/internal/permmode"
 )
 
 // SchemaVersion is the only supported vendors.toml schema version.
@@ -89,7 +90,114 @@ type Vendor struct {
 	// Required for openai-*, forbidden otherwise. May carry a clean path prefix,
 	// usually ending in /v1.
 	UpstreamURL string `toml:"upstream_url,omitempty"`
+	// StrongModel / FastModel are the optional "strong" and "fast" capability
+	// slots; blank → the slot follows DefaultModel. They populate the Claude Code
+	// model-tier env in the provider profile (opus/haiku aliases + subagent), so a
+	// teammate or subagent never falls back to a built-in claude-* id the provider
+	// can't serve. omitempty keeps existing files byte-stable.
+	StrongModel string `toml:"strong_model,omitempty"`
+	FastModel   string `toml:"fast_model,omitempty"`
+	// Effort is the optional reasoning-effort level (one of validEfforts; "" =
+	// unset). It is written into the profile by the least-intrusive knob that can
+	// express it — "max" via the CLAUDE_CODE_EFFORT_LEVEL env, the others via the
+	// settings effortLevel field — so a session /effort can still override a
+	// non-max default.
+	Effort string `toml:"effort,omitempty"`
+	// DefaultPermission is the permission mode cc-fleet run uses when the caller
+	// passes neither --permission-mode nor --dangerously-skip-permissions ("" = no
+	// default → Claude's own default mode). Run-only; spawn inherits the lead's
+	// mode and subagent keeps its own default.
+	DefaultPermission string `toml:"default_permission,omitempty"`
 }
+
+// The reserved capability keywords ResolveModel (and --model) accept in addition
+// to a literal model id.
+const (
+	ModelSlotDefault = "default"
+	ModelSlotStrong  = "strong"
+	ModelSlotFast    = "fast"
+)
+
+// contextMarker1M is Claude Code's model-id suffix that displays a 1M context
+// window; Claude Code strips it before the API request, so the provider never
+// sees it. Carried inside the stored model id — see With1M / Strip1M.
+const contextMarker1M = "[1m]"
+
+// validEfforts is the closed set of reasoning-effort levels ("" = unset
+// included), rejected at Load like every other enum.
+var validEfforts = []string{"", "low", "medium", "high", "xhigh", "max"}
+
+func isValidEffort(e string) bool {
+	for _, ok := range validEfforts {
+		if e == ok {
+			return true
+		}
+	}
+	return false
+}
+
+// EffortLevels returns the non-empty reasoning-effort levels in canonical order
+// (the dropdown vocabulary; "" / unset is handled at the UI boundary). One source
+// so the config validator and the TUI picker can't drift.
+func EffortLevels() []string {
+	out := make([]string, 0, len(validEfforts))
+	for _, e := range validEfforts {
+		if e != "" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// StrongModelOrDefault / FastModelOrDefault resolve a capability slot to a
+// concrete model id, falling back to DefaultModel when the slot is blank.
+func (v *Vendor) StrongModelOrDefault() string {
+	if v.StrongModel != "" {
+		return v.StrongModel
+	}
+	return v.DefaultModel
+}
+
+func (v *Vendor) FastModelOrDefault() string {
+	if v.FastModel != "" {
+		return v.FastModel
+	}
+	return v.DefaultModel
+}
+
+// ResolveModel maps a requested model to a concrete vendor model id: the reserved
+// keywords default/strong/fast name the matching slot, any other value is a
+// literal id passed through, and "" is DefaultModel. Keyword-first — the three
+// reserved words always name a slot (a real model id is never one of these bare
+// words). One resolver for every launcher (spawn / subagent / run, and the
+// workflow leaf via subagent.Run) so the keyword semantics can't drift.
+func (v *Vendor) ResolveModel(requested string) string {
+	switch requested {
+	case "", ModelSlotDefault:
+		return v.DefaultModel
+	case ModelSlotStrong:
+		return v.StrongModelOrDefault()
+	case ModelSlotFast:
+		return v.FastModelOrDefault()
+	default:
+		return requested
+	}
+}
+
+// With1M appends the 1M-context marker to a model id, idempotently (never doubles
+// it); a blank id is returned unchanged. Strip1M removes a TRAILING marker (an
+// interior "[1m]" is left alone); Has1M reports a trailing marker (the TUI
+// toggle's on/off state).
+func With1M(id string) string {
+	if id == "" || strings.HasSuffix(id, contextMarker1M) {
+		return id
+	}
+	return id + contextMarker1M
+}
+
+func Strip1M(id string) string { return strings.TrimSuffix(id, contextMarker1M) }
+
+func Has1M(id string) bool { return strings.HasSuffix(id, contextMarker1M) }
 
 // EffectiveProtocol resolves the wire protocol, applying the backward-compat rule
 // that a codex-oauth secret_backend with no explicit protocol means the codex
@@ -320,6 +428,14 @@ func (v *Vendor) validate(mapKey string) error {
 	if !isValidKeyRotation(v.KeyRotation) {
 		return fmt.Errorf("config: vendor %q: key_rotation %q invalid (want one of %v)",
 			name, v.KeyRotation, ValidKeyRotations())
+	}
+	if !isValidEffort(v.Effort) {
+		return fmt.Errorf("config: vendor %q: effort %q invalid (want one of %v)",
+			name, v.Effort, validEfforts)
+	}
+	if v.DefaultPermission != "" && !permmode.IsValid(v.DefaultPermission) {
+		return fmt.Errorf("config: vendor %q: default_permission %q invalid (want one of %v)",
+			name, v.DefaultPermission, permmode.Modes)
 	}
 	return nil
 }

--- a/internal/config/vendor.go
+++ b/internal/config/vendor.go
@@ -372,6 +372,25 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	// Each codex provider owns a distinct login credential: the single cli-ride-capable
+	// default (empty / the "codex-oauth" sentinel) plus one named credential per
+	// secret_ref. Two codex rows resolving to the same credential would clobber one
+	// login, so reject that here (the per-vendor pass cannot see across rows).
+	seenCred := make(map[string]string, len(names))
+	for _, name := range names {
+		v := c.Vendors[name]
+		if v.EffectiveProtocol() != ProtocolCodexOAuth {
+			continue
+		}
+		cred := v.SecretRef
+		if cred == "" || cred == CodexOAuthBackend {
+			cred = CodexOAuthBackend // canonical default
+		}
+		if prev, dup := seenCred[cred]; dup {
+			return fmt.Errorf("config: codex providers %q and %q share credential %q; give each a distinct secret_ref", prev, name, v.SecretRef)
+		}
+		seenCred[cred] = name
+	}
 	return nil
 }
 
@@ -465,6 +484,12 @@ func (v *Vendor) validateWire(name string) error {
 	case ProtocolCodexOAuth:
 		if v.SecretBackend != CodexOAuthBackend {
 			return fmt.Errorf("config: vendor %q: codex-oauth protocol requires secret_backend %q", name, CodexOAuthBackend)
+		}
+		// secret_ref is the per-provider credential id; it becomes a token-file and
+		// flock name component, so it must be a path-safe identifier (the legacy
+		// "codex-oauth" sentinel and any provider-name-derived ref both qualify).
+		if err := ids.ValidateVendorName(v.SecretRef); err != nil {
+			return fmt.Errorf("config: vendor %q: codex secret_ref %w", name, err)
 		}
 		if v.UpstreamURL != "" {
 			return fmt.Errorf("config: vendor %q: codex-oauth must not set upstream_url", name)

--- a/internal/profile/generate.go
+++ b/internal/profile/generate.go
@@ -16,10 +16,14 @@ import (
 // profileFile is the on-disk shape of a Claude Code settings/profile file.
 //
 // A named struct (rather than a map) makes MarshalIndent emit a stable key
-// order — apiKeyHelper first, then env.
+// order — apiKeyHelper first, then env, then effortLevel (omitted when unset).
 type profileFile struct {
 	APIKeyHelper string            `json:"apiKeyHelper"`
 	Env          map[string]string `json:"env"`
+	// EffortLevel is the settings reasoning-effort field for a non-"max" provider
+	// effort (max rides the env instead — see GenerateForVendor). omitempty so a
+	// provider with no/effort=="max" emits no effortLevel key.
+	EffortLevel string `json:"effortLevel,omitempty"`
 }
 
 // GenerateForVendor renders the profile JSON for v.
@@ -61,11 +65,34 @@ func GenerateForVendor(v *config.Vendor, helperBinary string) ([]byte, error) {
 	// never enters this string (keyget resolves it at runtime), so quoting
 	// protects only the path + name. A metachar-free path is emitted verbatim so
 	// the profile stays byte-stable.
+	// Pin every Claude Code model slot to a provider model so a teammate/subagent
+	// never falls back to a built-in claude-* id the provider can't serve — the
+	// haiku slot drives background work (titles, context compaction, quick
+	// classification), so leaving it unset breaks long sessions against a vendor
+	// base_url. The main model is the --model flag; these cover the opus/sonnet/
+	// haiku aliases and the Task-subagent model. The [1m] context marker is
+	// stripped here: only the main model (via --model) carries it, where Claude
+	// Code's strip-before-request is the documented behavior.
+	env := map[string]string{
+		"ANTHROPIC_BASE_URL":             v.BaseURL,
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   config.Strip1M(v.StrongModelOrDefault()),
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": config.Strip1M(v.DefaultModel),
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  config.Strip1M(v.FastModelOrDefault()),
+		"CLAUDE_CODE_SUBAGENT_MODEL":     config.Strip1M(v.DefaultModel),
+	}
 	pf := profileFile{
 		APIKeyHelper: posixQuote(helperBinary) + " keyget " + posixQuote(v.Name),
-		Env: map[string]string{
-			"ANTHROPIC_BASE_URL": v.BaseURL,
-		},
+		Env:          env,
+	}
+	// Reasoning effort: "max" only via the env (the settings effortLevel field
+	// can't express it); the other levels via the lower-precedence effortLevel, so
+	// a session /effort can still override the default. Empty → neither.
+	switch v.Effort {
+	case "":
+	case "max":
+		env["CLAUDE_CODE_EFFORT_LEVEL"] = "max"
+	default:
+		pf.EffortLevel = v.Effort
 	}
 
 	out, err := json.MarshalIndent(pf, "", "  ")

--- a/internal/profile/generate_test.go
+++ b/internal/profile/generate_test.go
@@ -36,10 +36,16 @@ func isolateHome(t *testing.T) string {
 func TestGenerateForVendor_Snapshot(t *testing.T) {
 	v := sampleVendor()
 	const helper = "/usr/local/bin/cc-fleet"
+	// A single-model provider (no strong/fast/effort): every Claude Code model tier
+	// is pinned to the default so no built-in claude-* id can escape to the vendor.
 	const want = `{
   "apiKeyHelper": "/usr/local/bin/cc-fleet keyget deepseek",
   "env": {
-    "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic"
+    "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-flash",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-flash",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-flash"
   }
 }`
 
@@ -65,6 +71,78 @@ func TestGenerateForVendor_Snapshot(t *testing.T) {
 	if back.Env["ANTHROPIC_BASE_URL"] != v.BaseURL {
 		t.Fatalf("env[ANTHROPIC_BASE_URL] = %q, want %q",
 			back.Env["ANTHROPIC_BASE_URL"], v.BaseURL)
+	}
+}
+
+// TestGenerateForVendor_TiersEffortAndStrip1M covers a provider that sets a strong
+// and fast slot, a 1M-marked default model, and a non-max effort: the tier env
+// must map opus→strong, sonnet→default, haiku/subagent→fast with the [1m] marker
+// STRIPPED from every tier value, and a non-max effort must ride the settings
+// effortLevel field (not the env).
+func TestGenerateForVendor_TiersEffortAndStrip1M(t *testing.T) {
+	v := &config.Vendor{
+		Name:           "deepseek",
+		BaseURL:        "https://api.deepseek.com/anthropic",
+		DefaultModel:   "deepseek-v4-pro[1m]",
+		StrongModel:    "deepseek-v4-max[1m]",
+		FastModel:      "deepseek-v4-flash",
+		Effort:         "high",
+		ModelsEndpoint: "https://api.deepseek.com/v1/models",
+		SecretBackend:  "file",
+		SecretRef:      "deepseek.key",
+		Enabled:        true,
+	}
+	got, err := GenerateForVendor(v, "/usr/local/bin/cc-fleet")
+	if err != nil {
+		t.Fatalf("GenerateForVendor: %v", err)
+	}
+	var back struct {
+		Env         map[string]string `json:"env"`
+		EffortLevel string            `json:"effortLevel"`
+	}
+	if err := json.Unmarshal(got, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	want := map[string]string{
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   "deepseek-v4-max", // strong, [1m] stripped
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro", // default, [1m] stripped
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "deepseek-v4-flash",
+		"CLAUDE_CODE_SUBAGENT_MODEL":     "deepseek-v4-pro", // default
+	}
+	for k, w := range want {
+		if back.Env[k] != w {
+			t.Errorf("env[%s] = %q, want %q", k, back.Env[k], w)
+		}
+	}
+	if _, ok := back.Env["CLAUDE_CODE_EFFORT_LEVEL"]; ok {
+		t.Errorf("a non-max effort must NOT set CLAUDE_CODE_EFFORT_LEVEL env, got %q", back.Env["CLAUDE_CODE_EFFORT_LEVEL"])
+	}
+	if back.EffortLevel != "high" {
+		t.Errorf("effortLevel = %q, want high", back.EffortLevel)
+	}
+}
+
+// TestGenerateForVendor_MaxEffortRidesEnv covers effort=max: it must ride the env
+// (the only knob that expresses max) and NOT the settings effortLevel field.
+func TestGenerateForVendor_MaxEffortRidesEnv(t *testing.T) {
+	v := sampleVendor()
+	v.Effort = "max"
+	got, err := GenerateForVendor(v, "/usr/local/bin/cc-fleet")
+	if err != nil {
+		t.Fatalf("GenerateForVendor: %v", err)
+	}
+	var back struct {
+		Env         map[string]string `json:"env"`
+		EffortLevel string            `json:"effortLevel"`
+	}
+	if err := json.Unmarshal(got, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.Env["CLAUDE_CODE_EFFORT_LEVEL"] != "max" {
+		t.Errorf("env CLAUDE_CODE_EFFORT_LEVEL = %q, want max", back.Env["CLAUDE_CODE_EFFORT_LEVEL"])
+	}
+	if back.EffortLevel != "" {
+		t.Errorf("max effort must NOT set the settings effortLevel field, got %q", back.EffortLevel)
 	}
 }
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -22,8 +22,10 @@ import (
 )
 
 // Request is a lane-0 launch request. Model overrides the vendor's default_model
-// when non-empty; PermissionMode is a validated permmode value ("" = none, no
-// permission flag); ExtraArgs are passed through to claude after cc-fleet's flags.
+// when non-empty; PermissionMode is a validated permmode value — "" means the
+// caller passed no permission flag, so Run falls back to the provider's configured
+// default_permission (itself possibly "" → no permission flag); ExtraArgs are
+// passed through to claude after cc-fleet's flags.
 type Request struct {
 	Vendor         string
 	Model          string
@@ -89,10 +91,9 @@ func Run(req Request) error {
 		return fmt.Errorf("vendor %q is disabled", req.Vendor)
 	}
 
-	model := req.Model
-	if model == "" {
-		model = v.DefaultModel
-	}
+	// Resolve model (capability keyword default/strong/fast → slot id, else a
+	// literal id, "" → default_model).
+	model := v.ResolveModel(req.Model)
 	// config.Load guarantees a non-empty default_model; this guard is defensive.
 	if model == "" {
 		return fmt.Errorf("vendor %q has no default_model; pass --model", req.Vendor)
@@ -115,7 +116,14 @@ func Run(req Request) error {
 		return fmt.Errorf("write profile: %w", err)
 	}
 
-	argv := buildArgv(bin, profilePath, model, permmode.ExplicitFlags(req.PermissionMode), req.ExtraArgs)
+	// An explicit --permission-mode / --dangerously-skip-permissions (resolved by
+	// the caller into a non-empty PermissionMode) wins; otherwise fall back to the
+	// provider's default_permission ("" → no permission flag, Claude's default mode).
+	permMode := req.PermissionMode
+	if permMode == "" {
+		permMode = v.DefaultPermission
+	}
+	argv := buildArgv(bin, profilePath, model, permmode.ExplicitFlags(permMode), req.ExtraArgs)
 	return execClaude(bin, argv, childenv.Clean(os.Environ()))
 }
 

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -218,7 +218,7 @@ func Spawn(req Request) Result {
 	//     daemon failure is fail-before-mutation (no profile, no pane).
 	if err := ensureVendorProxy(v); err != nil {
 		return fail(ErrCodeProxyUnavailable, err.Error(), req.Vendor,
-			"Run cc-fleet codex login (and check the codex base_url port is free), then retry")
+			"Conversion daemon failed to start — for codex run cc-fleet codex login (add --credential <name> for an extra one); otherwise free the base_url port, then retry")
 	}
 
 	// 6. Ensure the per-vendor profile exists (idempotent write).

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/ethanhq/cc-fleet/internal/childenv"
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
@@ -155,11 +156,9 @@ func Spawn(req Request) Result {
 			"team (--team) is required", req.Vendor, "")
 	}
 
-	// 3. Resolve model.
-	model := req.Model
-	if model == "" {
-		model = v.DefaultModel
-	}
+	// 3. Resolve model (capability keyword default/strong/fast → slot id, else a
+	//    literal id, "" → default_model).
+	model := v.ResolveModel(req.Model)
 
 	// 4. Optional vendor probe (3s GET against models_endpoint, with key).
 	//    Skipped for a codex provider: its models endpoint is served by the
@@ -695,6 +694,12 @@ func buildSpawnCommand(fp *fingerprint.Fingerprint, ctx fingerprint.SpawnContext
 	}
 
 	parts := []string{"env", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN"}
+	// The provider profile owns model/effort selection; unset any value the
+	// launching shell exported so it can't override the profile (mirrors childenv
+	// on the subagent/run path — one shared key list, no drift).
+	for _, k := range childenv.ModelEnvKeys {
+		parts = append(parts, "-u", k)
+	}
 	// Sort env keys for deterministic output (helps tests + diffs).
 	for _, k := range sortedKeys(fp.Env) {
 		parts = append(parts, tmux.Quote(k+"="+fp.Env[k]))

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethanhq/cc-fleet/internal/childenv"
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 	"github.com/ethanhq/cc-fleet/internal/tmux"
@@ -1124,6 +1125,11 @@ func TestBuildSpawnCommand_FrozenTemplate_StripsThenByteStable(t *testing.T) {
 	// permission flags STRIPPED + --settings + --model.
 	var want []string
 	want = append(want, "env", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN")
+	// The model/effort env is unset so the launching shell can't override the
+	// profile (same key list childenv strips on the subagent/run path).
+	for _, k := range childenv.ModelEnvKeys {
+		want = append(want, "-u", k)
+	}
 	want = append(want, tmux.Quote("CLAUDECODE=1"))
 	want = append(want, tmux.Quote("/usr/bin/claude"))
 	for _, f := range stripPermissionFlags(fingerprint.Apply(fp, ctx)) {

--- a/internal/subagent/classify.go
+++ b/internal/subagent/classify.go
@@ -251,7 +251,7 @@ func suggestionFor(code string) string {
 	case ErrCodeFingerprintMissing, ErrCodeFingerprintStale:
 		return "Run the FINGERPRINT self-heal flow (native probe → cc-fleet refresh-fingerprint), then retry"
 	case ErrCodeProxyUnavailable:
-		return "Run cc-fleet codex login (and check the codex base_url port is free), then retry"
+		return "Conversion daemon failed to start — for codex run cc-fleet codex login (add --credential <name> for an extra one); otherwise free the base_url port, then retry"
 	case ErrCodeKeyInvalid:
 		return "Rotate the vendor API key; do not retry until fixed"
 	case ErrCodeCloudflareBlocked:

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -121,11 +121,9 @@ func Run(req Request) Result {
 			req.Vendor, suggestionFor(ErrCodeVendorDisabled))
 	}
 
-	// 2. Resolve model.
-	model := req.Model
-	if model == "" {
-		model = v.DefaultModel
-	}
+	// 2. Resolve model (capability keyword default/strong/fast → slot id, else a
+	//    literal id, "" → default_model).
+	model := v.ResolveModel(req.Model)
 
 	// 3. Resolve the spawn recipe (probed fingerprint if present, else bundled
 	//    default). Use ONLY the binary path, never fp.Env — it carries the

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -26,7 +26,8 @@ func isModelSlotKey(key string) bool {
 	return key == "default_model" || key == "strong_model" || key == "fast_model"
 }
 
-// orOff maps an unset config value to the "off" dropdown option.
+// orOff maps an unset config value to the "off" label — the dropdown option in the
+// edit form and the displayed value in the read-only preview card.
 func orOff(s string) string {
 	if s == "" {
 		return "off"
@@ -105,19 +106,21 @@ func newTextInput(value, placeholder string, password bool) textinput.Model {
 
 // newAddForm builds the add wizard, prefilled from a vendor template. A zero
 // Template (the "Custom" choice) yields blank fields the user fills entirely.
-// Field order: name → base_url → models_endpoint → api_key → default_model.
+// Field order: name → base_url → models_endpoint → api_key → the model-config rows
+// (default/strong/fast + 1M toggles, effort, default permission).
 func newAddForm(t Template) form {
+	fields := []formField{
+		{key: "name", label: "Name", kind: fieldText, input: newTextInput(t.Name, "provider id, e.g. deepseek", false)},
+		{key: "base_url", label: "Base URL", kind: fieldText, input: newTextInput(t.BaseURL, "https://…/anthropic", false)},
+		{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(t.ModelsEndpoint, "https://…/v1/models", false)},
+		{key: "api_key", label: "API key", kind: fieldText, input: newTextInput("", "stored at <name>.key (mode 0600)", true)},
+	}
+	fields = append(fields, modelConfigFields(t.DefaultModel, "", "", "", "")...)
 	f := form{
 		title:  "Add provider",
-		intro:  "↑/↓ or tab move · enter advances · enter on [Add] submits · esc cancels",
+		intro:  "↑/↓ move rows · → 1M toggle · enter on [Add] submits · esc cancels",
 		submit: "Add",
-		fields: []formField{
-			{key: "name", label: "Name", kind: fieldText, input: newTextInput(t.Name, "provider id, e.g. deepseek", false)},
-			{key: "base_url", label: "Base URL", kind: fieldText, input: newTextInput(t.BaseURL, "https://…/anthropic", false)},
-			{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(t.ModelsEndpoint, "https://…/v1/models", false)},
-			{key: "api_key", label: "API key", kind: fieldText, input: newTextInput("", "stored at <name>.key (mode 0600)", true)},
-			{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(t.DefaultModel, "model id", false)},
-		},
+		fields: fields,
 	}
 	f.setFocus(0)
 	return f
@@ -131,17 +134,18 @@ func newOpenAIAddForm(t OAITemplate) form {
 	if t.UpstreamURL != "" {
 		models = strings.TrimRight(t.UpstreamURL, "/") + "/models"
 	}
+	fields := []formField{
+		{key: "name", label: "Name", kind: fieldText, input: newTextInput(t.Name, "provider id, e.g. openai", false)},
+		{key: "upstream_url", label: "Upstream URL", kind: fieldText, input: newTextInput(t.UpstreamURL, "https://api.openai.com/v1", false)},
+		{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(models, "https://…/v1/models", false)},
+		{key: "api_key", label: "API key", kind: fieldText, input: newTextInput("", "stored at <name>.key (mode 0600)", true)},
+	}
+	fields = append(fields, modelConfigFields(t.DefaultModel, "", "", "", "")...)
 	f := form{
 		title:  "Add OpenAI provider",
-		intro:  "↑/↓ or tab move · enter advances · enter on [Add] submits · esc cancels",
+		intro:  "↑/↓ move rows · → 1M toggle · enter on [Add] submits · esc cancels",
 		submit: "Add",
-		fields: []formField{
-			{key: "name", label: "Name", kind: fieldText, input: newTextInput(t.Name, "provider id, e.g. openai", false)},
-			{key: "upstream_url", label: "Upstream URL", kind: fieldText, input: newTextInput(t.UpstreamURL, "https://api.openai.com/v1", false)},
-			{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(models, "https://…/v1/models", false)},
-			{key: "api_key", label: "API key", kind: fieldText, input: newTextInput("", "stored at <name>.key (mode 0600)", true)},
-			{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(t.DefaultModel, "model id", false)},
-		},
+		fields: fields,
 	}
 	f.setFocus(0)
 	return f
@@ -150,19 +154,37 @@ func newOpenAIAddForm(t OAITemplate) form {
 // newCodexAddForm builds the minimal codex add wizard. The loopback base_url +
 // models_endpoint and the codex-oauth backend are assigned on submit; the
 // upstream is the fixed ChatGPT backend, so there is no key or URL to enter.
-func newCodexAddForm(defaultModel, statusNote string) form {
+func newCodexAddForm(name, defaultModel, statusNote string) form {
+	fields := []formField{
+		{key: "name", label: "Name", kind: fieldText, input: newTextInput(name, "provider id", false)},
+	}
+	fields = append(fields, modelConfigFields(defaultModel, "", "", "", "")...)
 	f := form{
 		title:      "Add codex provider",
-		intro:      "↑/↓ or tab move · enter on [Add] submits · esc cancels",
+		intro:      "↑/↓ move rows · → 1M toggle · enter on [Add] submits · esc cancels",
 		submit:     "Add",
 		statusNote: statusNote,
-		fields: []formField{
-			{key: "name", label: "Name", kind: fieldText, input: newTextInput("codex", "provider id", false)},
-			{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(defaultModel, "model id", false)},
-		},
+		fields:     fields,
 	}
 	f.setFocus(0)
 	return f
+}
+
+// modelConfigFields builds the shared model-roster rows used by the edit form and
+// the three add forms: default/strong/fast model slots (each a bare-id text field
+// with an inline [1m] toggle, recombined on submit) plus the effort + run-permission
+// choice dropdowns. One source so the add/edit dropdown vocab + nav can't drift.
+func modelConfigFields(defModel, strong, fast, effort, perm string) []formField {
+	return []formField{
+		{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(config.Strip1M(defModel), "model id", false)},
+		{key: "default_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(defModel)},
+		{key: "strong_model", label: "Strong model", kind: fieldText, input: newTextInput(config.Strip1M(strong), "blank → follows default", false)},
+		{key: "strong_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(strong)},
+		{key: "fast_model", label: "Fast model", kind: fieldText, input: newTextInput(config.Strip1M(fast), "blank → follows default", false)},
+		{key: "fast_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(fast)},
+		newChoiceField("effort", "Effort", effortChoices, orOff(effort)),
+		newChoiceField("permission", "Run perm", permChoices, orOff(perm)),
+	}
 }
 
 // newEditForm builds the edit wizard, prefilled from the vendor's current row.
@@ -185,19 +207,8 @@ func newEditForm(v userops.VendorView) form {
 			formField{key: "base_url", label: "Base URL", kind: fieldText, input: newTextInput(v.BaseURL, "https://…/anthropic", false)},
 			formField{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(v.ModelsEndpoint, "https://…/v1/models", false)})
 	}
-	// Model slots: each holds the BARE id in its text field with the [1m]
-	// context marker carried by an adjacent toggle — recombined on submit (see
-	// submitEdit). strong/fast blank → that slot follows the default.
-	fields = append(fields,
-		formField{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(config.Strip1M(v.DefaultModel), "model id", false)},
-		formField{key: "default_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(v.DefaultModel)},
-		formField{key: "strong_model", label: "Strong model", kind: fieldText, input: newTextInput(config.Strip1M(v.StrongModel), "blank → follows default", false)},
-		formField{key: "strong_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(v.StrongModel)},
-		formField{key: "fast_model", label: "Fast model", kind: fieldText, input: newTextInput(config.Strip1M(v.FastModel), "blank → follows default", false)},
-		formField{key: "fast_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(v.FastModel)},
-		newChoiceField("effort", "Effort", effortChoices, orOff(v.Effort)),
-		newChoiceField("permission", "Run perm", permChoices, orOff(v.DefaultPerm)),
-		formField{key: "enabled", label: "Enabled", kind: fieldToggle, on: v.Enabled})
+	fields = append(fields, modelConfigFields(v.DefaultModel, v.StrongModel, v.FastModel, v.Effort, v.DefaultPerm)...)
+	fields = append(fields, formField{key: "enabled", label: "Enabled", kind: fieldToggle, on: v.Enabled})
 	if v.SecretBackend != config.CodexOAuthBackend {
 		fields = append(fields, formField{key: "manage_keys", label: "Manage API keys →", kind: fieldAction})
 	}
@@ -255,9 +266,8 @@ func (f form) Update(msg tea.KeyMsg) (form, tea.Cmd, bool) {
 		f.setFocus(f.stepFocus(f.focus, +1))
 		return f, nil, false
 	case "right":
-		// → on a model slot reaches its inline 1M toggle — only when that toggle
-		// exists (the add form has model fields but no 1M toggles, so → there falls
-		// through to the text cursor; a choice cycles below).
+		// → on a model slot reaches its inline 1M toggle when that slot has one;
+		// otherwise it falls through to the text cursor (a choice cycles below).
 		if mk := oneMKeyFor(f.focusedKey()); mk != "" {
 			if idx, ok := f.indexOfKey(mk); ok {
 				f.setFocus(idx)
@@ -370,9 +380,9 @@ func (f form) keyAt(idx int) string {
 	return f.fields[idx].key
 }
 
-// indexOfKey returns the field index for key and whether it exists — a model slot
-// has a 1M toggle only in the edit form, so callers must guard on the bool rather
-// than mis-focusing a not-found key.
+// indexOfKey returns the field index for key and whether it exists — not every form
+// instance carries every field (a model slot may have no paired 1M toggle), so
+// callers must guard on the bool rather than mis-focusing a not-found key.
 func (f form) indexOfKey(key string) (int, bool) {
 	for i := range f.fields {
 		if f.fields[i].key == key {
@@ -463,6 +473,36 @@ func fieldNote(key string) string {
 		return "enter opens the per-provider key manager."
 	}
 	return ""
+}
+
+// fieldNoteKeys enumerates the keys fieldNote returns a non-empty note for, so the
+// per-width note reserve can find the tallest wrap (default_1m stands in for all
+// three 1M toggles — they share a note).
+var fieldNoteKeys = []string{
+	"default_model", "strong_model", "fast_model", "default_1m", "effort", "permission", "enabled", "manage_keys",
+}
+
+// fieldNoteReserve is the tallest a field note wraps to at this width (≥1). The edit
+// form and the read-only preview card both pad their Note body to it so the Config
+// block sits at the same row in both — entering edit doesn't shift Config down.
+func fieldNoteReserve(width int) int {
+	r := 1
+	for _, k := range fieldNoteKeys {
+		if n := len(wrapTo(fieldNote(k), width-2)); n > r {
+			r = n
+		}
+	}
+	return r
+}
+
+// noteReserve is the fixed line count the Note body occupies at this width: the
+// tallest wrap of the form's statusNote (codex source), or of any fieldNote, so the
+// Config block stays at a constant row as focus moves (no "jump"). At least 1.
+func (f form) noteReserve(width int) int {
+	if f.statusNote != "" {
+		return max(1, len(wrapTo(f.statusNote, width-2)))
+	}
+	return fieldNoteReserve(width)
 }
 
 // focusedKey returns the key of the currently focused field, or "" when focus
@@ -560,21 +600,29 @@ func (f form) viewLines(width int) []string {
 	// codex login a codex provider reuses) takes it and wraps to the pane width;
 	// otherwise it shows the focused field's contextual hint.
 	lines = append(lines, contentStyle.Render("Note"))
+	// Build the Note body + its style, then pad it to a fixed reserve = the tallest
+	// any note wraps to at this width (see noteReserve), so the Config block sits at
+	// a constant row as focus moves — no "jump" — and nothing is truncated.
+	var body []string
+	bodyStyle := faintStyle
 	if f.statusNote != "" {
-		for _, w := range wrapTo(f.statusNote, width-2) {
-			lines = append(lines, " "+okStyle.Render(w))
-		}
+		body, bodyStyle = wrapTo(f.statusNote, width-2), okStyle
 	} else {
 		focusedKey := ""
 		if f.focus < len(f.fields) {
 			focusedKey = f.fields[f.focus].key
 		}
 		if n := fieldNote(focusedKey); n != "" {
-			for _, w := range wrapTo(n, width-2) {
-				lines = append(lines, " "+noteStyle.Render(w))
-			}
+			body, bodyStyle = wrapTo(n, width-2), noteStyle
 		} else {
-			lines = append(lines, " "+faintStyle.Render("—"))
+			body = []string{"—"}
+		}
+	}
+	for i, reserve := 0, f.noteReserve(width); i < reserve; i++ {
+		if i < len(body) {
+			lines = append(lines, " "+bodyStyle.Render(body[i]))
+		} else {
+			lines = append(lines, "")
 		}
 	}
 	lines = append(lines, "", faintStyle.Render("Config"))
@@ -593,8 +641,8 @@ func (f form) viewLines(width int) []string {
 		switch fld.kind {
 		case fieldText:
 			line := " " + keyCell + "  " + fld.input.View()
-			// A model slot trails its 1M-context toggle on the same row — only when
-			// that toggle exists (the add form has no 1M toggles).
+			// A model slot trails its 1M-context toggle on the same row, when that
+			// slot has one.
 			if mk := oneMKeyFor(fld.key); mk != "" {
 				if _, ok := f.indexOfKey(mk); ok {
 					line += "   " + f.render1MTag(mk)

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -8,8 +8,31 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/permmode"
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
+
+// effortChoices / permChoices are the static edit-form dropdown vocabularies;
+// the leading "off" maps to an unset field on submit. Built from the config /
+// permmode sources so the dropdowns can't drift from the validators.
+var (
+	effortChoices = append([]string{"off"}, config.EffortLevels()...)
+	permChoices   = append([]string{"off"}, permmode.Modes...)
+)
+
+// isModelSlotKey reports whether key is one of the three model-slot text fields
+// (default/strong/fast) — the fields that open the model picker on enter.
+func isModelSlotKey(key string) bool {
+	return key == "default_model" || key == "strong_model" || key == "fast_model"
+}
+
+// orOff maps an unset config value to the "off" dropdown option.
+func orOff(s string) string {
+	if s == "" {
+		return "off"
+	}
+	return s
+}
 
 // fieldKind distinguishes a free-text input, a boolean toggle, and an action
 // row (a focusable label the parent model activates on enter — e.g. the edit
@@ -20,16 +43,33 @@ const (
 	fieldText fieldKind = iota
 	fieldToggle
 	fieldAction
+	fieldChoice
 )
 
 // formField is one row of a form. For fieldText the value lives in input;
-// for fieldToggle it lives in on; fieldAction rows carry only a label.
+// for fieldToggle it lives in on; for fieldChoice it is choices[choiceIdx];
+// fieldAction rows carry only a label.
 type formField struct {
-	key   string // logical key (base_url, api_key, enabled, …)
-	label string
-	kind  fieldKind
-	input textinput.Model // used when kind == fieldText
-	on    bool            // used when kind == fieldToggle
+	key       string // logical key (base_url, api_key, enabled, …)
+	label     string
+	kind      fieldKind
+	input     textinput.Model // used when kind == fieldText
+	on        bool            // used when kind == fieldToggle
+	choices   []string        // used when kind == fieldChoice (cycled with space/←/→)
+	choiceIdx int             // used when kind == fieldChoice
+}
+
+// newChoiceField builds a choice row pre-selected to current (the first choice
+// when current isn't in the set).
+func newChoiceField(key, label string, choices []string, current string) formField {
+	idx := 0
+	for i, c := range choices {
+		if c == current {
+			idx = i
+			break
+		}
+	}
+	return formField{key: key, label: label, kind: fieldChoice, choices: choices, choiceIdx: idx}
 }
 
 // form is a tiny multi-field wizard built on bubbles/textinput. Focus walks
@@ -145,15 +185,25 @@ func newEditForm(v userops.VendorView) form {
 			formField{key: "base_url", label: "Base URL", kind: fieldText, input: newTextInput(v.BaseURL, "https://…/anthropic", false)},
 			formField{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(v.ModelsEndpoint, "https://…/v1/models", false)})
 	}
+	// Model slots: each holds the BARE id in its text field with the [1m]
+	// context marker carried by an adjacent toggle — recombined on submit (see
+	// submitEdit). strong/fast blank → that slot follows the default.
 	fields = append(fields,
-		formField{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(v.DefaultModel, "model id", false)},
+		formField{key: "default_model", label: "Default model", kind: fieldText, input: newTextInput(config.Strip1M(v.DefaultModel), "model id", false)},
+		formField{key: "default_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(v.DefaultModel)},
+		formField{key: "strong_model", label: "Strong model", kind: fieldText, input: newTextInput(config.Strip1M(v.StrongModel), "blank → follows default", false)},
+		formField{key: "strong_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(v.StrongModel)},
+		formField{key: "fast_model", label: "Fast model", kind: fieldText, input: newTextInput(config.Strip1M(v.FastModel), "blank → follows default", false)},
+		formField{key: "fast_1m", label: "1M context", kind: fieldToggle, on: config.Has1M(v.FastModel)},
+		newChoiceField("effort", "Effort", effortChoices, orOff(v.Effort)),
+		newChoiceField("permission", "Run perm", permChoices, orOff(v.DefaultPerm)),
 		formField{key: "enabled", label: "Enabled", kind: fieldToggle, on: v.Enabled})
 	if v.SecretBackend != config.CodexOAuthBackend {
 		fields = append(fields, formField{key: "manage_keys", label: "Manage API keys →", kind: fieldAction})
 	}
 	f := form{
 		title:  "Edit provider: " + v.Name,
-		intro:  "↑/↓ or tab move · space toggles Enabled · enter on [Save] submits · esc cancels",
+		intro:  "↑/↓ move rows · → 1M toggle · space toggles · enter on [Save] submits · esc cancels",
 		submit: "Save",
 		fields: fields,
 	}
@@ -189,10 +239,10 @@ func (f *form) setFocus(i int) {
 func (f form) Update(msg tea.KeyMsg) (form, tea.Cmd, bool) {
 	switch msg.String() {
 	case "up", "shift+tab":
-		f.setFocus(f.focus - 1)
+		f.setFocus(f.stepFocus(f.focus, -1))
 		return f, nil, false
 	case "down", "tab":
-		f.setFocus(f.focus + 1)
+		f.setFocus(f.stepFocus(f.focus, +1))
 		return f, nil, false
 	case "enter":
 		if f.focus == len(f.fields) {
@@ -202,19 +252,46 @@ func (f form) Update(msg tea.KeyMsg) (form, tea.Cmd, bool) {
 			f.fields[f.focus].on = !f.fields[f.focus].on
 			return f, nil, false
 		}
-		f.setFocus(f.focus + 1)
+		f.setFocus(f.stepFocus(f.focus, +1))
 		return f, nil, false
+	case "right":
+		// → on a model slot reaches its inline 1M toggle — only when that toggle
+		// exists (the add form has model fields but no 1M toggles, so → there falls
+		// through to the text cursor; a choice cycles below).
+		if mk := oneMKeyFor(f.focusedKey()); mk != "" {
+			if idx, ok := f.indexOfKey(mk); ok {
+				f.setFocus(idx)
+				return f, nil, false
+			}
+		}
+	case "left":
+		// ← on a 1M toggle returns to its model slot (a choice cycles instead).
+		if mk := modelKeyFor1m(f.focusedKey()); mk != "" {
+			if idx, ok := f.indexOfKey(mk); ok {
+				f.setFocus(idx)
+				return f, nil, false
+			}
+		}
 	}
 
-	// On a field: toggles consume space/left/right; text fields get the key;
-	// action rows swallow everything else (the parent handles their enter).
+	// On a field: a toggle flips on space; a choice cycles on space/←/→; text
+	// fields get the key; action rows swallow everything else (the parent handles
+	// their enter).
 	if f.focus < len(f.fields) {
 		fld := &f.fields[f.focus]
 		switch fld.kind {
 		case fieldToggle:
 			switch msg.String() {
-			case " ", "space", "left", "right":
+			case " ", "space":
 				fld.on = !fld.on
+			}
+			return f, nil, false
+		case fieldChoice:
+			switch msg.String() {
+			case " ", "space", "right":
+				fld.choiceIdx = (fld.choiceIdx + 1) % len(fld.choices)
+			case "left":
+				fld.choiceIdx = (fld.choiceIdx - 1 + len(fld.choices)) % len(fld.choices)
 			}
 			return f, nil, false
 		case fieldAction:
@@ -242,6 +319,150 @@ func (f form) value(key string) string {
 // the arrow keys for cursor movement).
 func (f form) focusedText() bool {
 	return f.focus < len(f.fields) && f.fields[f.focus].kind == fieldText
+}
+
+// focusedChoice reports whether focus sits on a choice field (which consumes ←/→
+// to cycle its options rather than letting ← navigate back to the list).
+func (f form) focusedChoice() bool {
+	return f.focus < len(f.fields) && f.fields[f.focus].kind == fieldChoice
+}
+
+// oneMKeyFor maps a model-slot text field to its inline 1M-context toggle key, or
+// "" for a non-slot field. The toggle renders as a trailing column on the model
+// row (see viewLines) instead of its own line, and is reached laterally with →.
+func oneMKeyFor(modelKey string) string {
+	switch modelKey {
+	case "default_model":
+		return "default_1m"
+	case "strong_model":
+		return "strong_1m"
+	case "fast_model":
+		return "fast_1m"
+	}
+	return ""
+}
+
+// modelKeyFor1m is the inverse of oneMKeyFor: the model-slot key a 1M toggle
+// belongs to, or "" when key isn't a 1M toggle.
+func modelKeyFor1m(oneMKey string) string {
+	switch oneMKey {
+	case "default_1m":
+		return "default_model"
+	case "strong_1m":
+		return "strong_model"
+	case "fast_1m":
+		return "fast_model"
+	}
+	return ""
+}
+
+func isOneMKey(key string) bool { return modelKeyFor1m(key) != "" }
+
+// focusedOneM reports whether focus sits on an inline 1M toggle (reached via →,
+// returned from via ←) — so the parent's ← "back to list" doesn't fire there.
+func (f form) focusedOneM() bool { return isOneMKey(f.focusedKey()) }
+
+// keyAt returns the field key at idx (or "" for the submit row / out of range).
+func (f form) keyAt(idx int) string {
+	if idx < 0 || idx >= len(f.fields) {
+		return ""
+	}
+	return f.fields[idx].key
+}
+
+// indexOfKey returns the field index for key and whether it exists — a model slot
+// has a 1M toggle only in the edit form, so callers must guard on the bool rather
+// than mis-focusing a not-found key.
+func (f form) indexOfKey(key string) (int, bool) {
+	for i := range f.fields {
+		if f.fields[i].key == key {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// stepFocus returns the next focus index moving by dir (±1). The form is a small
+// grid: a model column (with the single-control rows) and a parallel 1M-context
+// column for the model rows. ↑/↓ stay in their column — from a 1M toggle they land
+// on the next row's 1M toggle (or fall back to the model column when the next row
+// has none); → / ← switch columns. The 1M toggles are skipped when walking the
+// model column.
+func (f form) stepFocus(from, dir int) int {
+	inCtx := isOneMKey(f.keyAt(from))
+	cur := from
+	if mk := modelKeyFor1m(f.keyAt(from)); mk != "" {
+		if idx, ok := f.indexOfKey(mk); ok {
+			cur = idx // navigate from the toggle's model row
+		}
+	}
+	next := -1
+	for i := cur + dir; i >= 0 && i < len(f.fields); i += dir {
+		if !isOneMKey(f.fields[i].key) {
+			next = i
+			break
+		}
+	}
+	if next < 0 {
+		if cur+dir >= len(f.fields) {
+			return len(f.fields) // the submit button
+		}
+		return 0
+	}
+	// Vertical nav keeps the 1M-context column when the next row also has one.
+	if inCtx {
+		if mk := oneMKeyFor(f.keyAt(next)); mk != "" {
+			if idx, ok := f.indexOfKey(mk); ok {
+				return idx
+			}
+		}
+	}
+	return next
+}
+
+// render1MTag draws a model slot's 1M-context toggle as a trailing tag, lit when
+// its toggle field holds focus.
+func (f form) render1MTag(key string) string {
+	on, focused := false, false
+	for i, fld := range f.fields {
+		if fld.key == key {
+			on, focused = fld.on, i == f.focus
+			break
+		}
+	}
+	state := "[ ]"
+	if on {
+		state = "[x]"
+	}
+	tag := "1M ctx " + state
+	if focused {
+		return selectedStyle.Render(tag)
+	}
+	return faintStyle.Render(tag)
+}
+
+// fieldNote is the focused field's contextual explanation, shown in the Note
+// section above the Config rows — what each slot is for, not just how to edit it.
+func fieldNote(key string) string {
+	switch key {
+	case "default_model":
+		return "default — the model teammates and subagents run on. enter picks from the provider's model list."
+	case "strong_model":
+		return "strong — for heavier reasoning and plan mode; blank follows default. enter picks from the list."
+	case "fast_model":
+		return "fast — background work (titles, context compaction) and light calls; blank follows default. enter picks from the list."
+	case "default_1m", "strong_1m", "fast_1m":
+		return "1M context — mark this model's window as 1M; the marker is stripped before the request reaches the provider."
+	case "effort":
+		return "reasoning effort — needs provider support, else requests may error. space / ←/→ cycles."
+	case "permission":
+		return "default permission mode for `cc-fleet run`. space / ←/→ cycles."
+	case "enabled":
+		return "enter / space toggles whether the provider is enabled."
+	case "manage_keys":
+		return "enter opens the per-provider key manager."
+	}
+	return ""
 }
 
 // focusedKey returns the key of the currently focused field, or "" when focus
@@ -276,6 +497,16 @@ func (f form) boolValue(key string) bool {
 	return false
 }
 
+// choiceValue returns the selected option of a choice field by key ("" if absent).
+func (f form) choiceValue(key string) string {
+	for _, fld := range f.fields {
+		if fld.key == key && fld.kind == fieldChoice && fld.choiceIdx >= 0 && fld.choiceIdx < len(fld.choices) {
+			return fld.choices[fld.choiceIdx]
+		}
+	}
+	return ""
+}
+
 // cardKey maps a field to the config card's short key column, so the edit card lines up
 // with the read-only preview (the same grammar, editable values).
 func cardKey(key string) string {
@@ -288,6 +519,14 @@ func cardKey(key string) string {
 		return "models"
 	case "default_model":
 		return "default"
+	case "strong_model":
+		return "strong"
+	case "fast_model":
+		return "fast"
+	case "effort":
+		return "effort"
+	case "permission":
+		return "run perm"
 	case "api_key":
 		return "key"
 	case "manage_keys":
@@ -326,21 +565,25 @@ func (f form) viewLines(width int) []string {
 			lines = append(lines, " "+okStyle.Render(w))
 		}
 	} else {
-		note := faintStyle.Render("—")
+		focusedKey := ""
 		if f.focus < len(f.fields) {
-			switch fld := f.fields[f.focus]; {
-			case fld.key == "default_model" && f.value("models_endpoint") != "":
-				note = contentStyle.Render("enter picks from the provider's model list")
-			case fld.kind == fieldToggle:
-				note = contentStyle.Render("enter / space toggles")
-			case fld.key == "manage_keys":
-				note = contentStyle.Render("enter opens the key manager")
-			}
+			focusedKey = f.fields[f.focus].key
 		}
-		lines = append(lines, " "+note)
+		if n := fieldNote(focusedKey); n != "" {
+			for _, w := range wrapTo(n, width-2) {
+				lines = append(lines, " "+noteStyle.Render(w))
+			}
+		} else {
+			lines = append(lines, " "+faintStyle.Render("—"))
+		}
 	}
 	lines = append(lines, "", faintStyle.Render("Config"))
 	for i, fld := range f.fields {
+		// A model slot's 1M toggle renders as a trailing column on the model row
+		// (below), not its own line — skip it in the per-field loop.
+		if fld.key == "default_1m" || fld.key == "strong_1m" || fld.key == "fast_1m" {
+			continue
+		}
 		focused := i == f.focus
 		key := fmt.Sprintf("%-8s", cardKey(fld.key))
 		keyCell := faintStyle.Render(key)
@@ -349,13 +592,27 @@ func (f form) viewLines(width int) []string {
 		}
 		switch fld.kind {
 		case fieldText:
-			lines = append(lines, " "+keyCell+"  "+fld.input.View())
+			line := " " + keyCell + "  " + fld.input.View()
+			// A model slot trails its 1M-context toggle on the same row — only when
+			// that toggle exists (the add form has no 1M toggles).
+			if mk := oneMKeyFor(fld.key); mk != "" {
+				if _, ok := f.indexOfKey(mk); ok {
+					line += "   " + f.render1MTag(mk)
+				}
+			}
+			lines = append(lines, line)
 		case fieldToggle:
 			state := "[ ] off"
 			if fld.on {
 				state = "[x] on"
 			}
 			lines = append(lines, " "+keyCell+"  "+contentStyle.Render(state))
+		case fieldChoice:
+			val := ""
+			if fld.choiceIdx >= 0 && fld.choiceIdx < len(fld.choices) {
+				val = fld.choices[fld.choiceIdx]
+			}
+			lines = append(lines, " "+keyCell+"  "+contentStyle.Render("‹ "+val+" ›"))
 		case fieldAction:
 			// Value-column action label; enter on it is handled by the parent
 			// model (e.g. open the key manager).

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -247,6 +247,9 @@ type Model struct {
 	modelCursor int
 	modelsErr   error
 	modelFilter string
+	// pickerTarget is the form field the model picker writes its choice back into
+	// (default_model / strong_model / fast_model). Empty falls back to default_model.
+	pickerTarget string
 
 	// Remove confirmation target.
 	removeName string
@@ -2969,9 +2972,10 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "esc" {
 		return m.toList()
 	}
-	// ← returns to the provider list from any non-text row (a text field keeps
-	// the arrow for its input cursor).
-	if msg.String() == "left" && !m.form.focusedText() {
+	// ← returns to the provider list from a row that doesn't consume it — a text
+	// field keeps the arrow for its input cursor, a choice field cycles options,
+	// and a 1M toggle uses ← to return to its model slot.
+	if msg.String() == "left" && !m.form.focusedText() && !m.form.focusedChoice() && !m.form.focusedOneM() {
 		return m.toList()
 	}
 	// Enter (or →, the descend key) on the "Manage API keys →" action row (edit
@@ -2989,8 +2993,9 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// codex has no probeable models endpoint (its /v1/models is the lazily-started
 	// loopback daemon), so it seeds the picker from the static codex model list
 	// instead of a fetch — for both add and edit.
-	if msg.String() == "enter" && m.form.focusedKey() == "default_model" &&
+	if msg.String() == "enter" && isModelSlotKey(m.form.focusedKey()) &&
 		m.addProtocol == config.ProtocolCodexOAuth {
+		m.pickerTarget = m.form.focusedKey()
 		m.screen = screenModelPick
 		m.loading = false
 		m.modelList = codexStaticModelList()
@@ -3001,8 +3006,9 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	// Other providers hit their models_endpoint; custom vendors without one fall
 	// through to manual text entry.
-	if msg.String() == "enter" && m.form.focusedKey() == "default_model" &&
+	if msg.String() == "enter" && isModelSlotKey(m.form.focusedKey()) &&
 		m.form.value("models_endpoint") != "" {
+		m.pickerTarget = m.form.focusedKey()
 		m.screen = screenModelPick
 		m.loading = true
 		m.modelList = nil
@@ -3038,7 +3044,11 @@ func (m Model) updateModelPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, textinput.Blink
 	case "enter":
 		if len(filtered) > 0 {
-			m.form.setValue("default_model", filtered[m.modelCursor].ID)
+			target := m.pickerTarget
+			if target == "" {
+				target = "default_model"
+			}
+			m.form.setValue(target, filtered[m.modelCursor].ID)
 		}
 		m.screen = screenForm
 		return m, textinput.Blink
@@ -3439,9 +3449,24 @@ func (m Model) submitAddAnthropic() (tea.Model, tea.Cmd) {
 
 // submitEdit validates the edit form and dispatches userops.Edit.
 func (m Model) submitEdit() (tea.Model, tea.Cmd) {
-	defaultModel := m.form.value("default_model")
+	// Recombine each model slot's bare id with its 1M toggle; the choice fields
+	// map "off" → unset. The TUI is the full editor, so every field is sent
+	// (including a clear) — editLocked diffs against the stored value.
+	defaultModel := combine1M(m.form.value("default_model"), m.form.boolValue("default_1m"))
+	strongModel := combine1M(m.form.value("strong_model"), m.form.boolValue("strong_1m"))
+	fastModel := combine1M(m.form.value("fast_model"), m.form.boolValue("fast_1m"))
+	effort := offToEmpty(m.form.choiceValue("effort"))
+	defaultPerm := offToEmpty(m.form.choiceValue("permission"))
 	enabled := m.form.boolValue("enabled")
-	req := userops.EditRequest{Name: m.editName, DefaultModel: &defaultModel, Enabled: &enabled}
+	req := userops.EditRequest{
+		Name:         m.editName,
+		DefaultModel: &defaultModel,
+		StrongModel:  &strongModel,
+		FastModel:    &fastModel,
+		Effort:       &effort,
+		DefaultPerm:  &defaultPerm,
+		Enabled:      &enabled,
+	}
 
 	// The editable endpoint follows the form's class (newEditForm): openai-* edits
 	// upstream_url, codex edits neither (loopback/internal), others edit base_url.
@@ -3471,6 +3496,27 @@ func (m Model) submitEdit() (tea.Model, tea.Cmd) {
 	m.form.err = ""
 	m.loading = true
 	return m, editVendorCmd(req)
+}
+
+// combine1M folds a model slot's bare id and its 1M toggle into the stored id: a
+// blank slot stays blank (it follows the default), an "on" slot carries the [1m]
+// marker, an "off" slot is stripped of it.
+func combine1M(id string, on bool) string {
+	if id == "" {
+		return ""
+	}
+	if on {
+		return config.With1M(id)
+	}
+	return config.Strip1M(id)
+}
+
+// offToEmpty maps the "off" dropdown option back to an unset ("") config value.
+func offToEmpty(s string) string {
+	if s == "off" {
+		return ""
+	}
+	return s
 }
 
 // missingLabels returns the labels (in the given order) whose value is empty.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/models"
 	"github.com/ethanhq/cc-fleet/internal/onboarding"
 	"github.com/ethanhq/cc-fleet/internal/panevis"
@@ -61,8 +62,9 @@ const (
 type codexAuthStage int
 
 const (
-	codexAuthConsent codexAuthStage = iota // risk notice; enter accepts
-	codexAuthDevice                        // device-code shown; polling for authorization
+	codexAuthConsent      codexAuthStage = iota // risk notice; enter accepts
+	codexAuthDevice                             // device-code shown; polling for authorization
+	codexAuthChooseSource                       // a subscription is detected: reuse it or log in separately
 )
 
 // formMode records whether the active form is an add or an edit so submit
@@ -109,12 +111,24 @@ type Model struct {
 	tmplCursor  int
 	addProtocol string
 
-	// screenCodexAuth: consent → device-code login session. codexAuthEpoch tags
-	// each login attempt so a prior visit's async msgs (esc then re-enter) drop.
-	codexAuthStage codexAuthStage
-	codexAuth      *codexproxy.LoginSession
-	codexAuthErr   string
-	codexAuthEpoch int
+	// screenCodexAuth: an optional source choice (reuse a detected subscription, or
+	// log in separately) then consent → device-code login. codexAuthEpoch tags each
+	// login attempt so a prior visit's async msgs (esc then re-enter) drop.
+	// codexPendingAdd holds the add request awaiting a source choice (cli-ride only).
+	// A login-needed codex commits its row FIRST (so a concurrent remove's
+	// referenced-check sees it), then logs in: codexCommittedName names that committed
+	// row (the rollback target if the login is abandoned) and codexAddRef its
+	// credential, so the login writes the file the provider's secret_ref names.
+	codexAuthStage     codexAuthStage
+	codexAuth          *codexproxy.LoginSession
+	codexAuthErr       string
+	codexAuthEpoch     int
+	codexAuthCtx       context.Context    // device-login session scope; cancelled on abandon/success
+	codexAuthCancel    context.CancelFunc // so an in-flight poll can't write a token after abandon
+	codexPendingAdd    *userops.AddRequest
+	codexAddRef        string
+	codexCommittedName string // committed-but-not-yet-logged-in codex row; rolled back on abandon
+	codexAuthAccount   string // detected cli-ride account, shown on the source-choice stage
 
 	// Agents Board (screenSpawn): live teammates, workflow runs, and async subagent
 	// jobs in one master-detail board. asMode re-roots the levels (projects → sessions →
@@ -1046,6 +1060,24 @@ func removeVendorCmd(name string) tea.Cmd {
 	}
 }
 
+// codexRollbackDoneMsg reports a finished abandon-rollback (a codex row removed after
+// its login was cancelled). Distinct from opDoneMsg so the cancel lands quietly on the
+// provider list rather than a "remove OK" result screen; epoch-tagged so a stale one
+// can't disturb a newer attempt.
+type codexRollbackDoneMsg struct{ epoch int }
+
+func (codexRollbackDoneMsg) owningScreen() screen { return screenCodexAuth }
+
+// codexRollbackCmd removes a codex row committed ahead of a login the user then
+// cancelled (best-effort: the row removal is what matters; its empty login is cleaned
+// by Remove's own LogoutIfUnreferenced).
+func codexRollbackCmd(name string, epoch int) tea.Cmd {
+	return func() tea.Msg {
+		_, _ = userops.Remove(userops.RemoveRequest{Name: name})
+		return codexRollbackDoneMsg{epoch: epoch}
+	}
+}
+
 // modelsMsg carries the result of fetching a vendor's model list for the picker.
 // It implements screenOwnedAsyncMsg so a result arriving after the user has
 // left the picker is dropped — otherwise a stale modelList would leak into the
@@ -1427,6 +1459,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case opDoneMsg:
 		m.loading = false
+		// A codex row committed ahead of its login (see submitAddCodex) now routes to the
+		// device-code login instead of a result screen; a failed add clears the marker.
+		if msg.verb == "add" && msg.err == nil && m.codexCommittedName != "" {
+			m.screen = screenCodexAuth
+			m.codexAuthStage = codexAuthConsent
+			m.codexAuthErr = ""
+			return m, nil
+		}
+		m.codexCommittedName = ""
 		m.screen = screenResult
 		if msg.err != nil {
 			m.resultErr = true
@@ -1449,10 +1490,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.codexAuth = msg.session
-		return m, pollCodexAuthCmd(m.codexAuthEpoch, msg.session)
+		return m, pollCodexAuthCmd(m.codexAuthCtx, m.codexAuthEpoch, msg.session)
 
 	case codexAuthPollMsg:
-		if msg.epoch != m.codexAuthEpoch {
+		// A stale-epoch result (the user abandoned and the epoch advanced) or one with no
+		// live session is dropped before it can show success for a torn-down attempt.
+		if msg.epoch != m.codexAuthEpoch || m.codexAuth == nil {
 			return m, nil
 		}
 		if msg.err != nil {
@@ -1461,14 +1504,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if msg.done {
+			// The provider row was already committed before the login (see
+			// submitAddCodex); the login just filled its credential, so report success.
+			if m.codexAuthCancel != nil {
+				m.codexAuthCancel()
+				m.codexAuthCancel, m.codexAuthCtx = nil, nil
+			}
 			m.codexAuth = nil
-			m.form = newCodexAddForm(codexproxy.ScanDefaultModel("gpt-5.5"), codexSourceNote(codexproxy.StatusReport()))
-			m.formMode = modeAdd
-			m.addProtocol = config.ProtocolCodexOAuth
-			m.screen = screenForm
-			return m, textinput.Blink
-		}
-		if m.codexAuth == nil {
+			name := m.codexCommittedName
+			m.codexCommittedName = ""
+			m.loading = false
+			m.screen = screenResult
+			m.resultErr = false
+			m.result = fmt.Sprintf("add %q: OK", name)
 			return m, nil
 		}
 		return m, codexAuthTickCmd(m.codexAuthEpoch, m.codexAuth.Interval())
@@ -1477,7 +1525,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.epoch != m.codexAuthEpoch || m.codexAuth == nil || m.screen != screenCodexAuth {
 			return m, nil
 		}
-		return m, pollCodexAuthCmd(m.codexAuthEpoch, m.codexAuth)
+		return m, pollCodexAuthCmd(m.codexAuthCtx, m.codexAuthEpoch, m.codexAuth)
+
+	case codexRollbackDoneMsg:
+		// Drop a rollback completion from an abandoned flow whose epoch has since moved
+		// on, so it can't yank a newer attempt back to the list.
+		if msg.epoch != m.codexAuthEpoch {
+			return m, nil
+		}
+		m.loading = false
+		return m.toList()
 
 	case keysetMsg:
 		if msg.err != nil {
@@ -2803,6 +2860,28 @@ func (m Model) updatePickTemplate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// uniqueName returns base, or the first free "<base>-N" when base is already a
+// configured provider — a prefill convenience for adding a second provider of one
+// type. The real uniqueness guard stays addLocked's VENDOR_EXISTS check; a blank
+// base (a Custom entry) is returned unchanged.
+func (m Model) uniqueName(base string) string {
+	if base == "" {
+		return ""
+	}
+	taken := make(map[string]bool, len(m.vendors))
+	for _, v := range m.vendors {
+		taken[v.Name] = true
+	}
+	if !taken[base] {
+		return base
+	}
+	for n := 2; ; n++ {
+		if cand := fmt.Sprintf("%s-%d", base, n); !taken[cand] {
+			return cand
+		}
+	}
+}
+
 // chooseAddItem opens the add form (or the codex auth flow) for a picked row.
 func (m Model) chooseAddItem(it addItem) (tea.Model, tea.Cmd) {
 	switch it.class {
@@ -2815,6 +2894,7 @@ func (m Model) chooseAddItem(it addItem) (tea.Model, tea.Cmd) {
 			t = OAITemplates[it.oIdx]
 			protocol = t.Protocol
 		}
+		t.Name = m.uniqueName(t.Name)
 		m.form = newOpenAIAddForm(t)
 		m.addProtocol = protocol
 	default: // addCatAnthropic
@@ -2822,6 +2902,7 @@ func (m Model) chooseAddItem(it addItem) (tea.Model, tea.Cmd) {
 		if it.tIdx >= 0 {
 			t = Templates[it.tIdx]
 		}
+		t.Name = m.uniqueName(t.Name)
 		m.form = newAddForm(t)
 		m.addProtocol = ""
 	}
@@ -2830,22 +2911,33 @@ func (m Model) chooseAddItem(it addItem) (tea.Model, tea.Cmd) {
 	return m, textinput.Blink
 }
 
-// enterCodexFlow opens the codex add form when a usable credential source already
-// exists (reusing the codex CLI login, or cc-fleet's own), naming the source so the
-// user sees no key is needed; with no source it routes to the consent + device-code
-// login screen.
+// enterCodexFlow opens the codex add form. The credential the provider will use —
+// the cli-ride-capable default for the first codex, a fresh per-provider login for
+// any later one — is decided here only to label the source note; the actual
+// login (when the credential has none) happens at submit, keyed on the final name.
 func (m Model) enterCodexFlow() (tea.Model, tea.Cmd) {
-	if st := codexproxy.StatusReport(); st.Active != "none" {
-		m.form = newCodexAddForm(codexproxy.ScanDefaultModel("gpt-5.5"), codexSourceNote(st))
-		m.formMode = modeAdd
-		m.addProtocol = config.ProtocolCodexOAuth
-		m.screen = screenForm
-		return m, textinput.Blink
+	var note string
+	if m.codexDefaultTaken() {
+		note = "a separate codex login is created for this provider when you submit"
+	} else {
+		note = codexSourceNote(codexproxy.StatusReport(codexproxy.SecretRef))
 	}
-	m.screen = screenCodexAuth
-	m.codexAuthStage = codexAuthConsent
-	m.codexAuthErr = ""
-	return m, nil
+	m.form = newCodexAddForm(m.uniqueName("codex"), codexproxy.ScanDefaultModel("gpt-5.5"), note)
+	m.formMode = modeAdd
+	m.addProtocol = config.ProtocolCodexOAuth
+	m.screen = screenForm
+	return m, textinput.Blink
+}
+
+// codexDefaultTaken reports whether an existing codex provider already claims the
+// default (cli-ride-capable) credential, so a new codex must get its own login.
+func (m Model) codexDefaultTaken() bool {
+	for _, v := range m.vendors {
+		if v.Protocol == config.ProtocolCodexOAuth && codexproxy.IsDefaultCredentialRef(v.SecretRef) {
+			return true
+		}
+	}
+	return false
 }
 
 // vendorClassRank and vendorClassHeader group the providers list by wire class:
@@ -2895,30 +2987,86 @@ func codexSourceNote(st codexproxy.CredStatus) string {
 	}
 }
 
-// updateCodexAuth drives the codex CLI-auth screen: a consent gate, then a
-// device-code login polled on its own interval until the user authorizes.
+// updateCodexAuth drives the codex CLI-auth screen: an optional source choice (reuse
+// a detected subscription — committing the add directly — or log in separately), a
+// consent gate, then a device-code login polled on its own interval until authorized.
 func (m Model) updateCodexAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.codexAuthStage {
+	case codexAuthChooseSource:
+		switch msg.String() {
+		case "esc", "q", "left":
+			// Back to the filled-in codex form (still in m.form) to amend or abandon.
+			m.codexPendingAdd = nil
+			m.screen = screenForm
+			return m, textinput.Blink
+		case "r", "enter", "y":
+			// Reuse the detected subscription: commit the row as-is (the daemon rides
+			// ~/.codex; no separate login, so no token write and no rollback).
+			if m.codexPendingAdd == nil {
+				return m.toList()
+			}
+			req := *m.codexPendingAdd
+			m.codexPendingAdd = nil
+			m.loading = true
+			return m, addVendorCmd(req)
+		case "s", "l":
+			// Log in separately (cc-fleet's own login overrides the ride): commit the row
+			// first, then log in — same ordering as the no-source path.
+			if m.codexPendingAdd == nil {
+				return m.toList()
+			}
+			req := *m.codexPendingAdd
+			m.codexPendingAdd = nil
+			m.codexCommittedName = req.Name
+			m.loading = true
+			return m, addVendorCmd(req)
+		}
 	case codexAuthConsent:
 		switch msg.String() {
 		case "esc", "q", "left", "n":
-			m.screen = screenPickTemplate
-			return m, nil
+			// The row was committed before this login (see submitAddCodex) — abandoning
+			// the login rolls it back.
+			return m.codexAbandonLogin()
 		case "enter", "y":
+			if m.codexAuthCancel != nil {
+				m.codexAuthCancel() // tear down any prior session before starting a fresh one
+			}
 			m.codexAuthStage = codexAuthDevice
 			m.codexAuthErr = ""
 			m.loading = true
 			m.codexAuthEpoch++ // a fresh login attempt; a prior visit's in-flight msgs fail the gate
-			return m, beginCodexAuthCmd(m.codexAuthEpoch)
+			ctx, cancel := context.WithCancel(context.Background())
+			m.codexAuthCtx, m.codexAuthCancel = ctx, cancel
+			return m, beginCodexAuthCmd(ctx, m.codexAuthEpoch, m.codexAddRef)
 		}
 	case codexAuthDevice:
 		if s := msg.String(); s == "esc" || s == "q" {
-			m.codexAuth = nil
-			m.loading = false
-			return m.toList()
+			return m.codexAbandonLogin()
 		}
 	}
 	return m, nil
+}
+
+// codexAbandonLogin backs out of a codex login the user cancelled. It cancels the
+// session (so an in-flight poll cannot persist a token after this) and bumps the epoch
+// (so any in-flight begin/poll/tick result is dropped). A row committed ahead of the
+// login is rolled back so the cancelled add leaves nothing behind; with no committed
+// row it just returns to the list.
+func (m Model) codexAbandonLogin() (tea.Model, tea.Cmd) {
+	if m.codexAuthCancel != nil {
+		m.codexAuthCancel()
+		m.codexAuthCancel, m.codexAuthCtx = nil, nil
+	}
+	m.codexAuthEpoch++
+	m.codexAuth = nil
+	name := m.codexCommittedName
+	m.codexCommittedName = ""
+	if name == "" {
+		m.loading = false
+		return m.toList()
+	}
+	m.loading = true
+	return m, codexRollbackCmd(name, m.codexAuthEpoch)
 }
 
 // codexAuthBegunMsg carries a started device-code session (URL + code to show);
@@ -2946,20 +3094,23 @@ type codexAuthTickMsg struct{ epoch int }
 
 func (codexAuthTickMsg) owningScreen() screen { return screenCodexAuth }
 
-func beginCodexAuthCmd(epoch int) tea.Cmd {
+// beginCodexAuthCmd and pollCodexAuthCmd derive their per-call timeout from the
+// session context, so codexAbandonLogin's cancel aborts an in-flight begin/poll —
+// the poll then returns before persisting a token, leaving no orphan login.
+func beginCodexAuthCmd(ctx context.Context, epoch int, ref string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		s, err := codexproxy.BeginDeviceLogin(ctx)
+		s, err := codexproxy.BeginDeviceLogin(cctx, ref)
 		return codexAuthBegunMsg{epoch: epoch, session: s, err: err}
 	}
 }
 
-func pollCodexAuthCmd(epoch int, s *codexproxy.LoginSession) tea.Cmd {
+func pollCodexAuthCmd(ctx context.Context, epoch int, s *codexproxy.LoginSession) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		done, err := s.Poll(ctx)
+		done, err := s.Poll(cctx)
 		return codexAuthPollMsg{epoch: epoch, done: done, err: err}
 	}
 }
@@ -3342,6 +3493,17 @@ func (m Model) submitAdd() (tea.Model, tea.Cmd) {
 	}
 }
 
+// modelConfigFromForm reads the shared model-roster rows back: each model slot's
+// bare id recombined with its 1M toggle, effort/permission mapped off→"". Used by
+// every add submitter and submitEdit so the read-back can't drift.
+func (m Model) modelConfigFromForm() (defModel, strong, fast, effort, perm string) {
+	return combine1M(m.form.value("default_model"), m.form.boolValue("default_1m")),
+		combine1M(m.form.value("strong_model"), m.form.boolValue("strong_1m")),
+		combine1M(m.form.value("fast_model"), m.form.boolValue("fast_1m")),
+		offToEmpty(m.form.choiceValue("effort")),
+		offToEmpty(m.form.choiceValue("permission"))
+}
+
 // submitAddOpenAI commits an OpenAI-protocol provider: the loopback base_url is
 // assigned from a free daemon port; the real upstream + key ride the form.
 func (m Model) submitAddOpenAI() (tea.Model, tea.Cmd) {
@@ -3349,7 +3511,7 @@ func (m Model) submitAddOpenAI() (tea.Model, tea.Cmd) {
 	upstream := m.form.value("upstream_url")
 	modelsEndpoint := m.form.value("models_endpoint")
 	apiKey := m.form.value("api_key")
-	defaultModel := m.form.value("default_model")
+	defaultModel, strong, fast, effort, perm := m.modelConfigFromForm()
 
 	if missing := missingLabels(map[string]string{
 		"Name":            name,
@@ -3373,6 +3535,10 @@ func (m Model) submitAddOpenAI() (tea.Model, tea.Cmd) {
 		BaseURL:        fmt.Sprintf("http://127.0.0.1:%d/", port),
 		ModelsEndpoint: modelsEndpoint,
 		DefaultModel:   defaultModel,
+		StrongModel:    strong,
+		FastModel:      fast,
+		Effort:         effort,
+		DefaultPerm:    perm,
 		SecretBackend:  "file",
 		SecretRef:      name + ".key",
 		Protocol:       m.addProtocol,
@@ -3386,7 +3552,7 @@ func (m Model) submitAddOpenAI() (tea.Model, tea.Cmd) {
 // backend; the upstream is the fixed ChatGPT backend, so there is no key.
 func (m Model) submitAddCodex() (tea.Model, tea.Cmd) {
 	name := m.form.value("name")
-	defaultModel := m.form.value("default_model")
+	defaultModel, strong, fast, effort, perm := m.modelConfigFromForm()
 	if missing := missingLabels(map[string]string{
 		"Name":          name,
 		"Default model": defaultModel,
@@ -3394,24 +3560,71 @@ func (m Model) submitAddCodex() (tea.Model, tea.Cmd) {
 		m.form.err = "required: " + strings.Join(missing, ", ")
 		return m, nil
 	}
+	// Validate the name up front: a codex add may start a device login before
+	// userops.Add runs, so reject a bad name here rather than authorize then fail.
+	if err := ids.ValidateVendorName(name); err != nil {
+		m.form.err = err.Error()
+		return m, nil
+	}
+	// The sentinel name would resolve to the default credential a first codex already
+	// holds; reject it here so a second codex never logs in then fails uniqueness.
+	if m.codexDefaultTaken() && codexproxy.IsDefaultCredentialRef(name) {
+		m.form.err = "name " + name + " is reserved for the default codex credential"
+		return m, nil
+	}
 	port, err := codexproxy.ChoosePort(0)
 	if err != nil {
 		m.form.err = err.Error()
 		return m, nil
 	}
+	// First codex → the default (cli-ride-capable) credential; later ones → their own,
+	// keyed on the provider name. secret_ref carries this so spawn/login resolve the
+	// same credential file.
+	ref := codexproxy.SecretRef
+	if m.codexDefaultTaken() {
+		ref = name
+	}
 	base := fmt.Sprintf("http://127.0.0.1:%d/", port)
-	m.form.err = ""
-	m.loading = true
-	return m, addVendorCmd(userops.AddRequest{
+	req := userops.AddRequest{
 		Name:           name,
 		BaseURL:        base,
 		ModelsEndpoint: base + "v1/models",
 		DefaultModel:   defaultModel,
+		StrongModel:    strong,
+		FastModel:      fast,
+		Effort:         effort,
+		DefaultPerm:    perm,
 		SecretBackend:  codexproxy.SecretBackend,
-		SecretRef:      codexproxy.SecretRef,
+		SecretRef:      ref,
 		Protocol:       config.ProtocolCodexOAuth,
 		Enabled:        true,
-	})
+	}
+	m.form.err = ""
+	m.codexAddRef = ref
+	m.codexAuthErr = ""
+	switch st := codexproxy.StatusReport(ref); st.Active {
+	case "own":
+		// cc-fleet already has its own login for this credential — reuse, no prompt.
+		m.loading = true
+		return m, addVendorCmd(req)
+	case "cli-ride":
+		// A codex subscription is signed in on the system; let the user reuse it or log
+		// in separately rather than silently riding ~/.codex. The choice is made before
+		// the row is committed; only the separate-login branch then writes a login.
+		m.codexPendingAdd = &req
+		m.codexAuthAccount = st.Account
+		m.screen = screenCodexAuth
+		m.codexAuthStage = codexAuthChooseSource
+		return m, nil
+	default: // "none" — no source; commit the row, then log in
+		// Commit the provider row (vendors lock) BEFORE the login writes its token (token
+		// lock), so a concurrent remove's referenced-check always sees the committed row
+		// and never unlinks the fresh login. opDoneMsg routes to the login once the row
+		// is in; abandoning the login rolls the row back.
+		m.codexCommittedName = req.Name
+		m.loading = true
+		return m, addVendorCmd(req)
+	}
 }
 
 // submitAddAnthropic validates the Anthropic-native add form and dispatches Add.
@@ -3420,7 +3633,7 @@ func (m Model) submitAddAnthropic() (tea.Model, tea.Cmd) {
 	baseURL := m.form.value("base_url")
 	modelsEndpoint := m.form.value("models_endpoint")
 	apiKey := m.form.value("api_key")
-	defaultModel := m.form.value("default_model")
+	defaultModel, strong, fast, effort, perm := m.modelConfigFromForm()
 
 	if missing := missingLabels(map[string]string{
 		"Name":            name,
@@ -3440,6 +3653,10 @@ func (m Model) submitAddAnthropic() (tea.Model, tea.Cmd) {
 		BaseURL:        baseURL,
 		ModelsEndpoint: modelsEndpoint,
 		DefaultModel:   defaultModel,
+		StrongModel:    strong,
+		FastModel:      fast,
+		Effort:         effort,
+		DefaultPerm:    perm,
 		SecretBackend:  "file",
 		SecretRef:      name + ".key",
 		APIKey:         apiKey,
@@ -3452,11 +3669,7 @@ func (m Model) submitEdit() (tea.Model, tea.Cmd) {
 	// Recombine each model slot's bare id with its 1M toggle; the choice fields
 	// map "off" → unset. The TUI is the full editor, so every field is sent
 	// (including a clear) — editLocked diffs against the stored value.
-	defaultModel := combine1M(m.form.value("default_model"), m.form.boolValue("default_1m"))
-	strongModel := combine1M(m.form.value("strong_model"), m.form.boolValue("strong_1m"))
-	fastModel := combine1M(m.form.value("fast_model"), m.form.boolValue("fast_1m"))
-	effort := offToEmpty(m.form.choiceValue("effort"))
-	defaultPerm := offToEmpty(m.form.choiceValue("permission"))
+	defaultModel, strongModel, fastModel, effort, defaultPerm := m.modelConfigFromForm()
 	enabled := m.form.boolValue("enabled")
 	req := userops.EditRequest{
 		Name:         m.editName,

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -352,10 +352,50 @@ func TestEditForm_1mLateralNav(t *testing.T) {
 	}
 }
 
-// TestAddForm_RightOnModelNoMisfocus: the add form has a default_model field but
-// no 1M toggle, so → there must NOT mis-focus (it falls through to the text cursor,
-// leaving focus on default_model).
-func TestAddForm_RightOnModelNoMisfocus(t *testing.T) {
+// TestUniqueName: a taken template name prefills the first free "<name>-N"; a free
+// name and a blank (Custom) name pass through.
+func TestUniqueName(t *testing.T) {
+	m := Model{vendors: []userops.VendorView{{Name: "deepseek"}, {Name: "deepseek-2"}}}
+	if got := m.uniqueName("deepseek"); got != "deepseek-3" {
+		t.Errorf("uniqueName(deepseek) = %q, want deepseek-3", got)
+	}
+	if got := m.uniqueName("glm"); got != "glm" {
+		t.Errorf("uniqueName(glm) = %q, want glm", got)
+	}
+	if got := m.uniqueName(""); got != "" {
+		t.Errorf("uniqueName(\"\") = %q, want \"\"", got)
+	}
+}
+
+// TestNoteBlockConstantHeight: the Note block reserves the same number of lines
+// regardless of which field is focused, so the Config header doesn't move.
+func TestNoteBlockConstantHeight(t *testing.T) {
+	f := newEditForm(userops.VendorView{Name: "x", DefaultModel: "d", SecretBackend: "file"})
+	noteToConfig := func(ff form) int {
+		lines := ff.viewLines(46)
+		note, cfg := -1, -1
+		for i, l := range lines {
+			if strings.Contains(l, "Note") && note < 0 {
+				note = i
+			}
+			if strings.Contains(l, "Config") {
+				cfg = i
+			}
+		}
+		return cfg - note
+	}
+	base := noteToConfig(f)
+	for i := 0; i < len(f.fields); i++ {
+		f.setFocus(i)
+		if h := noteToConfig(f); h != base {
+			t.Fatalf("Note→Config gap shifted at focus %d (key %q): %d != %d", i, f.focusedKey(), h, base)
+		}
+	}
+}
+
+// TestAddForm_HasModelConfigNav: the add form now carries the shared model-config
+// rows, so → on its default_model reaches the inline 1M toggle (like the edit form).
+func TestAddForm_HasModelConfigNav(t *testing.T) {
 	f := newAddForm(Template{})
 	for i := 0; i < len(f.fields) && f.focusedKey() != "default_model"; i++ {
 		f, _, _ = f.Update(keyMsg("down"))
@@ -364,8 +404,8 @@ func TestAddForm_RightOnModelNoMisfocus(t *testing.T) {
 		t.Fatalf("could not focus default_model, got %q", f.focusedKey())
 	}
 	f, _, _ = f.Update(keyMsg("right"))
-	if f.focusedKey() != "default_model" {
-		t.Fatalf("right on the add-form default_model must keep focus (no 1M toggle to jump to), got %q", f.focusedKey())
+	if f.focusedKey() != "default_1m" {
+		t.Fatalf("right on the add-form default_model should reach default_1m, got %q", f.focusedKey())
 	}
 }
 
@@ -657,8 +697,10 @@ func TestModelPickerSkippedWhenNoEndpoint(t *testing.T) {
 	if m.screen != screenForm {
 		t.Fatalf("enter with no endpoint opened a picker: screen = %d, want screenForm", m.screen)
 	}
-	if m.form.focusedKey() != "" {
-		t.Fatalf("enter should have advanced to the submit button, focusedKey = %q", m.form.focusedKey())
+	// No picker — enter just advances a row (skipping the inline 1M toggle) to the
+	// next model slot.
+	if m.form.focusedKey() != "strong_model" {
+		t.Fatalf("enter with no endpoint should advance to strong_model, focusedKey = %q", m.form.focusedKey())
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -317,9 +317,146 @@ func TestEditEnabledToggle(t *testing.T) {
 	if f.boolValue("enabled") {
 		t.Fatal("space should toggle enabled true -> false")
 	}
-	f, _, _ = f.Update(keyMsg("left"))
+	f, _, _ = f.Update(keyMsg("space"))
 	if !f.boolValue("enabled") {
-		t.Fatal("left should toggle enabled false -> true")
+		t.Fatal("space should toggle enabled false -> true")
+	}
+}
+
+// TestEditForm_1mLateralNav: ↑/↓ walk rows and skip the inline 1M toggles, while
+// → reaches a model slot's 1M toggle and ← returns to the slot.
+func TestEditForm_1mLateralNav(t *testing.T) {
+	f := newEditForm(userops.VendorView{Name: "x", DefaultModel: "d", SecretBackend: "file"})
+	for i := 0; i < len(f.fields) && f.focusedKey() != "default_model"; i++ {
+		f, _, _ = f.Update(keyMsg("down"))
+	}
+	if f.focusedKey() != "default_model" {
+		t.Fatalf("could not focus default_model, got %q", f.focusedKey())
+	}
+	// ↓ skips the inline 1M toggle and lands on the next row (strong_model).
+	if after, _, _ := f.Update(keyMsg("down")); after.focusedKey() != "strong_model" {
+		t.Fatalf("down from default_model should skip default_1m → strong_model, got %q", after.focusedKey())
+	}
+	// → reaches the slot's 1M toggle; space flips it; ← returns to the slot.
+	f, _, _ = f.Update(keyMsg("right"))
+	if f.focusedKey() != "default_1m" {
+		t.Fatalf("right should focus default_1m, got %q", f.focusedKey())
+	}
+	f, _, _ = f.Update(keyMsg("space"))
+	if !f.boolValue("default_1m") {
+		t.Fatal("space should toggle default_1m on")
+	}
+	f, _, _ = f.Update(keyMsg("left"))
+	if f.focusedKey() != "default_model" {
+		t.Fatalf("left from default_1m should return to default_model, got %q", f.focusedKey())
+	}
+}
+
+// TestAddForm_RightOnModelNoMisfocus: the add form has a default_model field but
+// no 1M toggle, so → there must NOT mis-focus (it falls through to the text cursor,
+// leaving focus on default_model).
+func TestAddForm_RightOnModelNoMisfocus(t *testing.T) {
+	f := newAddForm(Template{})
+	for i := 0; i < len(f.fields) && f.focusedKey() != "default_model"; i++ {
+		f, _, _ = f.Update(keyMsg("down"))
+	}
+	if f.focusedKey() != "default_model" {
+		t.Fatalf("could not focus default_model, got %q", f.focusedKey())
+	}
+	f, _, _ = f.Update(keyMsg("right"))
+	if f.focusedKey() != "default_model" {
+		t.Fatalf("right on the add-form default_model must keep focus (no 1M toggle to jump to), got %q", f.focusedKey())
+	}
+}
+
+// TestEditForm_1mColumnVerticalNav: ↓/↑ on a 1M toggle stay in the context column
+// (default_1m ↓ → strong_1m), and fall back to the model column when the next row
+// has no toggle (fast_1m ↓ → effort).
+func TestEditForm_1mColumnVerticalNav(t *testing.T) {
+	f := newEditForm(userops.VendorView{Name: "x", DefaultModel: "d", SecretBackend: "file"})
+	focus := func(key string) {
+		for i := 0; i < len(f.fields)*2 && f.focusedKey() != key; i++ {
+			f, _, _ = f.Update(keyMsg("down"))
+		}
+		if f.focusedKey() != key {
+			t.Fatalf("could not focus %q, got %q", key, f.focusedKey())
+		}
+	}
+	focus("default_model")
+	f, _, _ = f.Update(keyMsg("right")) // → default_1m
+	if f.focusedKey() != "default_1m" {
+		t.Fatalf("right → default_1m, got %q", f.focusedKey())
+	}
+	if after, _, _ := f.Update(keyMsg("down")); after.focusedKey() != "strong_1m" {
+		t.Fatalf("down in the ctx column: default_1m → strong_1m, got %q", after.focusedKey())
+	}
+	// Walk to fast_1m and down → effort (no ctx on the next row → fall back).
+	f, _, _ = f.Update(keyMsg("down")) // strong_1m
+	f, _, _ = f.Update(keyMsg("down")) // fast_1m
+	if f.focusedKey() != "fast_1m" {
+		t.Fatalf("expected fast_1m, got %q", f.focusedKey())
+	}
+	if after, _, _ := f.Update(keyMsg("down")); after.focusedKey() != "effort" {
+		t.Fatalf("down from fast_1m should fall back to effort, got %q", after.focusedKey())
+	}
+}
+
+// TestEditForm_ModelSlotsPrefill: the edit form splits each model slot into a
+// bare-id text field + a 1M toggle, and prefills effort/permission choices.
+func TestEditForm_ModelSlotsPrefill(t *testing.T) {
+	f := newEditForm(userops.VendorView{
+		Name:          "deepseek",
+		DefaultModel:  "d[1m]",
+		StrongModel:   "s[1m]",
+		FastModel:     "fst",
+		Effort:        "high",
+		DefaultPerm:   "acceptEdits",
+		SecretBackend: "file",
+	})
+	if got := f.value("default_model"); got != "d" {
+		t.Errorf("default_model text = %q, want bare d", got)
+	}
+	if !f.boolValue("default_1m") {
+		t.Error("default_1m should be on for a [1m] default model")
+	}
+	if got := f.value("strong_model"); got != "s" || !f.boolValue("strong_1m") {
+		t.Errorf("strong slot prefill wrong: text=%q 1m=%v", got, f.boolValue("strong_1m"))
+	}
+	if got := f.value("fast_model"); got != "fst" || f.boolValue("fast_1m") {
+		t.Errorf("fast slot prefill wrong: text=%q 1m=%v", got, f.boolValue("fast_1m"))
+	}
+	if got := f.choiceValue("effort"); got != "high" {
+		t.Errorf("effort choice = %q, want high", got)
+	}
+	if got := f.choiceValue("permission"); got != "acceptEdits" {
+		t.Errorf("permission choice = %q, want acceptEdits", got)
+	}
+}
+
+// TestEditForm_UnsetChoicesShowOff: a provider with no effort / default_permission
+// prefills both dropdowns to "off".
+func TestEditForm_UnsetChoicesShowOff(t *testing.T) {
+	f := newEditForm(userops.VendorView{Name: "x", DefaultModel: "d", SecretBackend: "file"})
+	if got := f.choiceValue("effort"); got != "off" {
+		t.Errorf("unset effort = %q, want off", got)
+	}
+	if got := f.choiceValue("permission"); got != "off" {
+		t.Errorf("unset permission = %q, want off", got)
+	}
+}
+
+func TestCombine1MAndOffToEmpty(t *testing.T) {
+	if got := combine1M("d", true); got != "d[1m]" {
+		t.Errorf("combine1M(d,true) = %q, want d[1m]", got)
+	}
+	if got := combine1M("d[1m]", false); got != "d" {
+		t.Errorf("combine1M strips when off: %q", got)
+	}
+	if got := combine1M("", true); got != "" {
+		t.Errorf("combine1M(\"\",true) = %q, want \"\" (blank slot follows default)", got)
+	}
+	if offToEmpty("off") != "" || offToEmpty("high") != "high" {
+		t.Errorf("offToEmpty mismatch: off=%q high=%q", offToEmpty("off"), offToEmpty("high"))
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -65,10 +65,15 @@ func press(t *testing.T, m Model, key string) (Model, tea.Cmd) {
 	return step(t, m, keyMsg(key))
 }
 
-// withVendors returns a fresh model on the Model Providers list with vs already loaded.
+// withVendors returns a fresh model on the Model Providers list with vs already
+// loaded. It pins screenList so the screenList-owned vendorsMsg is always applied —
+// otherwise a fresh install with no tmux/agent-teams (CI) opens on a setup nudge and
+// the message is dropped, leaving m.vendors empty.
 func withVendors(t *testing.T, vs ...userops.VendorView) Model {
 	t.Helper()
-	m, _ := step(t, NewModel(), vendorsMsg{vendors: vs})
+	m := NewModel()
+	m.screen, m.loading = screenList, true
+	m, _ = step(t, m, vendorsMsg{vendors: vs})
 	return m
 }
 

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -72,8 +73,9 @@ func TestAddPicker_OpenAISubmitValidatesThenDispatches(t *testing.T) {
 	}
 }
 
-// With no usable codex source, the codex row routes to the consent screen; accept
-// moves to the device-code stage; esc cancels back to the provider list.
+// The codex row opens the add form; submitting it with no usable source commits the
+// row, and once the add lands (opDoneMsg) it routes to consent → device login; esc
+// rolls the row back and returns to the list.
 func TestAddPicker_CodexRowNoSourceGoesToConsent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())            // no ~/.codex
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no own login
@@ -85,16 +87,189 @@ func TestAddPicker_CodexRowNoSourceGoesToConsent(t *testing.T) {
 	m, _ = press(t, m, "enter")
 	m = pressN(t, m, "down", codexIdx()) // to the codex row
 	m, _ = press(t, m, "enter")
-	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent {
-		t.Fatalf("no-source codex: screen=%d stage=%d", m.screen, m.codexAuthStage)
+	if m.screen != screenForm || m.addProtocol != config.ProtocolCodexOAuth {
+		t.Fatalf("codex row should open the add form: screen=%d proto=%q", m.screen, m.addProtocol)
 	}
-	m, cmd := press(t, m, "enter") // accept consent -> device stage
+	m = pressN(t, m, "down", len(m.form.fields)) // jump to submit
+	m, cmd := press(t, m, "enter")               // submit -> commit the row first
+	if cmd == nil || m.codexCommittedName == "" {
+		t.Fatalf("no-source codex submit must commit first: cmd=%v committed=%q", cmd, m.codexCommittedName)
+	}
+	m, _ = step(t, m, opDoneMsg{verb: "add", name: m.codexCommittedName}) // add landed -> consent
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent {
+		t.Fatalf("after add, codex must route to consent: screen=%d stage=%d", m.screen, m.codexAuthStage)
+	}
+	m, cmd = press(t, m, "enter") // accept consent -> device stage
 	if m.codexAuthStage != codexAuthDevice || cmd == nil {
 		t.Fatalf("consent accept: stage=%d cmd=%v", m.codexAuthStage, cmd)
 	}
-	m, _ = press(t, m, "esc")
+	m, cmd = press(t, m, "esc") // abandon -> rollback the committed row
+	if cmd == nil || m.codexCommittedName != "" {
+		t.Fatalf("esc must roll back the committed row: cmd=%v committed=%q", cmd, m.codexCommittedName)
+	}
+	m, _ = step(t, m, codexRollbackDoneMsg{epoch: m.codexAuthEpoch})
 	if m.screen != screenList {
-		t.Fatalf("esc from device stage: screen=%d, want screenList", m.screen)
+		t.Fatalf("after rollback: screen=%d, want screenList", m.screen)
+	}
+}
+
+// The first codex (no existing codex holds the default credential) claims the
+// default, cli-ride-capable credential: it commits the row keyed on the legacy
+// sentinel secret_ref before routing to its login.
+func TestFirstCodexClaimsDefaultCredential(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())            // no ~/.codex
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no own login
+	m := withVendors(t)                      // no providers yet
+	if m.codexDefaultTaken() {
+		t.Fatal("with no codex, the default credential must be free")
+	}
+	mm, _ := m.enterCodexFlow()
+	m = mm.(Model)
+	m = pressN(t, m, "down", len(m.form.fields)) // jump to submit
+	m, cmd := press(t, m, "enter")               // no source -> commit the row first
+	if cmd == nil || m.codexCommittedName != "codex" {
+		t.Fatalf("first codex must commit the row, got committed=%q cmd=%v", m.codexCommittedName, cmd)
+	}
+	if m.codexAddRef != codexproxy.SecretRef {
+		t.Fatalf("codexAddRef = %q, want the sentinel", m.codexAddRef)
+	}
+}
+
+// An invalid codex provider name is rejected at submit BEFORE any device login —
+// no auth screen, no credential file written, just a form error.
+func TestCodexInvalidNameRejectedBeforeLogin(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	m := withVendors(t)
+	mm, _ := m.enterCodexFlow()
+	m = mm.(Model)
+	m.form.setValue("name", "../escape")
+	m = pressN(t, m, "down", len(m.form.fields)) // jump to submit
+	m, cmd := press(t, m, "enter")
+	if m.screen != screenForm || m.form.err == "" {
+		t.Fatalf("invalid name must fail on the form: screen=%d err=%q", m.screen, m.form.err)
+	}
+	if m.codexPendingAdd != nil || cmd != nil {
+		t.Fatal("invalid name must not stash a request or start a login")
+	}
+}
+
+// A second codex (one already holds the default credential) gets its own named
+// credential keyed on the unique provider name, and submitting routes to its own
+// device login.
+func TestSecondCodexGetsOwnCredential(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	existing := userops.VendorView{
+		Name: "codex", BaseURL: "http://127.0.0.1:17222/", ModelsEndpoint: "http://127.0.0.1:17222/v1/models",
+		DefaultModel: "gpt-5.5", SecretBackend: config.CodexOAuthBackend, SecretRef: config.CodexOAuthBackend,
+		Protocol: config.ProtocolCodexOAuth, Enabled: true,
+	}
+	m := withVendors(t, existing)
+	if !m.codexDefaultTaken() {
+		t.Fatal("an existing default-credential codex must mark the default taken")
+	}
+	mm, _ := m.enterCodexFlow()
+	m = mm.(Model)
+	if m.screen != screenForm {
+		t.Fatalf("enterCodexFlow should open the form: screen=%d", m.screen)
+	}
+	m = pressN(t, m, "down", len(m.form.fields)) // jump to submit
+	m, cmd := press(t, m, "enter")               // commits the row first
+	if cmd == nil || m.codexCommittedName != "codex-2" {
+		t.Fatalf("second codex must commit a named-credential row, got committed=%q cmd=%v", m.codexCommittedName, cmd)
+	}
+	if m.codexAddRef != "codex-2" {
+		t.Fatalf("codexAddRef = %q, want codex-2", m.codexAddRef)
+	}
+	m, _ = step(t, m, opDoneMsg{verb: "add", name: "codex-2"}) // add landed -> its own login
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent {
+		t.Fatalf("second codex add must route to its own login: screen=%d stage=%d", m.screen, m.codexAuthStage)
+	}
+
+	// Naming the second codex with the sentinel would collapse onto the default
+	// credential: rejected on the form before any commit.
+	mm2, _ := withVendors(t, existing).enterCodexFlow()
+	m2 := mm2.(Model)
+	m2.form.setValue("name", codexproxy.SecretRef)
+	m2 = pressN(t, m2, "down", len(m2.form.fields))
+	m2, cmd2 := press(t, m2, "enter")
+	if m2.screen != screenForm || m2.form.err == "" || m2.codexCommittedName != "" || cmd2 != nil {
+		t.Fatalf("sentinel-named second codex must be rejected on the form: screen=%d err=%q", m2.screen, m2.form.err)
+	}
+}
+
+// Abandoning a codex device login cancels the session, bumps the epoch, and rolls the
+// committed row back — so a stale in-flight poll result can neither show success nor
+// persist a login behind the cancelled add.
+func TestCodexAbandonCancelsAndDropsStalePoll(t *testing.T) {
+	m := NewModel()
+	m.screen = screenCodexAuth
+	m.codexAuthStage = codexAuthDevice
+	m.codexAuthEpoch = 3
+	m.codexAuth = &codexproxy.LoginSession{}
+	m.codexCommittedName = "codex"
+	ctx, cancel := context.WithCancel(context.Background())
+	m.codexAuthCtx, m.codexAuthCancel = ctx, cancel
+
+	mm, cmd := m.codexAbandonLogin()
+	m = mm.(Model)
+	if cmd == nil || m.codexAuthEpoch != 4 || m.codexCommittedName != "" || m.codexAuth != nil {
+		t.Fatalf("abandon must bump epoch, clear state, and roll back: epoch=%d committed=%q auth=%v cmd=%v",
+			m.codexAuthEpoch, m.codexCommittedName, m.codexAuth, cmd)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("abandon must cancel the session context so an in-flight poll cannot persist a token")
+	}
+	// The in-flight poll's stale-epoch result must be dropped — no success screen.
+	if m2, _ := step(t, m, codexAuthPollMsg{epoch: 3, done: true}); m2.screen == screenResult {
+		t.Fatal("a stale-epoch poll-done after abandon must be dropped, not shown as success")
+	}
+}
+
+// When a codex subscription is detected (cli-ride), the add routes to a source choice:
+// reuse commits as-is; separate login commits the row first (marking it for the login);
+// esc returns to the form.
+func TestCodexChooseSourceBranches(t *testing.T) {
+	base := func() Model {
+		m := NewModel()
+		m.screen = screenCodexAuth
+		m.codexAuthStage = codexAuthChooseSource
+		req := userops.AddRequest{Name: "codex", SecretRef: codexproxy.SecretRef, Protocol: config.ProtocolCodexOAuth}
+		m.codexPendingAdd = &req
+		m.codexAddRef = codexproxy.SecretRef
+		return m
+	}
+	if m, cmd := press(t, base(), "r"); cmd == nil || !m.loading || m.codexPendingAdd != nil || m.codexCommittedName != "" {
+		t.Fatalf("reuse must commit with no follow-up login: cmd=%v loading=%v pending=%v committed=%q", cmd, m.loading, m.codexPendingAdd, m.codexCommittedName)
+	}
+	if m, cmd := press(t, base(), "s"); cmd == nil || m.codexPendingAdd != nil || m.codexCommittedName != "codex" {
+		t.Fatalf("separate login must commit the row first and mark it: cmd=%v pending=%v committed=%q", cmd, m.codexPendingAdd, m.codexCommittedName)
+	}
+	if m, _ := press(t, base(), "esc"); m.screen != screenForm || m.codexPendingAdd != nil {
+		t.Fatalf("esc must return to the form and drop the pending add: screen=%d", m.screen)
+	}
+}
+
+// The read-only preview card and the edit form keep the same Note→Config gap, so
+// entering edit does not shift the Config block down.
+func TestPreviewMatchesEditNoteGap(t *testing.T) {
+	v := userops.VendorView{Name: "glm", DefaultModel: "glm-4.5-air", SecretBackend: "file"}
+	gap := func(lines []string) int {
+		note, cfg := -1, -1
+		for i, l := range lines {
+			if strings.Contains(l, "Note") && note < 0 {
+				note = i
+			}
+			if strings.Contains(l, "Config") {
+				cfg = i
+			}
+		}
+		return cfg - note
+	}
+	const w = 60
+	if p, e := gap(vendorDetailLines(v, w)), gap(newEditForm(v).viewLines(w)); p != e {
+		t.Fatalf("Note→Config gap differs (Config jumps entering edit): preview=%d edit=%d", p, e)
 	}
 }
 
@@ -117,7 +292,7 @@ func TestCodexAuth_StaleEpochBegunDropped(t *testing.T) {
 // The codex form's source note renders inside the Note section (after the "Note"
 // header, before "Config"), wrapped to the pane — never as a banner above it.
 func TestCodexFormNoteInNoteSection(t *testing.T) {
-	f := newCodexAddForm("gpt-5.5", "reuses the codex CLI login (account …abc) — no key needed")
+	f := newCodexAddForm("codex", "gpt-5.5", "reuses the codex CLI login (account …abc) — no key needed")
 	lines := f.viewLines(48)
 	noteHdr, cfgHdr, body := -1, -1, -1
 	for i, l := range lines {
@@ -142,7 +317,7 @@ func TestCodexFormNoteInNoteSection(t *testing.T) {
 // seeded with the static codex model list (no live endpoint to probe at add time).
 func TestCodexForm_DefaultOpensStaticModelPicker(t *testing.T) {
 	m := NewModel()
-	m.form = newCodexAddForm("gpt-5.5", "")
+	m.form = newCodexAddForm("codex", "gpt-5.5", "")
 	m.formMode = modeAdd
 	m.addProtocol = config.ProtocolCodexOAuth
 	m.screen = screenForm

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -223,20 +223,12 @@ func vendorCacheFig(v userops.VendorView) string {
 
 // resolvedSlot renders a capability slot for the read-only preview: a blank
 // strong/fast slot shows the default model it follows (the concrete model that
-// will run), not the word "blank". orOffLabel renders an unset effort/permission
-// as off.
+// will run), not the word "blank". orOff renders an unset effort/permission as off.
 func resolvedSlot(slot, def string) string {
 	if slot == "" {
 		return def
 	}
 	return slot
-}
-
-func orOffLabel(s string) string {
-	if s == "" {
-		return "off"
-	}
-	return s
 }
 
 // vendorDetailLines is the Model Providers hub's read-only config card: the enabled state + default
@@ -250,8 +242,19 @@ func vendorDetailLines(v userops.VendorView, rightW int) []string {
 	if v.DefaultModel != "" {
 		status += liveStyle.Render(" · " + trunc(v.DefaultModel, 28))
 	}
-	lines := []string{status, "", contentStyle.Render("Note"),
-		" " + contentStyle.Render("→/⏎ edit · d delete"), "", faintStyle.Render("Config")}
+	// Pad the Note body to the same reserve the edit form uses (fieldNoteReserve), so
+	// the Config block sits at the same row here and in edit — entering edit doesn't
+	// shift it down.
+	lines := []string{status, "", contentStyle.Render("Note")}
+	note := []string{contentStyle.Render("→/⏎ edit · d delete")}
+	for i, reserve := 0, fieldNoteReserve(rightW); i < reserve; i++ {
+		if i < len(note) {
+			lines = append(lines, " "+note[i])
+		} else {
+			lines = append(lines, "")
+		}
+	}
+	lines = append(lines, "", faintStyle.Render("Config"))
 	detailField(&lines, "base url", v.BaseURL, rightW)
 	detailField(&lines, "models", v.ModelsEndpoint, rightW)
 	// Surface the full capability roster + effort + run permission so the preview
@@ -261,8 +264,8 @@ func vendorDetailLines(v userops.VendorView, rightW int) []string {
 	detailField(&lines, "default", v.DefaultModel, rightW)
 	detailField(&lines, "strong", resolvedSlot(v.StrongModel, v.DefaultModel), rightW)
 	detailField(&lines, "fast", resolvedSlot(v.FastModel, v.DefaultModel), rightW)
-	detailField(&lines, "effort", orOffLabel(v.Effort), rightW)
-	detailField(&lines, "run perm", orOffLabel(v.DefaultPerm), rightW)
+	detailField(&lines, "effort", orOff(v.Effort), rightW)
+	detailField(&lines, "run perm", orOff(v.DefaultPerm), rightW)
 	detailField(&lines, "cache", vendorCacheFig(v), rightW)
 	key := v.SecretBackend
 	if v.SecretRef != "" {
@@ -2806,10 +2809,10 @@ func (m Model) addItemDetail() []string {
 	}
 	switch it := items[m.tmplCursor]; it.class {
 	case addCatCLI:
-		if st := codexproxy.StatusReport(); st.Active != "none" {
+		if st := codexproxy.StatusReport(codexproxy.SecretRef); st.Active != "none" {
 			return []string{faintStyle.Render("  reuses the codex login (" + st.Active + ", account " + st.Account + ") — no key needed")}
 		}
-		return []string{faintStyle.Render("  not logged in — you'll authorize next (or run: cc-fleet codex login)")}
+		return []string{faintStyle.Render("  not logged in — the first codex reuses ~/.codex; extra ones get their own login")}
 	case addCatOpenAI:
 		if it.oIdx < 0 {
 			return []string{faintStyle.Render("  protocol  openai-chat · fill upstream_url + key")}
@@ -2841,6 +2844,20 @@ func (m Model) addItemDetail() []string {
 }
 
 func (m Model) viewCodexAuth() string {
+	if m.codexAuthStage == codexAuthChooseSource {
+		return m.vendorFlowView("Add codex provider · source", "", "+", "codex login",
+			"r reuse · s separate login · esc cancel", func(rightW int) []string {
+				detected := "A codex subscription is signed in on this system"
+				if m.codexAuthAccount != "" {
+					detected += " (account " + m.codexAuthAccount + ")"
+				}
+				return []string{
+					contentStyle.Render(detected + "."), "",
+					contentStyle.Render("  r  reuse it — no separate login needed"),
+					contentStyle.Render("  s  log in separately — cc-fleet keeps its own login"),
+				}
+			})
+	}
 	if m.codexAuthStage == codexAuthDevice {
 		return m.vendorFlowView("Add codex provider · authorize", "", "+", "device login",
 			"esc cancel", func(rightW int) []string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -32,6 +32,7 @@ var (
 	teamHdrStyle    = lipgloss.NewStyle().Bold(true) // team section header (flush-left bold title)
 	errStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
 	okStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	noteStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // contextual Note hints — a warm tone above the gray body
 )
 
 // footer renders a dim key-hint line.
@@ -220,6 +221,24 @@ func vendorCacheFig(v userops.VendorView) string {
 	return fig
 }
 
+// resolvedSlot renders a capability slot for the read-only preview: a blank
+// strong/fast slot shows the default model it follows (the concrete model that
+// will run), not the word "blank". orOffLabel renders an unset effort/permission
+// as off.
+func resolvedSlot(slot, def string) string {
+	if slot == "" {
+		return def
+	}
+	return slot
+}
+
+func orOffLabel(s string) string {
+	if s == "" {
+		return "off"
+	}
+	return s
+}
+
 // vendorDetailLines is the Model Providers hub's read-only config card: the enabled state + default
 // model, then the vendors.toml fields. The key row shows only the secret backend + ref —
 // never key material (the status line already carries the model, so no separate field).
@@ -235,6 +254,15 @@ func vendorDetailLines(v userops.VendorView, rightW int) []string {
 		" " + contentStyle.Render("→/⏎ edit · d delete"), "", faintStyle.Render("Config")}
 	detailField(&lines, "base url", v.BaseURL, rightW)
 	detailField(&lines, "models", v.ModelsEndpoint, rightW)
+	// Surface the full capability roster + effort + run permission so the preview
+	// mirrors the edit form. Each slot shows the concrete model that will run (a
+	// blank strong/fast resolves to the default); effort/permission show off when
+	// unset.
+	detailField(&lines, "default", v.DefaultModel, rightW)
+	detailField(&lines, "strong", resolvedSlot(v.StrongModel, v.DefaultModel), rightW)
+	detailField(&lines, "fast", resolvedSlot(v.FastModel, v.DefaultModel), rightW)
+	detailField(&lines, "effort", orOffLabel(v.Effort), rightW)
+	detailField(&lines, "run perm", orOffLabel(v.DefaultPerm), rightW)
 	detailField(&lines, "cache", vendorCacheFig(v), rightW)
 	key := v.SecretBackend
 	if v.SecretRef != "" {
@@ -1134,19 +1162,45 @@ func wrapTo(s string, w int) []string {
 	var out []string
 	var cur strings.Builder
 	curW := 0
-	for _, r := range s {
-		rw := ansi.StringWidth(string(r))
-		if curW+rw > w && curW > 0 {
+	flush := func() {
+		if cur.Len() > 0 {
 			out = append(out, cur.String())
 			cur.Reset()
 			curW = 0
 		}
-		cur.WriteRune(r)
-		curW += rw
 	}
-	if cur.Len() > 0 {
-		out = append(out, cur.String())
+	for _, word := range strings.Fields(s) {
+		// A word too wide for any line (a long token, or a space-less script like
+		// CJK) is character-wrapped; otherwise words pack greedily, breaking only on
+		// spaces so a word is never split mid-token.
+		if ansi.StringWidth(word) > w {
+			flush()
+			for _, r := range word {
+				rw := ansi.StringWidth(string(r))
+				if curW+rw > w && curW > 0 {
+					flush()
+				}
+				cur.WriteRune(r)
+				curW += rw
+			}
+			continue
+		}
+		sep := 0
+		if curW > 0 {
+			sep = 1
+		}
+		if curW+sep+ansi.StringWidth(word) > w {
+			flush()
+			sep = 0
+		}
+		if sep == 1 {
+			cur.WriteByte(' ')
+			curW++
+		}
+		cur.WriteString(word)
+		curW += ansi.StringWidth(word)
 	}
+	flush()
 	return out
 }
 
@@ -2766,7 +2820,7 @@ func (m Model) addItemDetail() []string {
 			faintStyle.Render("  upstream_url  " + t.UpstreamURL),
 		}
 		if t.Note != "" {
-			lines = append(lines, errStyle.Render("  note: "+t.Note))
+			lines = append(lines, noteStyle.Render("  note: "+t.Note))
 		}
 		return lines
 	default:
@@ -2780,7 +2834,7 @@ func (m Model) addItemDetail() []string {
 			faintStyle.Render("  default_model   " + t.DefaultModel),
 		}
 		if t.Note != "" {
-			lines = append(lines, errStyle.Render("  note: "+t.Note))
+			lines = append(lines, noteStyle.Render("  note: "+t.Note))
 		}
 		return lines
 	}

--- a/internal/userops/userops.go
+++ b/internal/userops/userops.go
@@ -612,7 +612,7 @@ func editLocked(req EditRequest) (*EditResult, error) {
 // RemoveRequest is the typed input for Remove.
 type RemoveRequest struct {
 	Name       string
-	KeepSecret bool // when true, file-backend secrets are preserved
+	KeepSecret bool // when true, a file-backend secret or a codex own-login is preserved
 }
 
 // RemoveResult is the structured result of Remove.
@@ -622,31 +622,56 @@ type RemoveResult struct {
 	ProfileRemoved bool   `json:"profile_removed"`
 }
 
-// Remove deletes the vendor row from vendors.toml, the per-vendor profile
-// JSON, and (for file-backend vendors without --keep-secret) the on-disk
-// secret. Non-file backends are never auto-purged — the user removes those
-// through the backend's own CLI.
+// Remove deletes the vendor row from vendors.toml, the per-vendor profile JSON,
+// and (without --keep-secret) the credential it owns: a file-backend on-disk secret,
+// or — for a codex provider — cc-fleet's own login token + its daemon. ~/.codex and
+// other external backends are never auto-purged; the user clears those themselves.
 //
 // Runs under the global vendors-config flock.
 func Remove(req RemoveRequest) (*RemoveResult, error) {
-	return withVendorsLock(func() (*RemoveResult, error) { return removeLocked(req) })
+	var codexRef string
+	res, err := withVendorsLock(func() (*RemoveResult, error) {
+		r, ref, e := removeLocked(req)
+		codexRef = ref
+		return r, e
+	})
+	if err != nil {
+		return res, err
+	}
+	// Drop a removed codex provider's cc-fleet login (token file) + its daemon here,
+	// OUTSIDE the vendors lock: codexproxy's token/proxy locks are standalone scopes
+	// that must never nest under it. LogoutIfUnreferenced no-ops if a concurrent re-add
+	// reclaimed the credential, and surfaces a removal failure (a surviving login would
+	// be silently reused on the next add). ~/.codex (the codex CLI login) is untouched.
+	if codexRef != "" && !req.KeepSecret {
+		if err := codexproxy.LogoutIfUnreferenced(codexRef); err != nil {
+			return res, opErr(CodeSecretRemoveFailed, fmt.Errorf("remove codex login: %w", err))
+		}
+	}
+	return res, nil
 }
 
-func removeLocked(req RemoveRequest) (*RemoveResult, error) {
+func removeLocked(req RemoveRequest) (*RemoveResult, string, error) {
 	if err := ValidateVendorName(req.Name); err != nil {
-		return nil, opErr(CodeVendorNameInvalid, err)
+		return nil, "", opErr(CodeVendorNameInvalid, err)
 	}
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, opErr(CodeConfigLoadFailed, err)
+		return nil, "", opErr(CodeConfigLoadFailed, err)
 	}
 	v, ok := cfg.Vendors[req.Name]
 	if !ok {
-		return nil, opErr(CodeVendorUnknown,
+		return nil, "", opErr(CodeVendorUnknown,
 			fmt.Errorf("vendor %q not in vendors.toml", req.Name))
 	}
 
 	res := &RemoveResult{Vendor: req.Name}
+	// A codex provider's login is removed after the lock (see Remove); capture its
+	// credential ref before the row is gone.
+	codexRef := ""
+	if v.EffectiveProtocol() == config.ProtocolCodexOAuth {
+		codexRef = v.SecretRef
+	}
 
 	// Commit the config row deletion FIRST, before any destructive profile/secret
 	// cleanup: if Save fails, vendors.toml is unchanged and the profile + secret
@@ -657,12 +682,12 @@ func removeLocked(req RemoveRequest) (*RemoveResult, error) {
 	// at the removed Vendor struct — the map entry is gone but the value is held.)
 	delete(cfg.Vendors, req.Name)
 	if err := config.Save(cfg); err != nil {
-		return nil, opErr(CodeConfigSaveFailed, err)
+		return nil, "", opErr(CodeConfigSaveFailed, err)
 	}
 
 	// Profile removal is idempotent (RemoveForVendor swallows ENOENT).
 	if err := profile.RemoveForVendor(req.Name); err != nil {
-		return nil, opErr(CodeProfileWriteFailed, err)
+		return nil, "", opErr(CodeProfileWriteFailed, err)
 	}
 	res.ProfileRemoved = true
 
@@ -671,7 +696,7 @@ func removeLocked(req RemoveRequest) (*RemoveResult, error) {
 	if v.SecretBackend == "file" && !req.KeepSecret {
 		if v.SecretRef != "" {
 			if err := removeFileSecret(v.SecretRef); err != nil {
-				return nil, opErr(CodeSecretRemoveFailed, err)
+				return nil, "", opErr(CodeSecretRemoveFailed, err)
 			}
 			res.SecretRemoved = true
 		}
@@ -679,11 +704,11 @@ func removeLocked(req RemoveRequest) (*RemoveResult, error) {
 		// missing file is not an error). Independent of secret_ref because a
 		// multi-key vendor's keys live in <vendor>.keys.json, not secret_ref.
 		if err := secrets.RemoveKeySet(req.Name); err != nil {
-			return nil, opErr(CodeSecretRemoveFailed, err)
+			return nil, "", opErr(CodeSecretRemoveFailed, err)
 		}
 	}
 
-	return res, nil
+	return res, codexRef, nil
 }
 
 // removeFileSecret deletes <SecretsDir>/<ref>. A missing file is fine —

--- a/internal/userops/userops.go
+++ b/internal/userops/userops.go
@@ -199,6 +199,10 @@ type AddRequest struct {
 	BaseURL        string
 	ModelsEndpoint string
 	DefaultModel   string
+	StrongModel    string // optional "strong" capability slot; blank → follows DefaultModel
+	FastModel      string // optional "fast" capability slot; blank → follows DefaultModel
+	Effort         string // optional reasoning-effort level (config.validEfforts); "" = unset
+	DefaultPerm    string // optional default permission mode for `cc-fleet run`; "" = unset
 	SecretBackend  string
 	SecretRef      string
 	Protocol       string // "" Anthropic-native | openai-chat | openai-responses | codex-oauth
@@ -270,16 +274,20 @@ func addLocked(req AddRequest) (*AddResult, error) {
 
 	// Build the candidate vendor and validate schema before any further work.
 	v := &config.Vendor{
-		Name:           req.Name,
-		BaseURL:        req.BaseURL,
-		ModelsEndpoint: req.ModelsEndpoint,
-		DefaultModel:   req.DefaultModel,
-		SecretBackend:  req.SecretBackend,
-		SecretRef:      req.SecretRef,
-		Protocol:       req.Protocol,
-		UpstreamURL:    req.UpstreamURL,
-		Enabled:        req.Enabled,
-		AddedAt:        time.Now().UTC(),
+		Name:              req.Name,
+		BaseURL:           req.BaseURL,
+		ModelsEndpoint:    req.ModelsEndpoint,
+		DefaultModel:      req.DefaultModel,
+		StrongModel:       req.StrongModel,
+		FastModel:         req.FastModel,
+		Effort:            req.Effort,
+		DefaultPermission: req.DefaultPerm,
+		SecretBackend:     req.SecretBackend,
+		SecretRef:         req.SecretRef,
+		Protocol:          req.Protocol,
+		UpstreamURL:       req.UpstreamURL,
+		Enabled:           req.Enabled,
+		AddedAt:           time.Now().UTC(),
 	}
 
 	// Merge the new vendor into the loaded config and validate before any
@@ -443,6 +451,10 @@ type EditRequest struct {
 	UpstreamURL    *string // openai-* real upstream base
 	ModelsEndpoint *string
 	DefaultModel   *string
+	StrongModel    *string // "strong" capability slot ("" clears → follows DefaultModel)
+	FastModel      *string // "fast" capability slot ("" clears → follows DefaultModel)
+	Effort         *string // reasoning-effort level ("" clears); config.Validate rejects bad values
+	DefaultPerm    *string // default permission mode for `cc-fleet run` ("" clears)
 	SecretBackend  *string
 	SecretRef      *string
 	Enabled        *bool
@@ -499,8 +511,25 @@ func editLocked(req EditRequest) (*EditResult, error) {
 	if req.ModelsEndpoint != nil {
 		v.ModelsEndpoint = *req.ModelsEndpoint
 	}
-	if req.DefaultModel != nil {
+	profileFieldChanged := false
+	if req.DefaultModel != nil && *req.DefaultModel != v.DefaultModel {
 		v.DefaultModel = *req.DefaultModel
+		profileFieldChanged = true
+	}
+	if req.StrongModel != nil && *req.StrongModel != v.StrongModel {
+		v.StrongModel = *req.StrongModel
+		profileFieldChanged = true
+	}
+	if req.FastModel != nil && *req.FastModel != v.FastModel {
+		v.FastModel = *req.FastModel
+		profileFieldChanged = true
+	}
+	if req.Effort != nil && *req.Effort != v.Effort {
+		v.Effort = *req.Effort // config.Validate rejects a bad value
+		profileFieldChanged = true
+	}
+	if req.DefaultPerm != nil {
+		v.DefaultPermission = *req.DefaultPerm // run-only; does not affect the profile
 	}
 	if req.SecretBackend != nil {
 		v.SecretBackend = *req.SecretBackend
@@ -563,9 +592,11 @@ func editLocked(req EditRequest) (*EditResult, error) {
 		return nil, opErr(CodeConfigSaveFailed, err)
 	}
 
-	// Re-render the profile only when base_url moved — the apiKeyHelper path is
-	// identical between vendors, so other field edits don't affect it.
-	if baseURLChanged {
+	// Re-render the profile when a field it embeds moved: base_url
+	// (ANTHROPIC_BASE_URL) or a model/effort field (the tier env + effortLevel).
+	// The apiKeyHelper path is vendor-independent, and default_permission is
+	// run-only, so neither touches the profile.
+	if baseURLChanged || profileFieldChanged {
 		if _, err := profile.WriteForVendor(v, ""); err != nil {
 			return nil, opErr(CodeProfileWriteFailed, err)
 		}
@@ -684,6 +715,10 @@ type VendorView struct {
 	Name           string `json:"name"`
 	BaseURL        string `json:"base_url"`
 	DefaultModel   string `json:"default_model"`
+	StrongModel    string `json:"strong_model,omitempty"` // blank → follows default_model
+	FastModel      string `json:"fast_model,omitempty"`   // blank → follows default_model
+	Effort         string `json:"effort,omitempty"`       // reasoning-effort level; blank → unset
+	DefaultPerm    string `json:"default_permission,omitempty"`
 	ModelsEndpoint string `json:"models_endpoint"`
 	SecretBackend  string `json:"secret_backend"`
 	SecretRef      string `json:"secret_ref"`
@@ -726,6 +761,10 @@ func List() (*ListResult, error) {
 			Name:           v.Name,
 			BaseURL:        v.BaseURL,
 			DefaultModel:   v.DefaultModel,
+			StrongModel:    v.StrongModel,
+			FastModel:      v.FastModel,
+			Effort:         v.Effort,
+			DefaultPerm:    v.DefaultPermission,
 			ModelsEndpoint: v.ModelsEndpoint,
 			SecretBackend:  v.SecretBackend,
 			SecretRef:      v.SecretRef,

--- a/internal/userops/userops_test.go
+++ b/internal/userops/userops_test.go
@@ -521,6 +521,56 @@ func TestRemove_FileBackendDeletesSecret(t *testing.T) {
 	}
 }
 
+// Removing a codex provider also deletes cc-fleet's own login for its credential
+// (so a re-add does not silently reuse a stale login); KeepSecret preserves it.
+func TestRemove_CodexDeletesOwnLogin(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		name := "remove"
+		if keep {
+			name = "keep"
+		}
+		t.Run(name, func(t *testing.T) {
+			setupHome(t)
+			if _, err := Init(); err != nil {
+				t.Fatalf("Init: %v", err)
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.Vendors["codex"] = &config.Vendor{
+				Name: "codex", BaseURL: "http://127.0.0.1:17222/",
+				ModelsEndpoint: "http://127.0.0.1:17222/v1/models", DefaultModel: "gpt-5.5",
+				SecretBackend: config.CodexOAuthBackend, SecretRef: config.CodexOAuthBackend,
+				Protocol: config.ProtocolCodexOAuth, Enabled: true,
+				AddedAt: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+			}
+			if err := config.Save(cfg); err != nil {
+				t.Fatalf("save codex: %v", err)
+			}
+			dir, err := config.ConfigDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			tok := filepath.Join(dir, "codex_oauth.json")
+			if err := os.WriteFile(tok, []byte(`{"refresh_token":"rt","account_id":"acc"}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := Remove(RemoveRequest{Name: "codex", KeepSecret: keep}); err != nil {
+				t.Fatalf("Remove: %v", err)
+			}
+			_, statErr := os.Stat(tok)
+			if keep && statErr != nil {
+				t.Fatalf("KeepSecret must preserve the codex login: %v", statErr)
+			}
+			if !keep && !os.IsNotExist(statErr) {
+				t.Fatalf("Remove must delete the codex login, stat err = %v", statErr)
+			}
+		})
+	}
+}
+
 func TestRemove_KeepSecretPreservesFile(t *testing.T) {
 	setupHome(t)
 	if _, err := Init(); err != nil {


### PR DESCRIPTION
This branch extends per-provider configuration and gives codex providers independent logins.

Per-provider model configuration: each provider carries a model roster (default / strong / fast slots) plus an optional reasoning-effort level and a default permission mode for `cc-fleet run`. The roster populates every Claude Code model tier in the generated profile, so a teammate or subagent never falls back to a built-in claude-* model id the provider cannot serve, and a manual 1M-context marker can be set per slot. These fields are now editable on the add forms, not just the edit form, so a provider is fully configured at creation.

Multiple providers of one type: adding a second provider from the same template auto-uniquifies its name to `<base>-N`, so two of the same vendor coexist with their own models and keys.

Per-codex logins: each codex provider owns its own login credential keyed on its secret_ref instead of all sharing one. The first codex claims the default credential and can ride the codex CLI's `~/.codex` login; when a subscription is detected on add you choose to reuse it or log in separately, and additional codex providers get their own credential and their own in-TUI device-code login, so two ChatGPT subscriptions run as separate teammates. Removing a codex provider also removes the cc-fleet login it owned (its token plus daemon) and leaves `~/.codex` untouched.

Correctness: credential refs are validated as path-safe identifiers both at config load and at the codexproxy boundary, the config rejects two codex providers that resolve to the same credential, and the OAuth bearer never leaves the loopback conversion daemon. The form's Note section reserves a stable height so the config block stays put between the preview and the edit views.
