### PR TITLE
Rework the update / version-check / doctor chain: `ccf update`, startup prompt, Core/Optional doctor, release version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,16 @@ permissions:
   contents: write
 
 jobs:
+  # Runs before any artifact is built: a stale plugin.json or npm version fails
+  # the whole release (the marketplace serves the committed plugin.json).
+  version-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: bash scripts/version-guard.sh "${GITHUB_REF_NAME}"
+
   goreleaser:
+    needs: version-guard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   npm-publish:
-    needs: goreleaser
+    needs: [version-guard, goreleaser]
     # OIDC trusted publishing (no stored token). Gated until cc-fleet's first
     # publish is done manually and a trusted publisher is configured on npmjs.
     if: vars.NPM_TRUSTED_PUBLISHING == 'true'

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DIST_DIR   := ./dist
 # the canonical source; `skill-drift-check` fails if they diverge.
 LOCAL_SKILL := .claude/skills/cc-fleet/SKILL.md
 
-.PHONY: build install install-bin install-skill skill-sync skill-drift-check uninstall test clean smoke cross-compile release-archive
+.PHONY: build install install-bin install-skill skill-sync skill-drift-check uninstall test clean smoke cross-compile release-archive release-prep version-guard
 
 build:
 	@mkdir -p $(BIN_DIR)
@@ -115,3 +115,19 @@ release-archive: cross-compile
 	done; \
 	rm -rf "$$stage_root"; \
 	echo "Built 4 release archives in $(DIST_DIR)/"
+
+# Bump the plugin manifest + npm package version in lockstep before tagging a
+# release (VERSION=vX.Y.Z). version-guard asserts these match the tag at release.
+release-prep:
+	@test -n "$(VERSION)" || { echo "usage: make release-prep VERSION=vX.Y.Z"; exit 1; }
+	@v="$(VERSION)"; v="$${v#v}"; \
+	  for f in .claude-plugin/plugin.json npm/package.json; do \
+	    tmp=$$(mktemp); \
+	    sed 's/\("version"[[:space:]]*:[[:space:]]*"\)[^"]*"/\1'"$$v"'"/' "$$f" > "$$tmp" && mv "$$tmp" "$$f"; \
+	  done; \
+	  echo "release-prep: set plugin.json + npm/package.json to $$v — commit, then tag v$$v"
+
+# Assert plugin.json == npm/package.json == VERSION (the release-time guard, run
+# locally). VERSION defaults to the latest git tag.
+version-guard:
+	@bash scripts/version-guard.sh "$(or $(VERSION),$$(git describe --tags --abbrev=0))"

--- a/cmd/cc-fleet/doctor.go
+++ b/cmd/cc-fleet/doctor.go
@@ -11,9 +11,8 @@ import (
 )
 
 // totalChecks is the [N/total] count shown in pretty output. Hard-coded (not
-// computed from RunAll's slice) — if you add a tenth check, update this constant
-// so the user-facing text stays consistent.
-const totalChecks = 9
+// computed from RunAll's slice) — keep it in step with RunAll's check list.
+const totalChecks = 10
 
 func newDoctorCmd() *cobra.Command {
 	var (
@@ -23,23 +22,27 @@ func newDoctorCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Run the 9 cc-fleet health checks",
-		Long: `Run cc-fleet's nine health checks:
+		Short: "Run the cc-fleet health checks",
+		Long: `Run cc-fleet's health checks, grouped Core vs Optional.
 
-  [1/9] ~/.claude/settings.json exists and is valid JSON
-  [2/9] ~/.claude/profiles/ writable
-  [3/9] tmux installed
-  [4/9] claude binary present; version known
-  [5/9] at least one attached tmux session (warn — out-of-tmux swarm works without)
-  [6/9] all configured vendors' keys reachable (probe /v1/models, 3s/vendor)
-  [7/9] skill installed at ~/.claude/skills/cc-fleet/
-  [8/9] fingerprint cached and matches current cc version
-  [9/9] OAuth credentials.json exists (informational only)
+Core (every run mode — subagent / workflow / run / teammate):
+  [1] ~/.claude/settings.json exists and is valid JSON
+  [2] ~/.claude/profiles/ writable
+  [4] claude binary present; version known
+  [6] all configured vendors' keys reachable (probe /v1/models, 3s/vendor)
+  [7] skill installed at ~/.claude/skills/cc-fleet/ (or via plugin)
+  [8] fingerprint cached and matches current cc version
+  [9] OAuth credentials.json exists (informational only)
+  [10] binary and plugin versions match
 
-Status semantics: ok = passed; fail = needs action; warn = informational
-(doesn't flip overall ok=false).
+Optional — live teammates only (tmux):
+  [3] tmux installed (warn — subagent / workflow / run work without it)
+  [5] at least one attached tmux session (warn — out-of-tmux swarm works without)
 
-Exit code: 0 if every check is ok or warn; 1 if any check is fail.
+Status semantics: ok = passed; fail = needs action; warn = informational.
+
+Exit code: 0 when every Core check is ok/warn; 1 only when a Core check fails.
+An Optional (tmux) warning never fails doctor.
 
 --fix attempts a small set of safe auto-repairs:
   check 2: mkdir -p ~/.claude/profiles (mode 0700)
@@ -77,20 +80,38 @@ func runDoctor(fix, asJSON bool) error {
 		}
 		fmt.Println(string(data))
 	} else {
-		for _, r := range res.Results {
-			fmt.Println(doctor.FormatLine(totalChecks, r))
-		}
+		printDoctorGroup("Core", doctor.GroupCore, res.Results)
+		printDoctorGroup("Optional — live teammates only", doctor.GroupOptional, res.Results)
 		if res.OK {
-			fmt.Println("\nall checks passed")
+			fmt.Println("core checks passed")
 		} else {
-			fmt.Println("\none or more checks failed; see hints above")
+			fmt.Println("one or more core checks failed; see hints above")
 		}
 	}
 
 	if !res.OK {
 		// cobra suppresses our error printing (SilenceErrors) so this only
 		// drives the exit code through main().
-		return fmt.Errorf("doctor: one or more checks failed")
+		return fmt.Errorf("doctor: one or more core checks failed")
 	}
 	return nil
+}
+
+// printDoctorGroup prints one section header and its check lines, or nothing if
+// the group has no results. Lines are indented two spaces under the header.
+func printDoctorGroup(title string, g doctor.Group, results []doctor.CheckResult) {
+	var lines []string
+	for _, r := range results {
+		if r.Group == g {
+			lines = append(lines, doctor.FormatLine(totalChecks, r))
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Println(title)
+	for _, l := range lines {
+		fmt.Println("  " + l)
+	}
+	fmt.Println()
 }

--- a/cmd/cc-fleet/init.go
+++ b/cmd/cc-fleet/init.go
@@ -91,15 +91,14 @@ func runInit(asJSON bool) error {
 	}
 	fmt.Println()
 
-	// Doctor block — same lines `cc-fleet doctor` prints, no fix attempts.
+	// Doctor block — same grouped output `cc-fleet doctor` prints, no fix attempts.
 	fmt.Println("Health checks:")
-	for _, r := range dres.Results {
-		fmt.Println(" ", doctor.FormatLine(totalChecks, r))
-	}
+	printDoctorGroup("Core", doctor.GroupCore, dres.Results)
+	printDoctorGroup("Optional — live teammates only", doctor.GroupOptional, dres.Results)
 	if dres.OK {
-		fmt.Println("\nall checks passed")
+		fmt.Println("core checks passed")
 	} else {
-		fmt.Println("\none or more checks failed; see hints above (run: cc-fleet doctor --fix)")
+		fmt.Println("one or more core checks failed; see hints above (run: cc-fleet doctor --fix)")
 	}
 	fmt.Println()
 

--- a/cmd/cc-fleet/init.go
+++ b/cmd/cc-fleet/init.go
@@ -42,7 +42,7 @@ right away. Replying "y" drops you into the same prompts that ` + "`cc-fleet add
 would. Anything else (including bare Enter / EOF) skips the vendor step.
 
 In --json mode, init is non-interactive: it creates the tree and runs the
-nine doctor checks once, then prints a single JSON envelope.
+doctor health checks once, then prints a single JSON envelope.
 
 Init is idempotent — running on a HOME that's already initialized just
 reports each existing path under "already_had" and does not overwrite

--- a/cmd/cc-fleet/main.go
+++ b/cmd/cc-fleet/main.go
@@ -64,6 +64,7 @@ teammate Claude Code sessions inside tmux windows.`,
 	root.AddCommand(newListCmd())
 	root.AddCommand(newRepairCmd())
 	root.AddCommand(newUninstallCmd())
+	root.AddCommand(newUpdateCmd())
 	return root
 }
 

--- a/cmd/cc-fleet/tui.go
+++ b/cmd/cc-fleet/tui.go
@@ -38,5 +38,9 @@ func runTUIIfInteractive(args []string) (handled bool, err error) {
 	if !shouldEnterTUI(args, stdinTTY, stdoutTTY) {
 		return false, nil
 	}
+	// Pre-TUI (terminal still in normal mode): offer a once-a-day update if a
+	// newer release is cached. Gated to exactly this bare-interactive path, so
+	// keyget / subagent / spawn / --json / non-TTY callers never reach it.
+	maybePromptUpdate()
 	return true, tui.Run()
 }

--- a/cmd/cc-fleet/update.go
+++ b/cmd/cc-fleet/update.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethanhq/cc-fleet/internal/selfupdate"
+)
+
+func newUpdateCmd() *cobra.Command {
+	var (
+		checkOnly  bool
+		binaryOnly bool
+		force      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update the cc-fleet binary and Claude Code plugin to the latest release",
+		Long: `Update cc-fleet to the latest GitHub release.
+
+The binary is updated according to how it was installed:
+  - curl|sh / release tarball: downloaded, sha256-verified, smoke-tested, then
+    atomically swapped in place (the previous binary is kept as <bin>.previous).
+  - npm:        runs 'npm install -g @ethanhq/cc-fleet@latest'.
+  - go install: runs 'go install github.com/ethanhq/cc-fleet/cmd/cc-fleet@latest'.
+When the needed tool is missing (or the install dir isn't writable), update
+prints the exact command instead of acting.
+
+The Claude Code plugin is refreshed in the same run (marketplace update + plugin
+update, preserving scope); --binary-only skips it. A dev/non-release build is
+reported as not comparable and is never updated.
+
+  cc-fleet update            update the binary + plugin
+  cc-fleet update --check    report current vs latest, change nothing
+  cc-fleet update rollback   restore the previous binary`,
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			if checkOnly {
+				return runUpdateCheck(ctx)
+			}
+			return selfupdate.Run(ctx, selfupdate.Options{
+				BinaryOnly: binaryOnly,
+				Force:      force,
+				Out:        os.Stdout,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&checkOnly, "check", false,
+		"Report current vs latest without updating")
+	cmd.Flags().BoolVar(&binaryOnly, "binary-only", false,
+		"Update only the binary, not the Claude Code plugin")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Self-update in place even when the install method can't be determined")
+
+	cmd.AddCommand(&cobra.Command{
+		Use:           "rollback",
+		Short:         "Restore the previous binary kept by the last update",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return selfupdate.Rollback(os.Stdout)
+		},
+	})
+
+	return cmd
+}
+
+// runUpdateCheck prints the current-vs-latest state and always exits 0 — it is
+// informational; an offline check is a notice, not a failure.
+func runUpdateCheck(ctx context.Context) error {
+	st, err := selfupdate.Check(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cc-fleet %s — could not check for updates: %s\n", st.Current, err)
+		return nil
+	}
+	switch {
+	case !st.Comparable:
+		fmt.Printf("Development build (%s) — not comparable. Latest release is %s.\n", st.Current, st.Latest)
+	case st.NewerAvailable:
+		fmt.Printf("cc-fleet %s  ·  latest %s  → run `ccf update`\n", st.Current, st.Latest)
+	default:
+		fmt.Printf("cc-fleet %s is the latest.\n", st.Current)
+	}
+	return nil
+}

--- a/cmd/cc-fleet/updateprompt.go
+++ b/cmd/cc-fleet/updateprompt.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/selfupdate"
+	"github.com/ethanhq/cc-fleet/internal/version"
+)
+
+// maybePromptUpdate shows a once-a-day "new version available" prompt just
+// before the TUI starts — while the terminal is still in normal mode, so an
+// "update now" re-exec is clean and no global pre-run can ever taint keyget or
+// any machine-facing command. It is driven purely by the cached check (no
+// network on the launch path); a background goroutine refreshes that cache for
+// the next launch. Called only from the bare-interactive both-TTY path.
+func maybePromptUpdate() {
+	if selfupdate.OptedOut() {
+		return
+	}
+	// Refresh the cache for next time in the background — never blocks launch.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		selfupdate.RefreshCache(ctx, time.Now())
+	}()
+
+	now := time.Now()
+	tag, ok := selfupdate.PromptTag(now)
+	if !ok {
+		return
+	}
+
+	fmt.Printf("\ncc-fleet %s is available — you're on %s.\n", tag, version.Resolve())
+	fmt.Println("  [u] update now      [enter] continue  (asked again tomorrow)")
+	fmt.Print("> ")
+	choice := strings.ToLower(readLineCooked(os.Stdin))
+
+	// Either choice suppresses the prompt for a day.
+	_ = selfupdate.Dismiss(tag, now)
+	if choice != "u" {
+		return // continue into the TUI on the current version
+	}
+
+	// Capture the binary path BEFORE the swap: after a self-update os.Executable
+	// resolves to the renamed .previous inode, so the re-exec must target the
+	// original path (which now holds the new binary).
+	bin, exeErr := os.Executable()
+	if exeErr == nil {
+		if resolved, e := filepath.EvalSymlinks(bin); e == nil {
+			bin = resolved
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if err := selfupdate.Run(ctx, selfupdate.Options{Out: os.Stdout}); err != nil {
+		fmt.Fprintln(os.Stderr, "cc-fleet update:", err)
+		return // fall through to the TUI on the current binary
+	}
+	if exeErr != nil {
+		fmt.Println("updated — restart ccf to use the new version.")
+		return
+	}
+	fmt.Println("relaunching…")
+	if err := syscall.Exec(bin, os.Args, os.Environ()); err != nil {
+		// Exec failed — the new binary is on disk; just continue this session.
+		fmt.Fprintln(os.Stderr, "cc-fleet: relaunch failed, continuing on the current version:", err)
+	}
+}
+
+// readLineCooked reads one line from f one byte at a time so it never buffers
+// past the newline — the bytes after it belong to bubbletea, which takes over
+// stdin once the TUI starts.
+func readLineCooked(f *os.File) string {
+	var b []byte
+	buf := make([]byte, 1)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				break
+			}
+			b = append(b, buf[0])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/install.sh
+++ b/install.sh
@@ -159,9 +159,10 @@ ln -sf cc-fleet "${PREFIX}/ccf"
 echo "==> Installed ${PREFIX}/cc-fleet (+ ccf alias)"
 
 # Install manifest (co-located with the binary) so `cc-fleet update` self-updates
-# in place without guessing how it was installed.
+# in place without guessing the method, preserves the plugin scope, and leaves
+# the plugin alone for a --skill none/global install.
 cat > "${PREFIX}/.cc-fleet-install.json" <<EOF
-{"method":"tarball","prefix":"${PREFIX}","plugin_scope":"${SCOPE}","marketplace":"${MARKETPLACE}"}
+{"method":"tarball","plugin_scope":"${SCOPE}","skill":"${SKILL_MODE}"}
 EOF
 
 # --- skill --------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -158,6 +158,12 @@ chmod 0755 "${PREFIX}/cc-fleet"
 ln -sf cc-fleet "${PREFIX}/ccf"
 echo "==> Installed ${PREFIX}/cc-fleet (+ ccf alias)"
 
+# Install manifest (co-located with the binary) so `cc-fleet update` self-updates
+# in place without guessing how it was installed.
+cat > "${PREFIX}/.cc-fleet-install.json" <<EOF
+{"method":"tarball","prefix":"${PREFIX}","plugin_scope":"${SCOPE}","marketplace":"${MARKETPLACE}"}
+EOF
+
 # --- skill --------------------------------------------------------------------
 
 case "$SKILL_MODE" in
@@ -190,6 +196,17 @@ case "$SKILL_MODE" in
         ;;
 esac
 
+# --- Claude Code precondition note --------------------------------------------
+
+if ! have claude; then
+    cat <<EOF
+
+==> Note: Claude Code ('claude') was not found on PATH.
+    cc-fleet drives Claude Code — install it to run teammates / subagents / workflows:
+    https://docs.anthropic.com/claude-code
+EOF
+fi
+
 # --- PATH check + next steps --------------------------------------------------
 
 case ":${PATH}:" in
@@ -212,4 +229,7 @@ cat <<EOF
    cc-fleet             # launch the interactive TUI — register a vendor and get started
                         #   (config is auto-created on first save; no init needed)
    cc-fleet doctor      # optional: run the health checks
+   cc-fleet update      # later: update cc-fleet + the plugin to the latest release
+
+   tmux is needed only for live teammates; subagent / workflow / run work without it.
 EOF

--- a/internal/doctor/check.go
+++ b/internal/doctor/check.go
@@ -1,4 +1,6 @@
-// Package doctor implements the nine health checks behind `cc-fleet doctor`.
+// Package doctor implements the health checks behind `cc-fleet doctor`,
+// split into a Core group (every run mode) and an Optional group (live
+// teammates only — tmux).
 //
 // Each check is an independent function in checks.go that returns a
 // CheckResult value — none of them panic, even on grossly broken systems.
@@ -22,8 +24,21 @@ const (
 	// Warns do NOT make DoctorResult.OK false.
 	StatusWarn Status = "warn"
 	// StatusFail means the check failed and the user almost certainly needs
-	// to act. Any single fail flips DoctorResult.OK to false.
+	// to act. A Core-group fail flips DoctorResult.OK to false; an Optional one
+	// does not (see Group).
 	StatusFail Status = "fail"
+)
+
+// Group classifies a check by which run modes need it. Core checks apply to
+// every mode (subagent / workflow / run / teammate); Optional checks matter
+// only for live teammates (tmux). Only a Core fail flips DoctorResult.OK.
+type Group string
+
+const (
+	// GroupCore is needed by every cc-fleet run mode.
+	GroupCore Group = "core"
+	// GroupOptional is needed only by live teammates (tmux).
+	GroupOptional Group = "optional"
 )
 
 // CheckResult is the verdict of a single check.
@@ -35,15 +50,17 @@ type CheckResult struct {
 	ID         int    `json:"id"`
 	Title      string `json:"title"`
 	Status     Status `json:"status"`
+	Group      Group  `json:"group"`
 	Detail     string `json:"detail,omitempty"`
 	Fixable    bool   `json:"fixable,omitempty"`
 	FixHint    string `json:"fix_hint,omitempty"`
 	AppliedFix bool   `json:"applied_fix,omitempty"`
 }
 
-// DoctorResult is the full output of RunAll — one envelope around the nine
+// DoctorResult is the full output of RunAll — one envelope around the
 // CheckResults plus an aggregate OK boolean. OK is the AND of "status !=
-// StatusFail" across all results.
+// StatusFail" across the Core-group results only; an Optional (live-teammate)
+// failure never flips OK.
 type DoctorResult struct {
 	OK      bool          `json:"ok"`
 	Results []CheckResult `json:"results"`

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 	"github.com/ethanhq/cc-fleet/internal/models"
 	"github.com/ethanhq/cc-fleet/internal/tmux"
+	"github.com/ethanhq/cc-fleet/internal/version"
 )
 
 // vendorProbeTimeout caps each vendor's /v1/models probe in check 6 at
@@ -148,15 +149,17 @@ func CheckProfilesDirWritable() CheckResult {
 	return r
 }
 
-// CheckTmuxInstalled is check 3: tmux is on PATH and `tmux -V` runs.
-// Returns Fail with a fix hint when tmux is missing (we don't auto-install).
+// CheckTmuxInstalled is check 3: tmux is on PATH and `tmux -V` runs. tmux is
+// needed only for live teammate panes; subagent / workflow / run all work
+// without it — so a missing tmux is a Warn (Optional group), not a Fail, and
+// never flips doctor's overall OK.
 func CheckTmuxInstalled() CheckResult {
-	r := CheckResult{ID: 3, Title: "tmux installed"}
+	r := CheckResult{ID: 3, Title: "tmux installed (live teammates only)"}
 	out, err := exec.Command("tmux", "-V").Output()
 	if err != nil {
-		r.Status = StatusFail
-		r.Detail = fmt.Sprintf("tmux -V failed: %s", err.Error())
-		r.FixHint = "install tmux (apt-get install tmux | brew install tmux)"
+		r.Status = StatusWarn
+		r.Detail = "not found — needed only for live teammate panes; subagent / workflow / run work without it"
+		r.FixHint = "for live teammates, install tmux (apt-get install tmux | brew install tmux)"
 		return r
 	}
 	r.Status = StatusOK
@@ -361,6 +364,77 @@ func pluginSkillPath(cdir string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// CheckPluginVersionMatch is check 10: the running cc-fleet binary's version
+// matches the installed cc-fleet plugin's version. The skill (shipped by the
+// plugin) drives the binary, so a large skew can surface stale guidance — a
+// mismatch is a WARN with a `ccf update` hint. It is OK when the two match,
+// when no plugin is installed (nothing to compare), or when the binary is a
+// non-release/dev build (version.IsRelease false → not comparable).
+func CheckPluginVersionMatch() CheckResult {
+	r := CheckResult{ID: 10, Title: "binary and plugin versions match"}
+	cur := version.Resolve()
+	if !version.IsRelease(cur) {
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("development build (%s) — not comparable", cur)
+		return r
+	}
+	cdir, err := claudeDir()
+	if err != nil {
+		// Can't locate ~/.claude — checks 1-2 already cover a broken home dir;
+		// this informational check never alarms on its own.
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("could not locate ~/.claude (%s)", err.Error())
+		return r
+	}
+	pv, ok := pluginVersion(cdir)
+	if !ok {
+		r.Status = StatusOK
+		r.Detail = "no cc-fleet plugin installed (nothing to compare)"
+		return r
+	}
+	if version.Normalize(pv) == version.Normalize(cur) {
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("binary %s == plugin %s", cur, pv)
+		return r
+	}
+	r.Status = StatusWarn
+	r.Detail = fmt.Sprintf("binary %s != plugin %s", cur, pv)
+	r.FixHint = "run `ccf update` to bring the binary and plugin to the same version"
+	return r
+}
+
+// pluginVersion returns the highest cc-fleet plugin version Claude Code has
+// cached, and ok=false if none. Claude Code unpacks marketplace plugins under
+// ~/.claude/plugins/cache/<marketplace>/cc-fleet/<version>/, so the <version>
+// path segment is the plugin's version; the cache can hold several, so the
+// newest comparable release wins (a stale leftover never WARNs against a
+// matching current one). A non-release segment is ignored.
+func pluginVersion(cdir string) (string, bool) {
+	pattern := filepath.Join(cdir, "plugins", "cache", "*", "cc-fleet", "*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", false // only ErrBadPattern, impossible for this fixed pattern
+	}
+	best := ""
+	for _, m := range matches {
+		info, statErr := os.Stat(m)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		ver := filepath.Base(m)
+		if !version.IsRelease(ver) {
+			continue
+		}
+		if best == "" || version.Newer(ver, best) {
+			best = ver
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	return best, true
 }
 
 // CheckFingerprint is check 8: a fingerprint cache exists and its cached

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -13,7 +13,29 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
+	"github.com/ethanhq/cc-fleet/internal/version"
 )
+
+// writePluginCache drops a cc-fleet plugin cache dir named by version (the
+// layout Claude Code uses: plugins/cache/<marketplace>/cc-fleet/<version>/) so
+// the binary↔plugin skew check has something to compare against.
+func writePluginCache(t *testing.T, home, ver string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "plugins", "cache", "ethanhq", "cc-fleet", ver)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin cache: %v", err)
+	}
+}
+
+// pinVersion overrides the binary's reported version for one test and restores
+// it after. version.Version is the link-time stamp; Resolve() returns it
+// verbatim when it differs from the dev default.
+func pinVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = v
+}
 
 // setupHome installs a fresh $HOME + $XDG_CONFIG_HOME inside a t.TempDir() so
 // every check below sees a controlled, empty filesystem. Returns the home dir
@@ -181,11 +203,13 @@ func TestCheckTmuxInstalled_OK(t *testing.T) {
 }
 
 func TestCheckTmuxInstalled_Missing(t *testing.T) {
-	// Don't install the mock; PATH points only at empty tempdir.
+	// Don't install the mock; PATH points only at empty tempdir. tmux is needed
+	// only for live teammates, so a missing tmux is a WARN (not a FAIL) and must
+	// not flip doctor's overall OK.
 	t.Setenv("PATH", t.TempDir())
 	r := CheckTmuxInstalled()
-	if r.Status != StatusFail {
-		t.Fatalf("Status = %s, want fail", r.Status)
+	if r.Status != StatusWarn {
+		t.Fatalf("Status = %s, want warn (tmux is optional — live teammates only)", r.Status)
 	}
 	if r.FixHint == "" {
 		t.Fatalf("FixHint empty, want install hint")
@@ -600,3 +624,66 @@ func TestCheckOAuthCredentials_MissingIsOK(t *testing.T) {
 		t.Fatalf("Status = %s, want ok (absence is informational, never a warn)", r.Status)
 	}
 }
+
+// ---------- Check 10: binary ↔ plugin version skew ----------
+
+func TestCheckPluginVersionMatch_DevBuildOK(t *testing.T) {
+	// A dev/non-release binary is not comparable — OK, never a warn, even with a
+	// plugin cached at some version.
+	home := setupHome(t)
+	pinVersion(t, devVersionForTest())
+	writePluginCache(t, home, "0.1.6")
+	r := CheckPluginVersionMatch()
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %s, want ok for a dev build (detail=%s)", r.Status, r.Detail)
+	}
+}
+
+func TestCheckPluginVersionMatch_NoPluginOK(t *testing.T) {
+	setupHome(t)
+	pinVersion(t, "v0.1.6")
+	r := CheckPluginVersionMatch()
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %s, want ok when no plugin is installed (detail=%s)", r.Status, r.Detail)
+	}
+}
+
+func TestCheckPluginVersionMatch_MatchOK(t *testing.T) {
+	home := setupHome(t)
+	pinVersion(t, "v0.1.6")            // binary carries the git tag (leading v)
+	writePluginCache(t, home, "0.1.6") // plugin manifest carries the bare version
+	r := CheckPluginVersionMatch()
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %s, want ok when binary == plugin (detail=%s)", r.Status, r.Detail)
+	}
+}
+
+func TestCheckPluginVersionMatch_SkewWarns(t *testing.T) {
+	home := setupHome(t)
+	pinVersion(t, "v0.1.8")
+	writePluginCache(t, home, "0.1.6")
+	r := CheckPluginVersionMatch()
+	if r.Status != StatusWarn {
+		t.Fatalf("Status = %s, want warn on binary≠plugin skew (detail=%s)", r.Status, r.Detail)
+	}
+	if r.FixHint == "" {
+		t.Fatalf("FixHint empty, want a `ccf update` hint")
+	}
+}
+
+// TestCheckPluginVersionMatch_NewestCachedWins: a stale older cache entry must
+// not WARN against a matching newer one.
+func TestCheckPluginVersionMatch_NewestCachedWins(t *testing.T) {
+	home := setupHome(t)
+	pinVersion(t, "v0.1.8")
+	writePluginCache(t, home, "0.1.6") // stale
+	writePluginCache(t, home, "0.1.8") // current
+	r := CheckPluginVersionMatch()
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %s, want ok (newest cached 0.1.8 matches; detail=%s)", r.Status, r.Detail)
+	}
+}
+
+// devVersionForTest returns a value version.IsRelease treats as a non-release,
+// matching the package's dev default without importing the unexported constant.
+func devVersionForTest() string { return "0.1.0-dev" }

--- a/internal/doctor/run.go
+++ b/internal/doctor/run.go
@@ -25,7 +25,8 @@ import (
 // would commit policy decisions doctor shouldn't make on the user's behalf.
 //
 // Results are returned in check-ID order so JSON consumers can index by
-// position. OK = AND of every result.Status != StatusFail.
+// position. OK is true unless a Core-group check failed; an Optional
+// (live-teammate) failure never flips it.
 func RunAll(fix bool) DoctorResult {
 	checks := []func() CheckResult{
 		CheckSettingsJSON,

--- a/internal/doctor/run.go
+++ b/internal/doctor/run.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 )
 
-// RunAll runs all nine checks and assembles the DoctorResult.
+// RunAll runs every check and assembles the DoctorResult.
 //
 // If fix is true, doctor attempts a conservative auto-repair for the small
 // set of issues it knows how to fix safely:
@@ -37,6 +37,7 @@ func RunAll(fix bool) DoctorResult {
 		CheckSkillInstalled,
 		CheckFingerprint,
 		CheckOAuthCredentials,
+		CheckPluginVersionMatch,
 	}
 
 	results := make([]CheckResult, 0, len(checks))
@@ -57,20 +58,34 @@ func RunAll(fix bool) DoctorResult {
 				}
 			}
 		}
+		r.Group = groupForID(r.ID)
 		results = append(results, r)
 	}
 
 	// Preserve check-ID order even if someone reorders checks above.
 	sort.Slice(results, func(i, j int) bool { return results[i].ID < results[j].ID })
 
+	// OK = no Core check failed. Optional (live-teammate) checks never flip OK,
+	// so a tmux-less machine that only uses subagent/workflow/run is healthy.
 	ok := true
 	for _, r := range results {
-		if r.Status == StatusFail {
+		if r.Group != GroupOptional && r.Status == StatusFail {
 			ok = false
 			break
 		}
 	}
 	return DoctorResult{OK: ok, Results: results}
+}
+
+// groupForID classifies a check. Only tmux-related checks (3 installed, 5
+// attached) are Optional — everything else is Core.
+func groupForID(id int) Group {
+	switch id {
+	case 3, 5:
+		return GroupOptional
+	default:
+		return GroupCore
+	}
 }
 
 // tryFix runs the auto-fix action for a single check, returning true if it

--- a/internal/selfupdate/binary.go
+++ b/internal/selfupdate/binary.go
@@ -119,23 +119,78 @@ func smokeTest(ctx context.Context, staged, tag string) error {
 	return nil
 }
 
-// swapBinary backs the current binary up to <exe>.previous and renames the
-// staged binary into place. On unix a running executable's file can be renamed
-// (the live process keeps its open inode); staged, exe, and the backup share a
-// directory so every rename is atomic and same-filesystem.
+// swapBinary backs the current binary up to <exe>.previous and replaces it with
+// the staged binary. It COPIES exe to the backup (leaving exe in place), then
+// does a single atomic rename of staged over exe — so exe is never momentarily
+// absent and a crash mid-swap leaves either the old or the new binary, never
+// none. On unix a running executable's file can be renamed (the live process
+// keeps its open inode); staged, exe, and the backup share a directory so the
+// rename is atomic and same-filesystem.
 func swapBinary(exe, staged, oldVer, newVer string, out io.Writer) error {
+	// If the on-disk binary already matches staged (a concurrent updater swapped
+	// it in first), there's nothing to do — overwriting .previous now would lose
+	// the genuine old binary the rollback target holds.
+	if same, _ := sameContent(exe, staged); same {
+		_ = os.Remove(staged)
+		fmt.Fprintf(out, "  ✔ binary already at %s\n", newVer)
+		return nil
+	}
 	backup := exe + ".previous"
-	if err := os.Rename(exe, backup); err != nil {
+	if err := copyFile(exe, backup, 0o755); err != nil {
 		_ = os.Remove(staged)
 		return fmt.Errorf("back up current binary: %w", err)
 	}
 	if err := os.Rename(staged, exe); err != nil {
-		_ = os.Rename(backup, exe) // restore
+		_ = os.Remove(staged)
 		return fmt.Errorf("install new binary: %w", err)
 	}
 	fmt.Fprintf(out, "  ✔ binary %s → %s  (%s; previous kept at %s)\n",
 		oldVer, newVer, exe, filepath.Base(backup))
 	return nil
+}
+
+// copyFile copies src to dst (truncating dst) with the given mode.
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// sameContent reports whether two files have identical sha256 digests.
+func sameContent(a, b string) (bool, error) {
+	ha, err := fileSha256(a)
+	if err != nil {
+		return false, err
+	}
+	hb, err := fileSha256(b)
+	if err != nil {
+		return false, err
+	}
+	return ha == hb, nil
+}
+
+func fileSha256(p string) (string, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // Rollback restores the <exe>.previous backup left by the last self-update.

--- a/internal/selfupdate/binary.go
+++ b/internal/selfupdate/binary.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/ethanhq/cc-fleet/internal/fileutil"
 	"github.com/ethanhq/cc-fleet/internal/version"
 )
 
@@ -135,8 +136,17 @@ func swapBinary(exe, staged, oldVer, newVer string, out io.Writer) error {
 		fmt.Fprintf(out, "  ✔ binary already at %s\n", newVer)
 		return nil
 	}
+	// Back the current binary up via the atomic-write primitive (temp + chmod +
+	// rename): it never follows a symlink/hardlink that may sit at the backup
+	// path, so it can't truncate the live binary, and exe stays in place until
+	// the single atomic rename below.
 	backup := exe + ".previous"
-	if err := copyFile(exe, backup, 0o755); err != nil {
+	cur, err := os.ReadFile(exe)
+	if err != nil {
+		_ = os.Remove(staged)
+		return fmt.Errorf("read current binary: %w", err)
+	}
+	if err := fileutil.AtomicWrite(backup, cur, 0o755); err != nil {
 		_ = os.Remove(staged)
 		return fmt.Errorf("back up current binary: %w", err)
 	}
@@ -147,24 +157,6 @@ func swapBinary(exe, staged, oldVer, newVer string, out io.Writer) error {
 	fmt.Fprintf(out, "  ✔ binary %s → %s  (%s; previous kept at %s)\n",
 		oldVer, newVer, exe, filepath.Base(backup))
 	return nil
-}
-
-// copyFile copies src to dst (truncating dst) with the given mode.
-func copyFile(src, dst string, mode os.FileMode) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
-		return err
-	}
-	return out.Close()
 }
 
 // sameContent reports whether two files have identical sha256 digests.

--- a/internal/selfupdate/binary.go
+++ b/internal/selfupdate/binary.go
@@ -1,0 +1,187 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ethanhq/cc-fleet/internal/version"
+)
+
+// prepareTarballBinary downloads the release tarball + checksums for this
+// os/arch, verifies sha256 (fail-closed), extracts the cc-fleet binary into a
+// temp file in the binary's own directory (same filesystem → atomic rename),
+// and smoke-tests it. It installs nothing; it returns the staged temp path for
+// swapBinary to commit. Any failure removes the staged file and leaves the live
+// binary untouched.
+func prepareTarballBinary(ctx context.Context, exe, tag string, out io.Writer) (string, error) {
+	dir := filepath.Dir(exe)
+	if !dirWritable(dir) {
+		return "", fmt.Errorf("%s is not writable — reinstall with elevated permissions or from a writable prefix", dir)
+	}
+
+	osArch := runtime.GOOS + "-" + runtime.GOARCH
+	tarName := fmt.Sprintf("cc-fleet-%s.tar.gz", osArch)
+	base := assetBase(tag)
+
+	fmt.Fprintf(out, "  ↓ %s\n", tarName)
+	tarBytes, err := download(ctx, base+"/"+tarName)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", tarName, err)
+	}
+	sumsBytes, err := download(ctx, base+"/checksums.txt")
+	if err != nil {
+		return "", fmt.Errorf("download checksums.txt: %w", err)
+	}
+	expected := checksumFor(string(sumsBytes), tarName)
+	if expected == "" {
+		return "", fmt.Errorf("no checksum for %s in checksums.txt", tarName)
+	}
+	actual := sha256Hex(tarBytes)
+	if actual != expected {
+		return "", fmt.Errorf("checksum mismatch for %s", tarName)
+	}
+	fmt.Fprintln(out, "  ✔ sha256 verified")
+
+	tmp, err := os.CreateTemp(dir, ".cc-fleet-update-*")
+	if err != nil {
+		return "", fmt.Errorf("stage new binary: %w", err)
+	}
+	staged := tmp.Name()
+	if err := extractBinaryTo(tarBytes, tmp); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(staged)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(staged)
+		return "", err
+	}
+	if err := os.Chmod(staged, 0o755); err != nil {
+		_ = os.Remove(staged)
+		return "", err
+	}
+	if err := smokeTest(ctx, staged, tag); err != nil {
+		_ = os.Remove(staged)
+		return "", err
+	}
+	fmt.Fprintln(out, "  ✔ smoke test passed")
+	return staged, nil
+}
+
+// extractBinaryTo writes the `cc-fleet` regular-file entry from the gzip tar to
+// w. The goreleaser archive wraps contents in cc-fleet-<os>-<arch>/, so the
+// binary is matched by basename.
+func extractBinaryTo(tarGz []byte, w io.Writer) error {
+	gz, err := gzip.NewReader(bytes.NewReader(tarGz))
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("cc-fleet binary not found in tarball")
+		}
+		if err != nil {
+			return fmt.Errorf("tar: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeReg && filepath.Base(hdr.Name) == "cc-fleet" {
+			if _, err := io.Copy(w, io.LimitReader(tr, maxAsset)); err != nil {
+				return fmt.Errorf("extract cc-fleet: %w", err)
+			}
+			return nil
+		}
+	}
+}
+
+// smokeTest runs `<staged> --version` and confirms it reports the expected tag,
+// so a corrupt or wrong-arch binary is caught before it replaces the live one.
+func smokeTest(ctx context.Context, staged, tag string) error {
+	out, err := exec.CommandContext(ctx, staged, "--version").Output()
+	if err != nil {
+		return fmt.Errorf("smoke test: %w", err)
+	}
+	if !strings.Contains(string(out), version.Normalize(tag)) {
+		return fmt.Errorf("smoke test: new binary reported %q, expected %s", strings.TrimSpace(string(out)), tag)
+	}
+	return nil
+}
+
+// swapBinary backs the current binary up to <exe>.previous and renames the
+// staged binary into place. On unix a running executable's file can be renamed
+// (the live process keeps its open inode); staged, exe, and the backup share a
+// directory so every rename is atomic and same-filesystem.
+func swapBinary(exe, staged, oldVer, newVer string, out io.Writer) error {
+	backup := exe + ".previous"
+	if err := os.Rename(exe, backup); err != nil {
+		_ = os.Remove(staged)
+		return fmt.Errorf("back up current binary: %w", err)
+	}
+	if err := os.Rename(staged, exe); err != nil {
+		_ = os.Rename(backup, exe) // restore
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	fmt.Fprintf(out, "  ✔ binary %s → %s  (%s; previous kept at %s)\n",
+		oldVer, newVer, exe, filepath.Base(backup))
+	return nil
+}
+
+// Rollback restores the <exe>.previous backup left by the last self-update.
+func Rollback(out io.Writer) error {
+	if out == nil {
+		out = os.Stdout
+	}
+	exe, err := exePath()
+	if err != nil {
+		return err
+	}
+	backup := exe + ".previous"
+	if _, err := os.Stat(backup); err != nil {
+		return fmt.Errorf("no previous binary to roll back to (%s)", backup)
+	}
+	if err := os.Rename(backup, exe); err != nil {
+		return fmt.Errorf("restore previous binary: %w", err)
+	}
+	fmt.Fprintf(out, "rolled back to the previous binary (%s)\n", exe)
+	return nil
+}
+
+// dirWritable reports whether a file can be created in dir.
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".cc-fleet-writetest-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
+}
+
+// checksumFor returns the hex sha256 for name from a `<sum>  <name>` listing.
+func checksumFor(sums, name string) string {
+	for _, line := range strings.Split(sums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == name {
+			return fields[0]
+		}
+	}
+	return ""
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/selfupdate/cache.go
+++ b/internal/selfupdate/cache.go
@@ -1,0 +1,142 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/fileutil"
+	"github.com/ethanhq/cc-fleet/internal/version"
+)
+
+// checkInterval bounds both how often the background refresh re-queries GitHub
+// and how long a dismissal suppresses the startup prompt.
+const checkInterval = 24 * time.Hour
+
+// OptOutEnv disables the startup update check entirely when set non-empty.
+const OptOutEnv = "CC_FLEET_NO_UPDATE_CHECK"
+
+// checkCache is the on-disk state behind the startup prompt. It is driven purely
+// from this cache (no network on the launch path); a background refresh keeps it
+// current for the next launch.
+type checkCache struct {
+	LastChecked  int64  `json:"last_checked"` // unix seconds of the last GitHub query
+	LatestTag    string `json:"latest_tag"`
+	DismissedTag string `json:"dismissed_tag,omitempty"`
+	DismissedAt  int64  `json:"dismissed_at,omitempty"`
+}
+
+func cachePath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "update-check.json"), nil
+}
+
+func cacheLockPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".cc-fleet-update-cache.lock"), nil
+}
+
+func loadCache() checkCache {
+	var c checkCache
+	p, err := cachePath()
+	if err != nil {
+		return c
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return c
+	}
+	_ = json.Unmarshal(data, &c) // a corrupt cache is treated as empty
+	return c
+}
+
+func saveCache(c checkCache) error {
+	p, err := cachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return fileutil.AtomicWrite(p, data, 0o600)
+}
+
+func withCacheLock(fn func() error) error {
+	p, err := cacheLockPath()
+	if err != nil {
+		return err
+	}
+	return config.WithFlock(p, fn)
+}
+
+// OptedOut reports whether the startup update check is disabled by env.
+func OptedOut() bool { return os.Getenv(OptOutEnv) != "" }
+
+// PromptTag returns a newer release tag to prompt about (ok=true) when the
+// cache holds a comparable release newer than the running binary that has not
+// been dismissed within checkInterval. It is a pure cache read — no network —
+// and returns false for a dev/non-release build or when opted out.
+func PromptTag(now time.Time) (string, bool) {
+	if OptedOut() {
+		return "", false
+	}
+	cur := version.Resolve()
+	if !version.IsRelease(cur) {
+		return "", false
+	}
+	c := loadCache()
+	if c.LatestTag == "" || !version.Newer(c.LatestTag, cur) {
+		return "", false
+	}
+	if c.DismissedTag == c.LatestTag && now.Unix()-c.DismissedAt < int64(checkInterval/time.Second) {
+		return "", false
+	}
+	return c.LatestTag, true
+}
+
+// Dismiss records that the user was prompted about tag and declined, so the
+// prompt stays quiet for checkInterval. Locked read-merge-write.
+func Dismiss(tag string, now time.Time) error {
+	return withCacheLock(func() error {
+		c := loadCache()
+		c.DismissedTag = tag
+		c.DismissedAt = now.Unix()
+		return saveCache(c)
+	})
+}
+
+// RefreshCache re-queries GitHub for the latest tag when the cache is older than
+// checkInterval and records it (locked). Meant to run in a background goroutine
+// so the launch never blocks on the network; an offline/transient failure
+// leaves the cache untouched (no prompt, no error).
+func RefreshCache(ctx context.Context, now time.Time) {
+	if OptedOut() {
+		return
+	}
+	if c := loadCache(); c.LastChecked != 0 && now.Unix()-c.LastChecked < int64(checkInterval/time.Second) {
+		return // still fresh
+	}
+	tag, err := LatestTag(ctx)
+	if err != nil {
+		return
+	}
+	_ = withCacheLock(func() error {
+		c := loadCache() // re-read under the lock to preserve a concurrent dismissal
+		c.LastChecked = now.Unix()
+		c.LatestTag = tag
+		return saveCache(c)
+	})
+}

--- a/internal/selfupdate/plugin.go
+++ b/internal/selfupdate/plugin.go
@@ -1,0 +1,88 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// updatePlugin brings the Claude Code plugin to the latest version, preserving
+// the install scope. If `claude` is not on PATH the plugin step is skipped (not
+// an error — the binary still updates). An installed plugin is refreshed via
+// `marketplace update` + `plugin update`, falling back to a same-scope
+// uninstall + reinstall; an absent plugin is installed.
+func updatePlugin(ctx context.Context, scope string, out io.Writer) error {
+	claude, err := exec.LookPath("claude")
+	if err != nil {
+		fmt.Fprintln(out, "  claude not on PATH — skipping the plugin update")
+		return nil
+	}
+	if scope == "" {
+		scope = "user"
+	}
+
+	if pluginInstalled() {
+		fmt.Fprintln(out, "  ↻ updating plugin "+pluginRef)
+		if err := runCmd(ctx, out, claude, "plugin", "marketplace", "update", marketplace); err != nil {
+			return fmt.Errorf("claude plugin marketplace update: %w", err)
+		}
+		if err := runCmd(ctx, out, claude, "plugin", "update", pluginRef); err == nil {
+			return nil
+		}
+		// Fall back to a clean reinstall in the same scope.
+		fmt.Fprintln(out, "  plugin update failed — reinstalling")
+		_ = runCmd(ctx, out, claude, "plugin", "uninstall", pluginRef)
+		return runCmd(ctx, out, claude, "plugin", "install", pluginRef, "--scope", scope)
+	}
+
+	fmt.Fprintln(out, "  ↓ installing plugin "+pluginRef)
+	if err := runCmd(ctx, out, claude, "plugin", "marketplace", "add", repo, "--scope", scope); err != nil {
+		return fmt.Errorf("claude plugin marketplace add: %w", err)
+	}
+	return runCmd(ctx, out, claude, "plugin", "install", pluginRef, "--scope", scope)
+}
+
+// pluginInstalled reports whether Claude Code has the cc-fleet plugin cached
+// (~/.claude/plugins/cache/<marketplace>/cc-fleet/<version>/). Offline + cheap.
+func pluginInstalled() bool {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+	matches, _ := filepath.Glob(filepath.Join(home, ".claude", "plugins", "cache", "*", "cc-fleet", "*"))
+	return len(matches) > 0
+}
+
+// updateViaPkgManager runs an installer-managed binary update (npm / go). The
+// binary lives in a package-manager-owned tree, so self-replacing it would
+// desync the manager — the manager must do the update. If the tool is missing,
+// print the command instead of failing the whole update.
+func updateViaPkgManager(ctx context.Context, out io.Writer, name string, args ...string) error {
+	cmdline := name + " " + strings.Join(args, " ")
+	if _, err := exec.LookPath(name); err != nil {
+		fmt.Fprintf(out, "  %s not on PATH — update manually:\n    %s\n", name, cmdline)
+		return nil
+	}
+	fmt.Fprintf(out, "  ↻ %s\n", cmdline)
+	if err := runCmd(ctx, out, name, args...); err != nil {
+		if name == "npm" {
+			fmt.Fprintf(out, "  npm failed — if it is a permissions error, try:\n    sudo %s\n", cmdline)
+		}
+		return fmt.Errorf("%s update: %w", name, err)
+	}
+	return nil
+}
+
+// runCmd runs an external admin tool (claude / npm / go), streaming its output.
+// It inherits the user's environment — childenv.Clean is for vendor-worker
+// children only, not for trusted local tooling.
+func runCmd(ctx context.Context, out io.Writer, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return cmd.Run()
+}

--- a/internal/selfupdate/plugin.go
+++ b/internal/selfupdate/plugin.go
@@ -11,18 +11,21 @@ import (
 )
 
 // updatePlugin brings the Claude Code plugin to the latest version, preserving
-// the install scope. If `claude` is not on PATH the plugin step is skipped (not
-// an error — the binary still updates). An installed plugin is refreshed via
-// `marketplace update` + `plugin update`, falling back to a same-scope
-// uninstall + reinstall; an absent plugin is installed.
-func updatePlugin(ctx context.Context, scope string, out io.Writer) error {
+// the install scope. A user who installed with --skill none or global declined
+// the plugin, so it is left alone. If `claude` is not on PATH the plugin step is
+// skipped (not an error — the binary still updates). An installed plugin is
+// refreshed via `marketplace update` + `plugin update`; the fallback
+// uninstall + reinstall runs ONLY when the scope is known, so an unknown-scope
+// install is never silently moved to user scope. An absent plugin is installed.
+func updatePlugin(ctx context.Context, scope, skill string, out io.Writer) error {
+	if skill == "none" || skill == "global" {
+		fmt.Fprintf(out, "  skill installed via --skill %s — leaving the plugin alone\n", skill)
+		return nil
+	}
 	claude, err := exec.LookPath("claude")
 	if err != nil {
 		fmt.Fprintln(out, "  claude not on PATH — skipping the plugin update")
 		return nil
-	}
-	if scope == "" {
-		scope = "user"
 	}
 
 	if pluginInstalled() {
@@ -33,12 +36,17 @@ func updatePlugin(ctx context.Context, scope string, out io.Writer) error {
 		if err := runCmd(ctx, out, claude, "plugin", "update", pluginRef); err == nil {
 			return nil
 		}
-		// Fall back to a clean reinstall in the same scope.
-		fmt.Fprintln(out, "  plugin update failed — reinstalling")
+		if scope == "" {
+			return fmt.Errorf("plugin update failed and the install scope is unknown — reinstall manually: claude plugin install %s --scope <user|project|local>", pluginRef)
+		}
+		fmt.Fprintln(out, "  plugin update failed — reinstalling in the "+scope+" scope")
 		_ = runCmd(ctx, out, claude, "plugin", "uninstall", pluginRef)
 		return runCmd(ctx, out, claude, "plugin", "install", pluginRef, "--scope", scope)
 	}
 
+	if scope == "" {
+		scope = "user"
+	}
 	fmt.Fprintln(out, "  ↓ installing plugin "+pluginRef)
 	if err := runCmd(ctx, out, claude, "plugin", "marketplace", "add", repo, "--scope", scope); err != nil {
 		return fmt.Errorf("claude plugin marketplace add: %w", err)

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -59,12 +59,13 @@ type Status struct {
 	NewerAvailable bool   // Comparable && Latest is newer than Current
 }
 
-// manifest is the co-located install record (next to the binary).
+// manifest is the co-located install record (next to the binary) install.sh /
+// npm write so update knows the install method, the plugin scope to preserve,
+// and the skill choice (so a --skill none/global user isn't force-fed a plugin).
 type manifest struct {
 	Method      string `json:"method"`
-	Prefix      string `json:"prefix,omitempty"`
 	PluginScope string `json:"plugin_scope,omitempty"`
-	Marketplace string `json:"marketplace,omitempty"`
+	Skill       string `json:"skill,omitempty"` // plugin | global | none
 }
 
 // Options tunes Run.
@@ -226,7 +227,18 @@ func runLocked(ctx context.Context, opts Options, out io.Writer) error {
 	//    tarball install this downloads + verifies + smoke-tests into a staged
 	//    temp file; commitBinary then renames it in. For npm/go there is no
 	//    dry-run, so commitBinary runs the package manager.
-	var commitBinary func() error
+	var (
+		commitBinary func() error
+		stagedPath   string
+		committed    bool
+	)
+	// Remove a staged-but-uncommitted binary on any early return after staging
+	// (e.g. the plugin step fails and we abort before the swap).
+	defer func() {
+		if stagedPath != "" && !committed {
+			_ = os.Remove(stagedPath)
+		}
+	}()
 	switch {
 	case !st.NewerAvailable:
 		fmt.Fprintf(out, "Binary already at the latest (%s).\n", st.Current)
@@ -235,6 +247,7 @@ func runLocked(ctx context.Context, opts Options, out io.Writer) error {
 		if perr != nil {
 			return perr
 		}
+		stagedPath = staged
 		commitBinary = func() error { return swapBinary(exe, staged, st.Current, st.Latest, out) }
 	case method == MethodNpm:
 		commitBinary = func() error { return updateViaPkgManager(ctx, out, "npm", "install", "-g", "@ethanhq/cc-fleet@latest") }
@@ -248,7 +261,7 @@ func runLocked(ctx context.Context, opts Options, out io.Writer) error {
 
 	// 2. Plugin update (independent of the binary; runs before the binary swap).
 	if !opts.BinaryOnly {
-		if perr := updatePlugin(ctx, man.PluginScope, out); perr != nil {
+		if perr := updatePlugin(ctx, man.PluginScope, man.Skill, out); perr != nil {
 			if commitBinary != nil {
 				return fmt.Errorf("plugin update failed; binary left unchanged to avoid a version skew (rerun with --binary-only to update the binary anyway): %w", perr)
 			}
@@ -261,6 +274,7 @@ func runLocked(ctx context.Context, opts Options, out io.Writer) error {
 		if cerr := commitBinary(); cerr != nil {
 			return cerr
 		}
+		committed = true
 	}
 	return nil
 }

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,301 @@
+// Package selfupdate updates the cc-fleet binary and its Claude Code plugin to
+// the latest GitHub release. It is method-aware: a tarball install self-updates
+// in-process (download the prebuilt release, verify sha256, smoke-test, then
+// atomically replace the running binary), while an npm or `go install` install
+// shells out to the right package manager — falling back to printing the exact
+// command only when the tool is missing or the install location is not writable.
+//
+// Only a comparable release version (version.IsRelease) is ever acted on: a dev
+// or VCS-pseudo build is reported as "not comparable" and never updated.
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/version"
+)
+
+const (
+	repo        = "ethanhq/cc-fleet"
+	marketplace = "ethanhq"
+	pluginRef   = "cc-fleet@ethanhq"
+	// manifestName is the co-located install record install.sh / npm write so
+	// update detects the install method without fragile path heuristics.
+	manifestName = ".cc-fleet-install.json"
+	// maxAsset bounds a downloaded asset so a hostile/oversized response can't
+	// exhaust memory (the binary tarball is ~10-15 MB).
+	maxAsset = 128 << 20
+)
+
+// githubBase is the GitHub origin; a package var so tests can point it at a
+// local httptest server.
+var githubBase = "https://github.com"
+
+// Method is how cc-fleet was installed, which decides how to update the binary.
+type Method string
+
+const (
+	MethodTarball Method = "tarball" // curl|sh / release tarball → in-Go self-update
+	MethodNpm     Method = "npm"     // npm -g → `npm install -g`
+	MethodGo      Method = "go"      // go install → `go install ...@latest`
+	MethodUnknown Method = "unknown"
+)
+
+// Status compares the running binary to the latest release.
+type Status struct {
+	Current        string // version.Resolve()
+	Latest         string // latest release tag, "" if unknown
+	Comparable     bool   // Current is a release version (not dev/pseudo)
+	NewerAvailable bool   // Comparable && Latest is newer than Current
+}
+
+// manifest is the co-located install record (next to the binary).
+type manifest struct {
+	Method      string `json:"method"`
+	Prefix      string `json:"prefix,omitempty"`
+	PluginScope string `json:"plugin_scope,omitempty"`
+	Marketplace string `json:"marketplace,omitempty"`
+}
+
+// Options tunes Run.
+type Options struct {
+	BinaryOnly bool      // skip the plugin update
+	Force      bool      // self-update even when the install method is unknown
+	Out        io.Writer // progress sink (defaults to os.Stdout)
+}
+
+// Check resolves the current version and the latest release tag and compares
+// them. A transport error is returned with Status.Current/Comparable still set
+// so callers can distinguish "offline" from "dev build".
+func Check(ctx context.Context) (Status, error) {
+	cur := version.Resolve()
+	st := Status{Current: cur, Comparable: version.IsRelease(cur)}
+	latest, err := LatestTag(ctx)
+	if err != nil {
+		return st, err
+	}
+	st.Latest = latest
+	st.NewerAvailable = st.Comparable && version.Newer(latest, cur)
+	return st, nil
+}
+
+// LatestTag returns the latest release tag (e.g. "v0.1.8") by reading the
+// /releases/latest redirect — no API token, no JSON, no rate-limit-prone API.
+// A repo with no releases redirects to /releases (no tag) and yields an error.
+func LatestTag(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("%s/%s/releases/latest", githubBase, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "cc-fleet")
+	// Stop at the redirect so we can read its Location instead of following it.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return "", fmt.Errorf("no redirect from %s (HTTP %d)", url, resp.StatusCode)
+	}
+	tag := path.Base(loc)
+	if !version.IsRelease(tag) {
+		return "", fmt.Errorf("no release found (latest resolved to %q)", tag)
+	}
+	return tag, nil
+}
+
+// osExecutable is os.Executable, indirected so tests can point the update flow
+// at a fake binary instead of the test runner.
+var osExecutable = os.Executable
+
+// exePath returns the running binary's real path with symlinks resolved (the
+// `ccf` alias is a relative symlink to cc-fleet).
+func exePath() (string, error) {
+	p, err := osExecutable()
+	if err != nil {
+		return "", err
+	}
+	if resolved, rerr := filepath.EvalSymlinks(p); rerr == nil {
+		p = resolved
+	}
+	return p, nil
+}
+
+// detectMethod reads the co-located install manifest, falling back to a path
+// heuristic. Returns the manifest too so the plugin scope is preserved.
+func detectMethod(exe string) (Method, manifest) {
+	dir := filepath.Dir(exe)
+	if data, err := os.ReadFile(filepath.Join(dir, manifestName)); err == nil {
+		var m manifest
+		if json.Unmarshal(data, &m) == nil && m.Method != "" {
+			return Method(m.Method), m
+		}
+	}
+	// No manifest (older install / go install has no postinstall hook): guess.
+	if strings.Contains(exe, string(filepath.Separator)+"node_modules"+string(filepath.Separator)) {
+		return MethodNpm, manifest{}
+	}
+	for _, c := range goBinDirs() {
+		if c != "" && dir == filepath.Clean(c) {
+			return MethodGo, manifest{}
+		}
+	}
+	return MethodUnknown, manifest{}
+}
+
+// goBinDirs lists the directories `go install` would target.
+func goBinDirs() []string {
+	var dirs []string
+	if v := os.Getenv("GOBIN"); v != "" {
+		dirs = append(dirs, v)
+	}
+	if v := os.Getenv("GOPATH"); v != "" {
+		dirs = append(dirs, filepath.Join(v, "bin"))
+	}
+	if h := os.Getenv("HOME"); h != "" {
+		dirs = append(dirs, filepath.Join(h, "go", "bin"))
+	}
+	return dirs
+}
+
+// updateLockPath is a single global lock under ConfigDir that serializes
+// concurrent `ccf update` runs (a user has one install; cross-install
+// serialization is harmless and ConfigDir is always writable, unlike a
+// system bin dir).
+func updateLockPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".cc-fleet-update.lock"), nil
+}
+
+// Run updates the binary and (unless BinaryOnly) the plugin, serialized by the
+// update lock. Order is prepare-binary → update-plugin → commit-binary so a
+// plugin failure never leaves binary and plugin at different versions.
+func Run(ctx context.Context, opts Options) error {
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	if runtime.GOOS == "windows" {
+		fmt.Fprintln(out, "cc-fleet self-update is not supported on Windows — reinstall the latest release manually.")
+		return nil
+	}
+	lockPath, err := updateLockPath()
+	if err != nil {
+		return err
+	}
+	return config.WithFlock(lockPath, func() error { return runLocked(ctx, opts, out) })
+}
+
+func runLocked(ctx context.Context, opts Options, out io.Writer) error {
+	exe, err := exePath()
+	if err != nil {
+		return err
+	}
+	// A dev/non-release build can't self-update — short-circuit before any
+	// network so an offline dev build still gets a clean notice.
+	if cur := version.Resolve(); !version.IsRelease(cur) {
+		fmt.Fprintf(out, "Development build (%s) — not a release; reinstall to update.\n", cur)
+		return nil
+	}
+	st, err := Check(ctx)
+	if err != nil {
+		return fmt.Errorf("check for updates: %w", err)
+	}
+
+	method, man := detectMethod(exe)
+
+	// 1. Prepare the binary update (no irreversible side effect yet). For a
+	//    tarball install this downloads + verifies + smoke-tests into a staged
+	//    temp file; commitBinary then renames it in. For npm/go there is no
+	//    dry-run, so commitBinary runs the package manager.
+	var commitBinary func() error
+	switch {
+	case !st.NewerAvailable:
+		fmt.Fprintf(out, "Binary already at the latest (%s).\n", st.Current)
+	case method == MethodTarball || (method == MethodUnknown && opts.Force):
+		staged, perr := prepareTarballBinary(ctx, exe, st.Latest, out)
+		if perr != nil {
+			return perr
+		}
+		commitBinary = func() error { return swapBinary(exe, staged, st.Current, st.Latest, out) }
+	case method == MethodNpm:
+		commitBinary = func() error { return updateViaPkgManager(ctx, out, "npm", "install", "-g", "@ethanhq/cc-fleet@latest") }
+	case method == MethodGo:
+		commitBinary = func() error {
+			return updateViaPkgManager(ctx, out, "go", "install", "github.com/ethanhq/cc-fleet/cmd/cc-fleet@latest")
+		}
+	default: // unknown method, not forced
+		fmt.Fprintf(out, "cc-fleet %s is available, but the install method is unknown — reinstall, or rerun `ccf update --force` to self-update in place.\n", st.Latest)
+	}
+
+	// 2. Plugin update (independent of the binary; runs before the binary swap).
+	if !opts.BinaryOnly {
+		if perr := updatePlugin(ctx, man.PluginScope, out); perr != nil {
+			if commitBinary != nil {
+				return fmt.Errorf("plugin update failed; binary left unchanged to avoid a version skew (rerun with --binary-only to update the binary anyway): %w", perr)
+			}
+			return perr
+		}
+	}
+
+	// 3. Commit the binary last.
+	if commitBinary != nil {
+		if cerr := commitBinary(); cerr != nil {
+			return cerr
+		}
+	}
+	return nil
+}
+
+// download GETs url (following redirects to the asset CDN) and returns the body,
+// failing explicitly if it exceeds maxAsset rather than silently truncating.
+func download(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "cc-fleet")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAsset+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxAsset {
+		return nil, fmt.Errorf("GET %s: response exceeds %d bytes", url, maxAsset)
+	}
+	return data, nil
+}
+
+// assetBase is the release-download base for a tag (CCF_BASE_URL overrides it
+// for a mirror or a local test, matching install.sh / npm).
+func assetBase(tag string) string {
+	if b := os.Getenv("CCF_BASE_URL"); b != "" {
+		return b
+	}
+	return fmt.Sprintf("%s/%s/releases/download/%s", githubBase, repo, tag)
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,306 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/version"
+)
+
+// --- LatestTag ---------------------------------------------------------------
+
+func TestLatestTag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/"+repo+"/releases/latest" {
+			w.Header().Set("Location", "/"+repo+"/releases/tag/v9.9.9")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	withGitHubBase(t, srv.URL)
+
+	tag, err := LatestTag(context.Background())
+	if err != nil {
+		t.Fatalf("LatestTag: %v", err)
+	}
+	if tag != "v9.9.9" {
+		t.Fatalf("tag = %q, want v9.9.9", tag)
+	}
+}
+
+func TestLatestTag_NoReleases(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A repo with no releases redirects /releases/latest to /releases.
+		w.Header().Set("Location", "/"+repo+"/releases")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+	withGitHubBase(t, srv.URL)
+
+	if _, err := LatestTag(context.Background()); err == nil {
+		t.Fatalf("LatestTag: want error when no release tag, got nil")
+	}
+}
+
+// --- detectMethod ------------------------------------------------------------
+
+func TestDetectMethod_Manifest(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "cc-fleet")
+	writeManifest(t, dir, `{"method":"tarball","plugin_scope":"project"}`)
+	m, man := detectMethod(exe)
+	if m != MethodTarball {
+		t.Fatalf("method = %q, want tarball", m)
+	}
+	if man.PluginScope != "project" {
+		t.Fatalf("plugin_scope = %q, want project", man.PluginScope)
+	}
+}
+
+func TestDetectMethod_NpmManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{"method":"npm"}`)
+	if m, _ := detectMethod(filepath.Join(dir, "cc-fleet")); m != MethodNpm {
+		t.Fatalf("method = %q, want npm", m)
+	}
+}
+
+func TestDetectMethod_NpmHeuristic(t *testing.T) {
+	// No manifest; a node_modules path falls back to the npm heuristic.
+	exe := filepath.Join(t.TempDir(), "node_modules", "@ethanhq", "cc-fleet", "bin", "cc-fleet")
+	if m, _ := detectMethod(exe); m != MethodNpm {
+		t.Fatalf("method = %q, want npm (node_modules heuristic)", m)
+	}
+}
+
+func TestDetectMethod_GoHeuristic(t *testing.T) {
+	gobin := t.TempDir()
+	t.Setenv("GOBIN", gobin)
+	if m, _ := detectMethod(filepath.Join(gobin, "cc-fleet")); m != MethodGo {
+		t.Fatalf("method = %q, want go (GOBIN heuristic)", m)
+	}
+}
+
+func TestDetectMethod_Unknown(t *testing.T) {
+	t.Setenv("GOBIN", "")
+	t.Setenv("GOPATH", "")
+	t.Setenv("HOME", t.TempDir())
+	if m, _ := detectMethod(filepath.Join(t.TempDir(), "cc-fleet")); m != MethodUnknown {
+		t.Fatalf("method = %q, want unknown", m)
+	}
+}
+
+// --- checksumFor -------------------------------------------------------------
+
+func TestChecksumFor(t *testing.T) {
+	sums := "abc123  cc-fleet-linux-amd64.tar.gz\ndef456  cc-fleet-darwin-arm64.tar.gz\n"
+	if got := checksumFor(sums, "cc-fleet-darwin-arm64.tar.gz"); got != "def456" {
+		t.Fatalf("checksumFor = %q, want def456", got)
+	}
+	if got := checksumFor(sums, "missing.tar.gz"); got != "" {
+		t.Fatalf("checksumFor(missing) = %q, want empty", got)
+	}
+}
+
+// --- smokeTest ---------------------------------------------------------------
+
+func TestSmokeTest(t *testing.T) {
+	bin := writeScript(t, t.TempDir(), "cc-fleet", `echo "cc-fleet version v9.9.9"`)
+	if err := smokeTest(context.Background(), bin, "v9.9.9"); err != nil {
+		t.Fatalf("smokeTest: %v", err)
+	}
+	// Wrong reported version → fail.
+	bad := writeScript(t, t.TempDir(), "cc-fleet", `echo "cc-fleet version v0.0.1"`)
+	if err := smokeTest(context.Background(), bad, "v9.9.9"); err == nil {
+		t.Fatalf("smokeTest: want error on version mismatch")
+	}
+}
+
+// --- swapBinary + Rollback ---------------------------------------------------
+
+func TestSwapBinaryAndRollback(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "cc-fleet")
+	if err := os.WriteFile(exe, []byte("OLD"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staged := filepath.Join(dir, ".cc-fleet-update-staged")
+	if err := os.WriteFile(staged, []byte("NEW"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := swapBinary(exe, staged, "v0.1.0", "v9.9.9", &bytes.Buffer{}); err != nil {
+		t.Fatalf("swapBinary: %v", err)
+	}
+	if b, _ := os.ReadFile(exe); string(b) != "NEW" {
+		t.Fatalf("after swap exe = %q, want NEW", b)
+	}
+	if b, _ := os.ReadFile(exe + ".previous"); string(b) != "OLD" {
+		t.Fatalf(".previous = %q, want OLD", b)
+	}
+	// Rollback restores OLD.
+	withExe(t, exe)
+	if err := Rollback(&bytes.Buffer{}); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if b, _ := os.ReadFile(exe); string(b) != "OLD" {
+		t.Fatalf("after rollback exe = %q, want OLD", b)
+	}
+}
+
+func TestRollback_NoBackup(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "cc-fleet")
+	_ = os.WriteFile(exe, []byte("X"), 0o755)
+	withExe(t, exe)
+	if err := Rollback(&bytes.Buffer{}); err == nil {
+		t.Fatalf("Rollback: want error when no .previous backup")
+	}
+}
+
+// --- Run (end-to-end tarball self-update) ------------------------------------
+
+func TestRun_TarballEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	withVersion(t, "v0.1.0")
+
+	bindir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(bindir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := writeScript(t, bindir, "cc-fleet", `echo "cc-fleet version v0.1.0"`)
+	writeManifest(t, bindir, `{"method":"tarball"}`)
+	withExe(t, exe)
+
+	// Serve a release whose binary prints v9.9.9.
+	tarName := fmt.Sprintf("cc-fleet-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	tarGz := buildReleaseTarGz(t, "#!/bin/sh\necho \"cc-fleet version v9.9.9\"\n")
+	sums := fmt.Sprintf("%s  %s\n", sha256Hex(tarGz), tarName)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+repo+"/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/"+repo+"/releases/tag/v9.9.9")
+		w.WriteHeader(http.StatusFound)
+	})
+	mux.HandleFunc("/"+repo+"/releases/download/v9.9.9/"+tarName, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tarGz)
+	})
+	mux.HandleFunc("/"+repo+"/releases/download/v9.9.9/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(sums))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	withGitHubBase(t, srv.URL)
+
+	var out bytes.Buffer
+	// BinaryOnly: skip the plugin step (no real `claude` in the test env).
+	if err := Run(context.Background(), Options{BinaryOnly: true, Out: &out}); err != nil {
+		t.Fatalf("Run: %v\n%s", err, out.String())
+	}
+	got, _ := os.ReadFile(exe)
+	if !bytes.Contains(got, []byte("v9.9.9")) {
+		t.Fatalf("after update exe is not the new binary:\n%s", got)
+	}
+	if _, err := os.Stat(exe + ".previous"); err != nil {
+		t.Fatalf(".previous backup missing: %v", err)
+	}
+}
+
+func TestRun_DevBuildIsNoOp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	withVersion(t, "0.1.0-dev") // non-release → not comparable
+
+	bindir := filepath.Join(home, "bin")
+	_ = os.MkdirAll(bindir, 0o755)
+	exe := writeScript(t, bindir, "cc-fleet", `echo "cc-fleet version 0.1.0-dev"`)
+	withExe(t, exe)
+	// Reaching the network would be a bug; serve nothing reachable.
+	withGitHubBase(t, "http://127.0.0.1:0")
+
+	var out bytes.Buffer
+	if err := Run(context.Background(), Options{BinaryOnly: true, Out: &out}); err != nil {
+		t.Fatalf("Run dev build: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Development build")) {
+		t.Fatalf("dev build output = %q, want a 'Development build' notice", out.String())
+	}
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func withGitHubBase(t *testing.T, base string) {
+	t.Helper()
+	orig := githubBase
+	t.Cleanup(func() { githubBase = orig })
+	githubBase = base
+}
+
+func withExe(t *testing.T, path string) {
+	t.Helper()
+	orig := osExecutable
+	t.Cleanup(func() { osExecutable = orig })
+	osExecutable = func() (string, error) { return path, nil }
+}
+
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = v
+}
+
+func writeManifest(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, manifestName), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func buildReleaseTarGz(t *testing.T, script string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	body := []byte(script)
+	hdr := &tar.Header{
+		Name:     fmt.Sprintf("cc-fleet-%s-%s/cc-fleet", runtime.GOOS, runtime.GOARCH),
+		Mode:     0o755,
+		Size:     int64(len(body)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -159,6 +159,35 @@ func TestSwapBinaryAndRollback(t *testing.T) {
 	}
 }
 
+// TestSwapBinary_AlreadyEqualSkips: when the on-disk binary already matches the
+// staged one (a concurrent updater swapped it in first), swapBinary is a no-op
+// and must NOT overwrite an existing .previous (which would lose the real old
+// binary the rollback target holds).
+func TestSwapBinary_AlreadyEqualSkips(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "cc-fleet")
+	if err := os.WriteFile(exe, []byte("NEW"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A genuine OLD backup from a prior update.
+	if err := os.WriteFile(exe+".previous", []byte("OLD"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staged := filepath.Join(dir, ".cc-fleet-update-staged")
+	if err := os.WriteFile(staged, []byte("NEW"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := swapBinary(exe, staged, "v0.1.0", "v9.9.9", &bytes.Buffer{}); err != nil {
+		t.Fatalf("swapBinary: %v", err)
+	}
+	if b, _ := os.ReadFile(exe + ".previous"); string(b) != "OLD" {
+		t.Fatalf(".previous clobbered to %q, want OLD preserved", b)
+	}
+	if _, err := os.Stat(staged); !os.IsNotExist(err) {
+		t.Fatalf("staged file should be removed when already up to date")
+	}
+}
+
 func TestRollback_NoBackup(t *testing.T) {
 	dir := t.TempDir()
 	exe := filepath.Join(dir, "cc-fleet")

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/ethanhq/cc-fleet/internal/version"
 )
@@ -239,7 +240,124 @@ func TestRun_DevBuildIsNoOp(t *testing.T) {
 	}
 }
 
+// --- cache / startup prompt --------------------------------------------------
+
+func TestPromptTag_FreshNewer(t *testing.T) {
+	setHome(t)
+	withVersion(t, "v0.1.0")
+	writeCache(t, `{"latest_tag":"v0.1.8"}`)
+	tag, ok := PromptTag(time.Unix(1_000_000, 0))
+	if !ok || tag != "v0.1.8" {
+		t.Fatalf("PromptTag = (%q,%v), want (v0.1.8,true)", tag, ok)
+	}
+}
+
+func TestPromptTag_NotNewer(t *testing.T) {
+	setHome(t)
+	withVersion(t, "v0.1.8")
+	writeCache(t, `{"latest_tag":"v0.1.8"}`)
+	if _, ok := PromptTag(time.Unix(1_000_000, 0)); ok {
+		t.Fatalf("PromptTag ok=true, want false when latest == current")
+	}
+}
+
+func TestPromptTag_DevBuildNeverPrompts(t *testing.T) {
+	setHome(t)
+	withVersion(t, "0.1.0-dev")
+	writeCache(t, `{"latest_tag":"v9.9.9"}`)
+	if _, ok := PromptTag(time.Unix(1_000_000, 0)); ok {
+		t.Fatalf("PromptTag ok=true for a dev build, want false")
+	}
+}
+
+func TestPromptTag_OptedOut(t *testing.T) {
+	setHome(t)
+	withVersion(t, "v0.1.0")
+	writeCache(t, `{"latest_tag":"v0.1.8"}`)
+	t.Setenv(OptOutEnv, "1")
+	if _, ok := PromptTag(time.Unix(1_000_000, 0)); ok {
+		t.Fatalf("PromptTag ok=true while opted out, want false")
+	}
+}
+
+func TestPromptTag_DismissedWindow(t *testing.T) {
+	setHome(t)
+	withVersion(t, "v0.1.0")
+	now := time.Unix(1_000_000, 0)
+	// Dismissed just now → suppressed.
+	writeCache(t, `{"latest_tag":"v0.1.8","dismissed_tag":"v0.1.8","dismissed_at":1000000}`)
+	if _, ok := PromptTag(now); ok {
+		t.Fatalf("PromptTag ok=true right after dismissal, want false")
+	}
+	// Dismissed > 24h ago → prompts again.
+	later := now.Add(25 * time.Hour)
+	if _, ok := PromptTag(later); !ok {
+		t.Fatalf("PromptTag ok=false 25h after dismissal, want true")
+	}
+}
+
+func TestDismissSuppresses(t *testing.T) {
+	setHome(t)
+	withVersion(t, "v0.1.0")
+	writeCache(t, `{"latest_tag":"v0.1.8"}`)
+	now := time.Unix(1_000_000, 0)
+	if _, ok := PromptTag(now); !ok {
+		t.Fatalf("precondition: PromptTag should be true before dismissal")
+	}
+	if err := Dismiss("v0.1.8", now); err != nil {
+		t.Fatalf("Dismiss: %v", err)
+	}
+	if _, ok := PromptTag(now); ok {
+		t.Fatalf("PromptTag ok=true after Dismiss within the window, want false")
+	}
+}
+
+func TestRefreshCache(t *testing.T) {
+	setHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/"+repo+"/releases/tag/v9.9.9")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+	withGitHubBase(t, srv.URL)
+
+	now := time.Unix(2_000_000, 0)
+	RefreshCache(context.Background(), now) // empty cache → fetches
+	c := loadCache()
+	if c.LatestTag != "v9.9.9" || c.LastChecked != now.Unix() {
+		t.Fatalf("after refresh cache = %+v, want latest v9.9.9 @ %d", c, now.Unix())
+	}
+
+	// A fresh cache (checked just now) is not re-queried even if the server moves.
+	RefreshCache(context.Background(), now.Add(time.Hour))
+	if c2 := loadCache(); c2.LatestTag != "v9.9.9" || c2.LastChecked != now.Unix() {
+		t.Fatalf("fresh cache was re-queried: %+v", c2)
+	}
+}
+
 // --- helpers -----------------------------------------------------------------
+
+func setHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	return home
+}
+
+func writeCache(t *testing.T, body string) {
+	t.Helper()
+	p, err := cachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func withGitHubBase(t *testing.T, base string) {
 	t.Helper()

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -188,6 +188,36 @@ func TestSwapBinary_AlreadyEqualSkips(t *testing.T) {
 	}
 }
 
+// TestSwapBinary_BackupSymlinkSafe: if .previous is (adversarially) a symlink
+// back to the live binary, backing up must NOT follow it and truncate exe — the
+// atomic-write backup replaces the symlink with a real copy.
+func TestSwapBinary_BackupSymlinkSafe(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "cc-fleet")
+	if err := os.WriteFile(exe, []byte("OLD"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(exe, exe+".previous"); err != nil {
+		t.Skip("symlinks unsupported here")
+	}
+	staged := filepath.Join(dir, ".cc-fleet-update-staged")
+	if err := os.WriteFile(staged, []byte("NEW"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := swapBinary(exe, staged, "v0.1.0", "v9.9.9", &bytes.Buffer{}); err != nil {
+		t.Fatalf("swapBinary: %v", err)
+	}
+	if b, _ := os.ReadFile(exe); string(b) != "NEW" {
+		t.Fatalf("exe = %q, want NEW (must not be truncated via the symlink)", b)
+	}
+	if b, _ := os.ReadFile(exe + ".previous"); string(b) != "OLD" {
+		t.Fatalf(".previous = %q, want a real OLD copy", b)
+	}
+	if fi, _ := os.Lstat(exe + ".previous"); fi != nil && fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf(".previous is still a symlink; backup did not replace it")
+	}
+}
+
 func TestRollback_NoBackup(t *testing.T) {
 	dir := t.TempDir()
 	exe := filepath.Join(dir, "cc-fleet")

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2939,14 +2939,14 @@ func renderSetupOptions(opts []string, cursor int) string {
 	return b.String()
 }
 
-// viewSetupTmux renders the first-run tmux setup nudge. tmux is needed to spawn
-// teammate panes but optional for one-shot subagent jobs, so this offers
-// install-vs-subagent-only rather than forcing it.
+// viewSetupTmux renders the first-run tmux setup nudge. tmux is needed only for
+// live teammate panes (subagent / workflow / run work without it), so this
+// offers install-vs-skip rather than forcing it.
 func (m Model) viewSetupTmux() string {
 	var b strings.Builder
 	b.WriteString(titleStyle.Render("cc-fleet · setup") + "\n\n")
-	b.WriteString("tmux isn't installed — it's needed to spawn teammate panes.\n")
-	b.WriteString(faintStyle.Render("(one-shot `cc-fleet subagent` jobs work without it.)") + "\n\n")
+	b.WriteString("tmux isn't installed — it's needed only for live teammate panes.\n")
+	b.WriteString(faintStyle.Render("(subagent / workflow / run all work without it.)") + "\n\n")
 	b.WriteString(renderSetupOptions(tmuxOptions, m.tmuxCursor))
 	b.WriteString("\n" + footer("↑/↓ move · enter select · esc skip"))
 	return b.String()
@@ -2967,7 +2967,7 @@ func (m Model) viewSetup() string {
 	}
 	b.WriteString("agent-teams isn't set in your env / shell rc / settings.json.\n")
 	b.WriteString("It powers vendor " + selectedStyle.Render("teammates") + ".\n")
-	b.WriteString(faintStyle.Render("(one-shot `cc-fleet subagent` jobs work without it.)") + "\n\n")
+	b.WriteString(faintStyle.Render("(subagent / workflow / run all work without it.)") + "\n\n")
 	b.WriteString(renderSetupOptions(setupOptions, m.setupCursor))
 	b.WriteString("\n" + footer("↑/↓ move · enter select · esc skip"))
 	return b.String()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,9 @@
 package version
 
 import (
+	"regexp"
 	"runtime/debug"
+	"strconv"
 	"strings"
 )
 
@@ -33,4 +35,57 @@ func Resolve() string {
 		}
 	}
 	return Version
+}
+
+// releaseRE matches a comparable release version: MAJOR.MINOR.PATCH with an
+// optional leading v and nothing trailing. The dev default ("0.1.0-dev") and
+// VCS pseudo-versions ("v0.1.7-0.<date>-<sha>") are deliberately excluded.
+var releaseRE = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+$`)
+
+// IsRelease reports whether v is a comparable release version. Update checks
+// and the startup prompt only act on releases; a non-release build (dev default
+// or pseudo-version) is reported as "not comparable" and never prompts.
+func IsRelease(v string) bool {
+	return releaseRE.MatchString(strings.TrimSpace(v))
+}
+
+// Normalize strips a leading v and surrounding space so "v0.1.6" and "0.1.6"
+// compare equal (the binary carries the git tag "v0.1.6"; the plugin manifest
+// carries the bare "0.1.6").
+func Normalize(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// parseRelease parses a release into its three integer components; ok is false
+// when v is not a comparable release.
+func parseRelease(v string) ([3]int, bool) {
+	if !IsRelease(v) {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, p := range strings.Split(Normalize(v), ".") {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
+// Newer reports whether release a is strictly newer than release b. It returns
+// false if either side is not a comparable release, so a dev/pseudo current
+// version can never be told an update is available (or that it is a downgrade).
+func Newer(a, b string) bool {
+	av, aok := parseRelease(a)
+	bv, bok := parseRelease(b)
+	if !aok || !bok {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if av[i] != bv[i] {
+			return av[i] > bv[i]
+		}
+	}
+	return false
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -25,3 +25,45 @@ func TestResolve_UnstampedFallsBackToDevDefault(t *testing.T) {
 		t.Fatalf("Resolve() = %q, want the dev default %q for an unstamped build", got, devDefault)
 	}
 }
+
+func TestIsRelease(t *testing.T) {
+	releases := []string{"0.1.6", "v0.1.6", "1.2.3", "v10.20.30", " v0.1.6 "}
+	for _, v := range releases {
+		if !IsRelease(v) {
+			t.Errorf("IsRelease(%q) = false, want true", v)
+		}
+	}
+	nonReleases := []string{"0.1.0-dev", "v0.1.7-0.20260609133342-c27032ba21ef", "(devel)", "1.2", "1.2.3.4", "v1.2.x", ""}
+	for _, v := range nonReleases {
+		if IsRelease(v) {
+			t.Errorf("IsRelease(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"v0.1.8", "v0.1.6", true},
+		{"0.1.8", "v0.1.6", true}, // mixed v-prefix
+		{"v0.2.0", "v0.1.9", true},
+		{"v1.0.0", "v0.9.9", true},
+		{"v0.1.6", "v0.1.6", false},    // equal is not newer
+		{"v0.1.6", "v0.1.8", false},    // older
+		{"0.1.0-dev", "v0.1.6", false}, // non-release current never "newer"
+		{"v0.1.8", "0.1.0-dev", false}, // non-release base is not comparable
+	}
+	for _, c := range cases {
+		if got := Newer(c.a, c.b); got != c.want {
+			t.Errorf("Newer(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	if Normalize("v0.1.6") != "0.1.6" || Normalize("0.1.6") != "0.1.6" {
+		t.Fatalf("Normalize did not strip the leading v consistently")
+	}
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -85,6 +85,12 @@ async function main() {
     const dest = path.join(binDir, "cc-fleet");
     fs.copyFileSync(extracted, dest);
     fs.chmodSync(dest, 0o755);
+    // Install manifest (co-located with the binary): `cc-fleet update` reads it
+    // and delegates to npm instead of self-replacing an npm-managed binary.
+    fs.writeFileSync(
+      path.join(binDir, ".cc-fleet-install.json"),
+      JSON.stringify({ method: "npm" })
+    );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.1.0",
+  "version": "0.1.6",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API as real Claude Code agent-team teammates or one-shot subagents. The main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",

--- a/release/README.md
+++ b/release/README.md
@@ -3,16 +3,13 @@
 A prebuilt `cc-fleet` binary plus the `cc-fleet` skill. No Go toolchain
 needed — this archive ships a compiled binary for your platform.
 
-## Install (3 steps)
+## Install
 
 ```bash
 # 1. install the binary (+ ccf alias) and the skill (skill via the plugin by default)
 ./install.sh --prefix ~/.local/bin
 
-# 2. first-time setup
-cc-fleet init
-
-# 3. add a vendor — pipe the key on stdin, never inline it in argv (it leaks
+# 2. add a vendor — pipe the key on stdin, never inline it in argv (it leaks
 #    to shell history / `ps`)
 printf '%s' "$DEEPSEEK_KEY" | cc-fleet add deepseek \
   --base-url https://api.deepseek.com/anthropic \
@@ -21,7 +18,10 @@ printf '%s' "$DEEPSEEK_KEY" | cc-fleet add deepseek \
   --secret-backend file --secret-ref deepseek.key --api-key-stdin
 ```
 
-Then `cc-fleet doctor` to health-check and `cc-fleet list` to see what's configured.
+The config tree is created automatically on first use — `cc-fleet init` is optional
+(run it only to create the tree and health-check up front). Then `cc-fleet doctor` to
+health-check, `cc-fleet list` to see what's configured, and `cc-fleet update` to update
+the binary + plugin later.
 
 > **Skill channel.** By default `install.sh` installs the skill via the Claude Code
 > plugin (`--skill plugin`). Use `--skill global` to copy the bundled `SKILL.md`

--- a/release/install.sh
+++ b/release/install.sh
@@ -85,9 +85,10 @@ ln -sf cc-fleet "${PREFIX}/ccf"
 echo "==> Installed: ${PREFIX}/cc-fleet (+ ccf alias)"
 
 # Install manifest (co-located with the binary) so `cc-fleet update` self-updates
-# in place without guessing how it was installed.
+# in place without guessing the method, preserves the plugin scope, and leaves
+# the plugin alone for a --skill none/global install.
 cat > "${PREFIX}/.cc-fleet-install.json" <<EOF
-{"method":"tarball","prefix":"${PREFIX}","plugin_scope":"${SCOPE}","marketplace":"${MARKETPLACE}"}
+{"method":"tarball","plugin_scope":"${SCOPE}","skill":"${SKILL_MODE}"}
 EOF
 
 # --- Skill --------------------------------------------------------------------

--- a/release/install.sh
+++ b/release/install.sh
@@ -84,6 +84,12 @@ chmod +x "${PREFIX}/cc-fleet"
 ln -sf cc-fleet "${PREFIX}/ccf"
 echo "==> Installed: ${PREFIX}/cc-fleet (+ ccf alias)"
 
+# Install manifest (co-located with the binary) so `cc-fleet update` self-updates
+# in place without guessing how it was installed.
+cat > "${PREFIX}/.cc-fleet-install.json" <<EOF
+{"method":"tarball","prefix":"${PREFIX}","plugin_scope":"${SCOPE}","marketplace":"${MARKETPLACE}"}
+EOF
+
 # --- Skill --------------------------------------------------------------------
 
 case "$SKILL_MODE" in
@@ -124,6 +130,17 @@ case "$SKILL_MODE" in
         ;;
 esac
 
+# --- Claude Code precondition note --------------------------------------------
+
+if ! command -v claude >/dev/null 2>&1; then
+    cat <<EOF
+
+==> Note: Claude Code ('claude') was not found on PATH.
+    cc-fleet drives Claude Code — install it to run teammates / subagents / workflows:
+    https://docs.anthropic.com/claude-code
+EOF
+fi
+
 # --- PATH check ---------------------------------------------------------------
 
 case ":${PATH}:" in
@@ -150,6 +167,9 @@ cat <<EOF
    cc-fleet             # launch the interactive TUI — register a vendor and get started
                         #   (config is auto-created on first save; no init needed)
    cc-fleet doctor      # optional: run the health checks
+   cc-fleet update      # later: update cc-fleet + the plugin to the latest release
+
+   tmux is needed only for live teammates; subagent / workflow / run work without it.
 
    See README.md in this archive for the full quick-start.
 EOF

--- a/scripts/version-guard.sh
+++ b/scripts/version-guard.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Assert the plugin manifest and npm package versions match the release tag, so
+# a release can never ship a stale .claude-plugin/plugin.json (the marketplace
+# serves the committed manifest) or a mismatched npm package. Run as a release
+# prerequisite BEFORE any artifact is built; a mismatch fails the release loudly.
+# We never auto-bump on a tag — fix it with `make release-prep VERSION=vX.Y.Z`,
+# commit, then re-tag.
+set -euo pipefail
+
+tag="${1:-${GITHUB_REF_NAME:-}}"
+tag="${tag#v}" # strip a leading v
+if [ -z "$tag" ]; then
+  echo "version-guard: no tag given (pass vX.Y.Z or set GITHUB_REF_NAME)" >&2
+  exit 2
+fi
+
+jsonver() { sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -1; }
+
+plugin_ver="$(jsonver .claude-plugin/plugin.json)"
+npm_ver="$(jsonver npm/package.json)"
+
+fail=0
+if [ "$plugin_ver" != "$tag" ]; then
+  echo "version-guard: .claude-plugin/plugin.json version=$plugin_ver != tag=$tag" >&2
+  fail=1
+fi
+if [ "$npm_ver" != "$tag" ]; then
+  echo "version-guard: npm/package.json version=$npm_ver != tag=$tag" >&2
+  fail=1
+fi
+if [ "$fail" -ne 0 ]; then
+  echo "version-guard: run 'make release-prep VERSION=v$tag', commit, then re-tag." >&2
+  exit 1
+fi
+echo "version-guard: plugin.json, npm/package.json, and tag all at $tag"

--- a/skills/cc-fleet/references/cli-reference.md
+++ b/skills/cc-fleet/references/cli-reference.md
@@ -26,8 +26,8 @@ cc-fleet edit <vendor> [flags]           Modify one or more vendor fields. Incl.
 cc-fleet remove <vendor>                 Delete vendor + derived files (incl. multi-
                                          key store + rotation counter).
 cc-fleet list                            Pretty table of configured vendors.
-cc-fleet doctor [--fix]                  Run nine health checks; --fix auto-repairs
-                                         the safe ones.
+cc-fleet doctor [--fix]                  Run the health checks (Core + live-teammate
+                                         Optional); --fix auto-repairs the safe ones.
 cc-fleet repair                          Rebuild derived files from vendors.toml.
 cc-fleet uninstall [--wipe-secrets]      Remove config/profiles/models cache. Secrets are
                                          PRESERVED by default; --wipe-secrets also removes


### PR DESCRIPTION
cc-fleet had no update path, and its health story was teammate-centric — predating workflow and subagent becoming core capabilities. This reworks the whole install → update → version-check → doctor chain.

`ccf update` is new and updates both the binary and the Claude Code plugin, method-aware. A curl/tarball install self-updates in place: it downloads the prebuilt release, verifies the sha256, smoke-tests the new binary, then atomically replaces the running one and keeps a `.previous` for `ccf update rollback`; an npm or `go install` install delegates to that package manager; and when the needed tool is missing or the install directory isn't writable it prints the exact command instead of acting. The installers write a co-located manifest so the method, plugin scope, and skill choice are known without path guessing, and `ccf update --check` reports current-versus-latest without changing anything.

A bare interactive `ccf` launch now offers a once-a-day update prompt before the TUI starts, while the terminal is still in normal mode so choosing "update now" cleanly re-execs into the new binary. The prompt is driven purely by a locked cache refreshed in the background, so launch never blocks on the network; it is opt-out via `CC_FLEET_NO_UPDATE_CHECK`, and it runs only on the bare both-TTY path so keyget and every machine-facing command never reach it.

`cc-fleet doctor` now groups its checks into Core (needed by every run mode) and Optional — live teammates only (tmux). A missing tmux is a warning rather than a failure, since subagent, workflow, and run need none, so only a Core failure makes doctor exit non-zero; a new check reports a binary-versus-plugin version skew. Onboarding and install messaging name workflow and run alongside subagent as the tmux-free modes, and the install scripts gain a Claude Code precondition note and an update hint.

A release-time version guard now fails the release before any artifact is built unless the plugin manifest, the npm package, and the git tag all agree, with `make release-prep VERSION=vX.Y.Z` to bump them in lockstep — closing the drift that previously let a stale plugin manifest ship.

Unit tests cover the version comparability contract, the atomic binary swap with its symlink-safety and concurrent-updater guards, rollback, install-method detection, the cached prompt's gating to the interactive path, and the release version guard.