### PR TITLE
feat(tui): route provider hub prompts through the centered modal

### DIFF
--- a/internal/tui/confirm.go
+++ b/internal/tui/confirm.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -24,18 +25,19 @@ const (
 	modalResult                    // the outcome is shown; any key dismisses
 )
 
-// confirmModal is the centered overlay on the board — the single home for every transient prompt and
-// outcome the board surfaces. It confirms a destructive or disruptive action (delete a run / ended
-// team / job, clear a session's finished, stop or restart a run/agent) via the Cancel / Confirm
-// buttons (←/→, cursor starts on Cancel, the safe default; no esc), then,
-// for an async action, stays open through a modalRunning stage until its outcome lands. A bare
-// outcome with no preceding question (a control result, a hide/show or pin failure) opens straight in
-// modalResult via withInfo. Any key dismisses a result.
+// confirmModal is the centered overlay shared by the Agents Board and the provider hub — the single
+// home for every transient prompt and outcome they surface. It confirms a destructive or disruptive
+// action (delete a run / ended team / job, clear a session's finished, stop or restart a run/agent,
+// remove a provider, delete or replace an API key) via the Cancel / Confirm buttons (←/→, cursor
+// starts on Cancel, the safe default; no esc), then, for an async action, stays open through a
+// modalRunning stage until its outcome lands. A bare outcome with no preceding question (a control
+// result, a hide/show or pin failure) opens straight in modalResult via withInfo. Any key dismisses
+// a result.
 type confirmModal struct {
 	prompt    string
-	kind      string // confirmRun | confirmTeam | confirmJob | confirmClear | confirmStop | confirmRestart | confirmRestartAgent | confirmSession
-	id        string // the run / team / job / session id the action targets
-	arg       string // extra action input — the leaf journal key for confirmRestartAgent
+	kind      string // one of the confirm* kind constants below
+	id        string // the action's target: a run / team / job / session id, a vendor name, or a key index
+	arg       string // extra action input — the leaf journal key (restart-agent) or the targeted key's current value (delete-key / replace-key; identity only, never rendered)
 	cursor    int    // 0 = Cancel (default), 1 = Confirm
 	danger    bool   // a heavy/irreversible ask — the ask frame + prompt warn in red, not amber
 	phase     modalPhase
@@ -53,6 +55,9 @@ const (
 	confirmRestart      = "restart"
 	confirmRestartAgent = "restart-agent"
 	confirmSession      = "session"
+	confirmRemoveVendor = "remove-vendor"
+	confirmDeleteKey    = "delete-key"
+	confirmReplaceKey   = "replace-key"
 )
 
 // confirmAmber is the modal's confirm-phase accent: the border AND the Cancel/Confirm buttons share
@@ -157,6 +162,38 @@ func (m Model) runConfirmed() (tea.Model, tea.Cmd) {
 	case confirmJob:
 		m.confirm = nil
 		return m, deleteJobCmd(c.id, m.boardEpoch)
+	case confirmRemoveVendor:
+		m.confirm = nil
+		m.loading = true
+		return m, removeVendorCmd(c.id)
+	case confirmDeleteKey:
+		// The keyset can refresh while the modal is open, so the target is re-validated
+		// by identity (index + the key value captured at open) before the splice.
+		m.confirm = nil
+		idx, err := strconv.Atoi(c.id)
+		if err != nil || idx < 0 || idx >= len(m.keys) || m.keys[idx].Key != c.arg {
+			m.keyErr = "key list changed; nothing deleted"
+			return m, nil
+		}
+		m.keys = append(m.keys[:idx], m.keys[idx+1:]...)
+		if m.keyCursor > len(m.keys) {
+			m.keyCursor = len(m.keys)
+		}
+		return m, m.saveKeysetCmd()
+	case confirmReplaceKey:
+		// Same identity re-validation as the delete; a vanished target also ends the
+		// edit — committing the typed value into a refreshed list could hit the wrong row.
+		m.confirm = nil
+		idx, err := strconv.Atoi(c.id)
+		if err != nil || idx < 0 || idx >= len(m.keys) || m.keys[idx].Key != c.arg {
+			m.keyEditing = false
+			m.keyErr = "key list changed; nothing replaced"
+			return m, nil
+		}
+		m.keys[idx].Key = strings.TrimSpace(m.keyInput.Value())
+		m.keyEditing = false
+		m.keyErr = ""
+		return m, m.saveKeysetCmd()
 	}
 	m.confirm = nil
 	return m, nil
@@ -206,6 +243,12 @@ func (m Model) confirmBorder() lipgloss.Color {
 // renderConfirmBox is the modal's bordered content per phase: the colored outcome (modalResult), the
 // in-flight busy label (modalRunning), or the prompt over the Cancel / Confirm buttons (modalAsk).
 func (m Model) renderConfirmBox() string {
+	// Long prompts and outcome lines (the hub's consequence-stating asks, a failed-op
+	// message) wrap to the modal's width budget; the board's one-liners pass through.
+	w := 56
+	if m.width > 0 && m.width-12 < w {
+		w = m.width - 12
+	}
 	var body string
 	switch m.confirm.phase {
 	case modalResult:
@@ -214,7 +257,7 @@ func (m Model) renderConfirmBox() string {
 			resultStyle = errStyle
 		}
 		body = lipgloss.JoinVertical(lipgloss.Center,
-			resultStyle.Render(m.confirm.result),
+			resultStyle.Render(strings.Join(wrapTo(m.confirm.result, w), "\n")),
 			faintStyle.Render("press any key"))
 	case modalRunning:
 		body = liveStyle.Render(m.confirm.busy)
@@ -224,7 +267,7 @@ func (m Model) renderConfirmBox() string {
 			promptStyle = errStyle // a heavy delete warns in red
 		}
 		body = lipgloss.JoinVertical(lipgloss.Center,
-			promptStyle.Render(m.confirm.prompt),
+			promptStyle.Render(strings.Join(wrapTo(m.confirm.prompt, w), "\n")),
 			"",
 			confirmButtons(m.confirm.cursor, m.confirmBorder()))
 	}

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -660,7 +660,11 @@ func (f form) viewLines(width int) []string {
 			if fld.choiceIdx >= 0 && fld.choiceIdx < len(fld.choices) {
 				val = fld.choices[fld.choiceIdx]
 			}
-			lines = append(lines, " "+keyCell+"  "+contentStyle.Render("‹ "+val+" ›"))
+			st := contentStyle
+			if fld.key == "permission" {
+				st = permModeStyle(val) // the Claude permission-indicator palette
+			}
+			lines = append(lines, " "+keyCell+"  "+st.Render("‹ "+val+" ›"))
 		case fieldAction:
 			// Value-column action label; enter on it is handled by the parent
 			// model (e.g. open the key manager).

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,12 +43,10 @@ const (
 	screenPickTemplate
 	screenForm
 	screenModelPick
-	screenRemoveConfirm
-	screenResult
 	screenKeys      // EDIT form → "Manage API keys →": per-vendor multi-key manager
 	screenSetupTmux // first-run tmux setup nudge; shown before agent-teams/hub
 	screenSetup     // first-run agent-teams setup nudge; shown before the hub
-	screenCodexAuth // CLI-auth → codex: consent → device-code login
+	screenCodexAuth // CLI-auth → codex: committing → consent → device-code login, modal-rendered
 )
 
 // addCategory is the provider class a picker row belongs to.
@@ -66,6 +65,7 @@ const (
 	codexAuthConsent      codexAuthStage = iota // risk notice; enter accepts
 	codexAuthDevice                             // device-code shown; polling for authorization
 	codexAuthChooseSource                       // a subscription is detected: reuse it or log in separately
+	codexAuthCommitting                         // the add is committing; all keys trapped until opDoneMsg routes on
 )
 
 // formMode records whether the active form is an add or an edit so submit
@@ -130,6 +130,7 @@ type Model struct {
 	codexAddRef        string
 	codexCommittedName string // committed-but-not-yet-logged-in codex row; rolled back on abandon
 	codexAuthAccount   string // detected cli-ride account, shown on the source-choice stage
+	codexSourceCursor  int    // source-choice selection: 0 reuse the detected login, 1 log in separately
 
 	// Agents Board (screenSpawn): live teammates, workflow runs, and async subagent
 	// jobs in one master-detail board. asMode re-roots the levels (projects → sessions →
@@ -259,9 +260,6 @@ type Model struct {
 	// (default_model / strong_model / fast_model). Empty falls back to default_model.
 	pickerTarget string
 
-	// Remove confirmation target.
-	removeName string
-
 	// Key manager (screenKeys), reached from the EDIT form's "Manage API keys →"
 	// action. keys holds the in-memory key set — full keys live here but the view
 	// renders ONLY secrets.MaskKey. keyCursor ranges over [0, len(keys)] (the last
@@ -276,10 +274,6 @@ type Model struct {
 	keyEditing  bool
 	keyRotation string
 	keyErr      string
-
-	// Result screen contents.
-	result    string
-	resultErr bool
 
 	// First-run setup nudges. setupCursor/tmuxCursor select an option on the
 	// agent-teams / tmux screens respectively. setupMsg, once non-empty, replaces
@@ -914,8 +908,11 @@ func (m Model) anyLeafRunning() bool {
 // paneVisMsg carries the outcome of an inline hide/show so the board can surface
 // a failure (its code/reason/suggestion) instead of silently relying on the next
 // refresh to show an unchanged HIDDEN column. Its handler pops an info modal and
-// then reloads the board to reflect the new state.
+// then reloads the board to reflect the new state. Owned by screenSpawn so a
+// result landing after the user left the board can't pop a stale modal on the hub.
 type paneVisMsg struct{ res panevis.Result }
+
+func (paneVisMsg) owningScreen() screen { return screenSpawn }
 
 // hideTeammateCmd hides the selected teammate row's pane and reports the
 // panevis.Result so the board can surface success/failure; the result handler
@@ -1079,7 +1076,7 @@ func removeVendorCmd(name string) tea.Cmd {
 
 // codexRollbackDoneMsg reports a finished abandon-rollback (a codex row removed after
 // its login was cancelled). Distinct from opDoneMsg so the cancel lands quietly on the
-// provider list rather than a "remove OK" result screen; epoch-tagged so a stale one
+// provider list rather than a "remove OK" outcome modal; epoch-tagged so a stale one
 // can't disturb a newer attempt.
 type codexRollbackDoneMsg struct{ epoch int }
 
@@ -1496,25 +1493,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case opDoneMsg:
-		m.loading = false
-		// A codex row committed ahead of its login (see submitAddCodex) now routes to the
-		// device-code login instead of a result screen; a failed add clears the marker.
-		if msg.verb == "add" && msg.err == nil && m.codexCommittedName != "" {
-			m.screen = screenCodexAuth
-			m.codexAuthStage = codexAuthConsent
-			m.codexAuthErr = ""
+		// While a marked codex login flow owns the screen (committing, consent, or
+		// device), a stale result from an earlier, unrelated op is dropped outright:
+		// yanking the user to an outcome modal would free them to start another codex
+		// commit and overwrite the single marker, silently orphaning the first row
+		// without login or rollback. Only the committed add's own result moves the
+		// flow; only its failure clears the marker.
+		if m.screen == screenCodexAuth && m.codexCommittedName != "" &&
+			!(msg.verb == "add" && msg.name == m.codexCommittedName) {
 			return m, nil
 		}
-		m.codexCommittedName = ""
-		m.screen = screenResult
-		if msg.err != nil {
-			m.resultErr = true
-			m.result = fmt.Sprintf("%s %q failed:\n\n%v", msg.verb, msg.name, msg.err)
-		} else {
-			m.resultErr = false
-			m.result = fmt.Sprintf("%s %q: OK", msg.verb, msg.name)
+		m.loading = false
+		if msg.verb == "add" && m.codexCommittedName != "" && msg.name == m.codexCommittedName {
+			if msg.err == nil {
+				m.screen = screenCodexAuth
+				m.codexAuthStage = codexAuthConsent
+				m.codexAuthErr = ""
+				return m, nil
+			}
+			m.codexCommittedName = ""
 		}
-		return m, nil
+		// The outcome pops as an info modal over the list (green ok / red failure, any
+		// key dismisses) while the list reloads underneath — loading stays false so the
+		// previous frame, not a bare "loading…", is the underlay.
+		m.screen = screenList
+		line := fmt.Sprintf("%s %q: OK", msg.verb, msg.name)
+		isErr := false
+		if msg.err != nil {
+			line = fmt.Sprintf("%s %q failed: %v", msg.verb, msg.name, msg.err)
+			isErr = true
+		}
+		return m.withInfo(line, isErr), loadVendors
 
 	case codexAuthBegunMsg:
 		// Drop a begin from a prior login attempt (esc then re-enter starts a new
@@ -1543,7 +1552,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.done {
 			// The provider row was already committed before the login (see
-			// submitAddCodex); the login just filled its credential, so report success.
+			// submitAddCodex); the login just filled its credential, so report success
+			// as an info modal over the reloading list.
 			if m.codexAuthCancel != nil {
 				m.codexAuthCancel()
 				m.codexAuthCancel, m.codexAuthCtx = nil, nil
@@ -1552,10 +1562,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			name := m.codexCommittedName
 			m.codexCommittedName = ""
 			m.loading = false
-			m.screen = screenResult
-			m.resultErr = false
-			m.result = fmt.Sprintf("add %q: OK", name)
-			return m, nil
+			m.screen = screenList
+			return m.withInfo(fmt.Sprintf("add %q: OK", name), false), loadVendors
 		}
 		return m, codexAuthTickCmd(m.codexAuthEpoch, m.codexAuth.Interval())
 
@@ -1628,10 +1636,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateForm(msg)
 		case screenModelPick:
 			return m.updateModelPick(msg)
-		case screenRemoveConfirm:
-			return m.updateRemoveConfirm(msg)
-		case screenResult:
-			return m.updateResult(msg)
 		case screenKeys:
 			return m.updateKeys(msg)
 		case screenSetup:
@@ -1646,18 +1650,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // toList returns to the Model Providers list (the hub) and reloads it — after an
-// add/edit/remove the content changed, and a plain cancel just re-reads.
+// add/edit/remove the content changed, and a plain cancel just re-reads. Any open
+// hub modal is dropped with the screen it overlaid.
 func (m Model) toList() (tea.Model, tea.Cmd) {
 	m.screen = screenList
 	m.loading = true
+	m.confirm = nil
 	return m, loadVendors
 }
 
 // updateList drives the Model Providers hub. The cursor ranges over [0, len(vendors)];
 // the final index is the synthetic "+ Add provider…" row. →/enter edits the
 // highlighted provider (or opens the add wizard on the Add row); d deletes it
-// (with a confirm); tab switches to the Agents Board; q/esc quit.
+// (via a confirm modal); tab switches to the Agents Board; q/esc quit.
 func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.confirm != nil {
+		return m.updateConfirm(msg) // the remove-confirm modal traps focus until resolved
+	}
 	addRow := len(m.vendors) // index of the trailing "+ Add provider…" row
 	switch msg.String() {
 	case "q", "esc":
@@ -1709,9 +1718,18 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenForm
 		return m, textinput.Blink
 	case "d":
-		if m.vendorCursor < addRow { // a vendor row, not the Add row
-			m.removeName = m.vendors[m.vendorCursor].Name
-			m.screen = screenRemoveConfirm
+		// No new ask while a mutation is in flight: its outcome modal would find this
+		// one open and be silently swallowed (withInfo never clobbers an open modal).
+		if m.vendorCursor < addRow && !m.loading { // a vendor row, not the Add row
+			v := m.vendors[m.vendorCursor]
+			// State the real consequences per class: a codex remove tears down cc-fleet's
+			// own login (when unreferenced), never ~/.codex; a file-backend remove drops
+			// the secret + key store.
+			prompt := "Remove " + v.Name + "? Deletes its config row, profile, and (file backend) its secret + key store."
+			if v.Protocol == config.ProtocolCodexOAuth {
+				prompt = "Remove " + v.Name + "? Deletes its profile and cc-fleet's codex login (if unused elsewhere); ~/.codex is untouched."
+			}
+			return m.openConfirm(confirmRemoveVendor, v.Name, prompt)
 		}
 	}
 	return m, nil
@@ -3052,25 +3070,28 @@ func (m Model) updateCodexAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.codexPendingAdd = nil
 			m.screen = screenForm
 			return m, textinput.Blink
-		case "r", "enter", "y":
-			// Reuse the detected subscription: commit the row as-is (the daemon rides
-			// ~/.codex; no separate login, so no token write and no rollback).
+		case "up", "k":
+			if m.codexSourceCursor > 0 {
+				m.codexSourceCursor--
+			}
+		case "down", "j":
+			if m.codexSourceCursor < 1 {
+				m.codexSourceCursor++
+			}
+		case "enter":
+			// Commit the cursored choice: reuse rides ~/.codex (no token write, no
+			// rollback); separate login commits the row first and marks it for the
+			// login — same ordering as the no-source path. Either way the committing
+			// stage traps keys until opDoneMsg routes on.
 			if m.codexPendingAdd == nil {
 				return m.toList()
 			}
 			req := *m.codexPendingAdd
 			m.codexPendingAdd = nil
-			m.loading = true
-			return m, addVendorCmd(req)
-		case "s", "l":
-			// Log in separately (cc-fleet's own login overrides the ride): commit the row
-			// first, then log in — same ordering as the no-source path.
-			if m.codexPendingAdd == nil {
-				return m.toList()
+			if m.codexSourceCursor == 1 {
+				m.codexCommittedName = req.Name
 			}
-			req := *m.codexPendingAdd
-			m.codexPendingAdd = nil
-			m.codexCommittedName = req.Name
+			m.codexAuthStage = codexAuthCommitting
 			m.loading = true
 			return m, addVendorCmd(req)
 		}
@@ -3096,6 +3117,10 @@ func (m Model) updateCodexAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if s := msg.String(); s == "esc" || s == "q" {
 			return m.codexAbandonLogin()
 		}
+	case codexAuthCommitting:
+		// The add is committing (a short flocked local write); every key is trapped so
+		// the underlying form can't change until opDoneMsg routes to consent or result.
+		return m, nil
 	}
 	return m, nil
 }
@@ -3183,8 +3208,11 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.toList()
 	}
 	// Enter (or →, the descend key) on the "Manage API keys →" action row (edit
-	// form only) opens the per-vendor key manager and loads its key set.
-	if (msg.String() == "enter" || msg.String() == "right") && m.formMode == modeEdit && m.form.focusedKey() == "manage_keys" {
+	// form only) opens the per-vendor key manager and loads its key set. Not while a
+	// submit is in flight: a key confirm opened in that window would swallow the
+	// pending outcome modal (withInfo never clobbers an open modal).
+	if (msg.String() == "enter" || msg.String() == "right") && m.formMode == modeEdit &&
+		m.form.focusedKey() == "manage_keys" && !m.loading {
 		m.screen = screenKeys
 		m.keyVendor = m.editName
 		m.keyCursor = 0
@@ -3296,22 +3324,6 @@ func (m Model) filteredModels() []models.Model {
 	return out
 }
 
-func (m Model) updateRemoveConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "y", "Y":
-		m.loading = true
-		return m, removeVendorCmd(m.removeName)
-	case "n", "N", "esc", "q", "left":
-		return m.toList()
-	}
-	return m, nil
-}
-
-// updateResult returns to the Model Providers list on any key press.
-func (m Model) updateResult(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.toList()
-}
-
 // setupOptionCount is the number of choices on the agent-teams setup screen
 // (enable / already-set-up / not-now).
 const setupOptionCount = 3
@@ -3419,8 +3431,12 @@ func tmuxInstallNote() string {
 // updateKeys drives the key manager. While the password input is active
 // (keyEditing) keystrokes edit the new key value; otherwise the cursor walks
 // the key rows + the trailing "+ Add key…" row and the action keys mutate the
-// set. esc returns to the EDIT form.
+// set. esc returns to the EDIT form. The modal trap precedes the input
+// delegation: a delete/replace confirm freezes the input behind it.
 func (m Model) updateKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.confirm != nil {
+		return m.updateConfirm(msg)
+	}
 	if m.keyEditing {
 		return m.updateKeyInput(msg)
 	}
@@ -3458,19 +3474,44 @@ func (m Model) updateKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "d":
 		if m.keyCursor < addRow {
-			m.keys = append(m.keys[:m.keyCursor], m.keys[m.keyCursor+1:]...)
-			if m.keyCursor > len(m.keys) {
-				m.keyCursor = len(m.keys)
+			idx := m.keyCursor
+			prompt := "Delete key " + m.keyLabel(idx) + "?"
+			danger := false
+			if m.keys[idx].Enabled && countEnabled(m.keys) == 1 {
+				prompt += " It is the last enabled key — " + m.keyVendor + " will have no usable key."
+				danger = true
 			}
-			return m, m.saveKeysetCmd()
+			// Built inline: the captured key value in arg is the delete's identity check
+			// (labels are optional and non-unique); it is never rendered.
+			m.confirm = &confirmModal{
+				kind:   confirmDeleteKey,
+				id:     strconv.Itoa(idx),
+				arg:    m.keys[idx].Key,
+				prompt: prompt,
+				danger: danger,
+			}
+			return m, nil
 		}
 	}
 	return m, nil
 }
 
+// countEnabled returns how many keys in the set are enabled.
+func countEnabled(ks []secrets.KeyEntry) int {
+	n := 0
+	for _, e := range ks {
+		if e.Enabled {
+			n++
+		}
+	}
+	return n
+}
+
 // updateKeyInput handles the add/edit password input. enter commits a non-empty
-// value (append for add, replace for edit) and saves; esc cancels back to the
-// list without changes. The typed value is never rendered in plaintext.
+// value: an add appends and saves directly; an edit first confirms through the
+// replace modal (the current value is unrecoverable) — the input stays alive and
+// frozen behind it, so Cancel drops back into it. esc cancels back to the list
+// without changes. The typed value is never rendered in plaintext.
 func (m Model) updateKeyInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
@@ -3488,12 +3529,23 @@ func (m Model) updateKeyInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// SaveKeySet writes keys.json — keys[0] was seeded from the legacy key).
 			m.keys = append(m.keys, secrets.KeyEntry{Key: val, Enabled: true})
 			m.keyCursor = len(m.keys) - 1
-		} else if m.keyEditIdx < len(m.keys) {
-			m.keys[m.keyEditIdx].Key = val
+			m.keyEditing = false
+			m.keyErr = ""
+			return m, m.saveKeysetCmd()
 		}
-		m.keyEditing = false
-		m.keyErr = ""
-		return m, m.saveKeysetCmd()
+		if m.keyEditIdx >= len(m.keys) {
+			// The keyset refreshed under the edit and the target row is gone.
+			m.keyEditing = false
+			m.keyErr = "key list changed; nothing replaced"
+			return m, nil
+		}
+		m.confirm = &confirmModal{
+			kind:   confirmReplaceKey,
+			id:     strconv.Itoa(m.keyEditIdx),
+			arg:    m.keys[m.keyEditIdx].Key,
+			prompt: "Replace key " + m.keyLabel(m.keyEditIdx) + "? The current value cannot be recovered.",
+		}
+		return m, nil
 	}
 	var cmd tea.Cmd
 	m.keyInput, cmd = m.keyInput.Update(msg)
@@ -3663,18 +3715,23 @@ func (m Model) submitAddCodex() (tea.Model, tea.Cmd) {
 	case "cli-ride":
 		// A codex subscription is signed in on the system; let the user reuse it or log
 		// in separately rather than silently riding ~/.codex. The choice is made before
-		// the row is committed; only the separate-login branch then writes a login.
+		// the row is committed; only the separate-login choice then writes a login.
 		m.codexPendingAdd = &req
 		m.codexAuthAccount = st.Account
 		m.screen = screenCodexAuth
 		m.codexAuthStage = codexAuthChooseSource
+		m.codexSourceCursor = 0
 		return m, nil
 	default: // "none" — no source; commit the row, then log in
 		// Commit the provider row (vendors lock) BEFORE the login writes its token (token
 		// lock), so a concurrent remove's referenced-check always sees the committed row
 		// and never unlinks the fresh login. opDoneMsg routes to the login once the row
-		// is in; abandoning the login rolls the row back.
+		// is in; abandoning the login rolls the row back. The committing stage owns the
+		// screen meanwhile, so the form can't be escaped or repopulated mid-commit — the
+		// login modal's underlay stays the form that was submitted.
 		m.codexCommittedName = req.Name
+		m.screen = screenCodexAuth
+		m.codexAuthStage = codexAuthCommitting
 		m.loading = true
 		return m, addVendorCmd(req)
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/models"
 	"github.com/ethanhq/cc-fleet/internal/panevis"
 	"github.com/ethanhq/cc-fleet/internal/secrets"
@@ -273,14 +274,18 @@ func TestAddFormTypingAndSubmitDispatches(t *testing.T) {
 		t.Fatal("submit should set loading=true")
 	}
 
-	m, _ = step(t, m, opDoneMsg{verb: "add", name: Templates[0].Name})
-	if m.screen != screenResult || m.resultErr {
-		t.Fatalf("after success: screen=%d resultErr=%v, want screenResult+false", m.screen, m.resultErr)
+	m, cmd = step(t, m, opDoneMsg{verb: "add", name: Templates[0].Name})
+	if m.screen != screenList || m.confirm == nil || m.confirm.resultErr || cmd == nil {
+		t.Fatalf("success should pop a green info modal over the reloading list: screen=%d confirmOpen=%v cmd=%v",
+			m.screen, m.confirm != nil, cmd)
 	}
-	// Any key returns to the Model Providers list (not a menu).
+	if !strings.Contains(m.confirm.result, "OK") {
+		t.Fatalf("outcome line = %q, want an OK line", m.confirm.result)
+	}
+	// Any key dismisses the outcome; the list stays.
 	m, _ = press(t, m, "enter")
-	if m.screen != screenList {
-		t.Fatalf("result -> any key should return to the list, screen = %d", m.screen)
+	if m.screen != screenList || m.confirm != nil {
+		t.Fatalf("dismiss should keep the list, screen=%d confirmOpen=%v", m.screen, m.confirm != nil)
 	}
 }
 
@@ -505,32 +510,88 @@ func TestCombine1MAndOffToEmpty(t *testing.T) {
 	}
 }
 
-// TestDeleteFromListConfirmAndCancel: d on a highlighted vendor row opens the
-// confirm; n returns to the list, y dispatches the remove.
+// TestDeleteFromListConfirmAndCancel: d on a highlighted vendor row opens the centered
+// confirm modal over the list; Cancel (the default) closes it in place, Confirm
+// dispatches the remove and the outcome pops as an info modal over the list.
 func TestDeleteFromListConfirmAndCancel(t *testing.T) {
 	mk := func() Model {
 		m := withVendors(t, userops.VendorView{Name: "kimi", Enabled: true})
-		m, _ = press(t, m, "d") // delete highlighted vendor -> confirm
+		m, _ = press(t, m, "d") // delete highlighted vendor -> confirm modal
 		return m
 	}
 
 	m := mk()
-	if m.screen != screenRemoveConfirm || m.removeName != "kimi" {
-		t.Fatalf("screen=%d removeName=%q, want removeConfirm+kimi", m.screen, m.removeName)
+	if m.screen != screenList || m.confirm == nil {
+		t.Fatalf("screen=%d confirmOpen=%v, want modal open over screenList", m.screen, m.confirm != nil)
 	}
-	m, _ = press(t, m, "n")
-	if m.screen != screenList {
-		t.Fatalf("n should cancel back to the list, screen = %d", m.screen)
+	if m.confirm.kind != confirmRemoveVendor || m.confirm.id != "kimi" {
+		t.Fatalf("modal kind=%q id=%q, want remove-vendor + kimi", m.confirm.kind, m.confirm.id)
+	}
+	if !strings.Contains(m.View(), "Remove kimi?") {
+		t.Fatalf("modal prompt missing from view")
+	}
+	// The modal traps list keys: d again must not re-open / mutate anything.
+	m, _ = press(t, m, "d")
+	if m.confirm == nil || m.confirm.cursor != 0 {
+		t.Fatalf("d while modal open should be swallowed")
+	}
+	m, _ = press(t, m, "enter") // Cancel is the default cursor
+	if m.confirm != nil || m.screen != screenList {
+		t.Fatalf("enter on Cancel should close the modal in place, confirmOpen=%v screen=%d", m.confirm != nil, m.screen)
 	}
 
 	m = mk()
-	m, cmd := press(t, m, "y")
-	if cmd == nil || !m.loading {
-		t.Fatalf("y should dispatch remove cmd + set loading, cmd=%v loading=%v", cmd, m.loading)
+	m, _ = press(t, m, "right") // -> Confirm
+	m, cmd := press(t, m, "enter")
+	if cmd == nil || !m.loading || m.confirm != nil {
+		t.Fatalf("confirm should dispatch remove cmd + set loading + close, cmd=%v loading=%v confirmOpen=%v", cmd, m.loading, m.confirm != nil)
 	}
 	m, _ = step(t, m, opDoneMsg{verb: "remove", name: "kimi", err: errors.New("boom")})
-	if m.screen != screenResult || !m.resultErr {
-		t.Fatalf("failed op: screen=%d resultErr=%v, want screenResult+true", m.screen, m.resultErr)
+	if m.screen != screenList || m.confirm == nil || !m.confirm.resultErr {
+		t.Fatalf("failed op should pop a red info modal over the list: screen=%d confirmOpen=%v", m.screen, m.confirm != nil)
+	}
+}
+
+// TestDeleteGatedWhileMutationInFlight: d opens no new ask while a mutation is loading —
+// its outcome modal would find the new ask open and be silently swallowed.
+func TestDeleteGatedWhileMutationInFlight(t *testing.T) {
+	m := withVendors(t, userops.VendorView{Name: "kimi", Enabled: true})
+	m.loading = true
+	m, _ = press(t, m, "d")
+	if m.confirm != nil {
+		t.Fatal("d during an in-flight mutation must not open a modal")
+	}
+}
+
+// TestManageKeysGatedWhileMutationInFlight: the manage-keys descent is blocked while a
+// submit is in flight — a key confirm opened in that window would swallow the pending
+// outcome modal.
+func TestManageKeysGatedWhileMutationInFlight(t *testing.T) {
+	m := withVendors(t, userops.VendorView{
+		Name: "glm", BaseURL: "https://api.example/anthropic",
+		ModelsEndpoint: "https://api.example/v1/models", DefaultModel: "m", Enabled: true,
+	})
+	m, _ = press(t, m, "enter") // edit form
+	for i := 0; i < len(m.form.fields) && m.form.focusedKey() != "manage_keys"; i++ {
+		m, _ = press(t, m, "down")
+	}
+	m.loading = true
+	m, cmd := press(t, m, "enter")
+	if m.screen == screenKeys || cmd != nil {
+		t.Fatalf("manage-keys during an in-flight mutation must not open, screen=%d cmd=%v", m.screen, cmd)
+	}
+}
+
+// TestRemoveCodexPromptStatesLoginCleanup: the remove prompt for a codex provider names
+// the login teardown (and ~/.codex safety) instead of the file-secret wording.
+func TestRemoveCodexPromptStatesLoginCleanup(t *testing.T) {
+	m := withVendors(t, userops.VendorView{Name: "codex", Enabled: true, Protocol: config.ProtocolCodexOAuth})
+	m, _ = press(t, m, "d")
+	if m.confirm == nil {
+		t.Fatalf("d should open the remove modal")
+	}
+	if !strings.Contains(m.confirm.prompt, "codex login") || !strings.Contains(m.confirm.prompt, "~/.codex") {
+		t.Fatalf("codex remove prompt = %q, want login-cleanup wording", m.confirm.prompt)
 	}
 }
 
@@ -1671,7 +1732,9 @@ func TestBoardSurfacesHideShowResult(t *testing.T) {
 		t.Fatalf("a failed hide should pop a red info modal, got %+v", m.confirm)
 	}
 	out := m.View()
-	for _, want := range []string{"hide", "alice", panevis.ErrTmuxFailed, "break-pane failed", "check tmux"} {
+	// The outcome line wraps to the modal width, so assert fragments that survive a
+	// wrap point rather than the full sentence.
+	for _, want := range []string{"hide", "alice", panevis.ErrTmuxFailed, "break-pane", "tmux"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("the info modal should surface the failure %q:\n%s", want, out)
 		}
@@ -1722,7 +1785,7 @@ func TestViewsRenderForEveryScreen(t *testing.T) {
 	// Smoke test: every screen must render a non-empty frame without panic.
 	screens := []screen{
 		screenList, screenSpawn, screenPickTemplate,
-		screenForm, screenModelPick, screenRemoveConfirm, screenResult, screenKeys,
+		screenForm, screenModelPick, screenKeys, screenCodexAuth,
 	}
 	for _, s := range screens {
 		m := NewModel()
@@ -1731,8 +1794,6 @@ func TestViewsRenderForEveryScreen(t *testing.T) {
 		m.teammates = []teardown.Teammate{{Name: "a", Team: "t1", Vendor: "v", Model: "m", PaneID: "%1", PID: 1}}
 		m.screen = s
 		m.form = newAddForm(Templates[0])
-		m.removeName = "x"
-		m.result = "done"
 		m.modelList = []models.Model{{ID: "x", OwnedBy: "y"}}
 		m.keyVendor = "x"
 		m.keys = []secrets.KeyEntry{{Label: "key1", Key: "sk-abcdef-123", Enabled: true}}
@@ -1876,15 +1937,83 @@ func TestKeyManagerEditKeyReplacesValueNoPrefill(t *testing.T) {
 		t.Fatalf("edit input prefilled with %q, want empty", got)
 	}
 	m, _ = step(t, m, keyMsg("sk-new-999"))
-	m, cmd := press(t, m, "enter")
+	m, cmd := press(t, m, "enter") // opens the replace confirm, no commit yet
+	if cmd != nil || m.confirm == nil || m.confirm.kind != confirmReplaceKey {
+		t.Fatalf("enter should open the replace modal without saving, cmd=%v kind=%q", cmd, modalKind(m))
+	}
+	if m.keys[0].Key != "sk-old-111" {
+		t.Fatal("value must not change before the confirm")
+	}
+	m, _ = press(t, m, "right")
+	m, cmd = press(t, m, "enter")
 	if cmd == nil {
-		t.Fatal("committing an edit should dispatch a save cmd")
+		t.Fatal("confirming the replace should dispatch a save cmd")
 	}
 	if m.keys[0].Key != "sk-new-999" {
 		t.Fatalf("edited key = %q, want sk-new-999", m.keys[0].Key)
 	}
 	if m.keys[0].Label != "a" || !m.keys[0].Enabled {
-		t.Fatalf("edit should preserve label/enabled: %+v", m.keys[0])
+		t.Fatalf("edit should preserve label/enabled: label=%q enabled=%v", m.keys[0].Label, m.keys[0].Enabled)
+	}
+	if m.keyEditing || m.confirm != nil {
+		t.Fatalf("confirm should end the edit and close the modal")
+	}
+}
+
+// modalKind reads the open modal's kind without dumping the struct (arg may hold a key).
+func modalKind(m Model) string {
+	if m.confirm == nil {
+		return "<nil>"
+	}
+	return m.confirm.kind
+}
+
+// TestKeyReplaceCancelReturnsToInput: Cancel on the replace modal drops back into the
+// still-populated password input; typing while the modal is open never reaches it.
+func TestKeyReplaceCancelReturnsToInput(t *testing.T) {
+	m := keysModel(t, "glm", "off",
+		secrets.KeyEntry{Label: "a", Key: "sk-old-111", Enabled: true})
+	m, _ = press(t, m, "e")
+	m, _ = step(t, m, keyMsg("sk-new-999"))
+	m, _ = press(t, m, "enter") // replace modal opens
+	if m.confirm == nil {
+		t.Fatal("enter should open the replace modal")
+	}
+	m, _ = step(t, m, keyMsg("xxx")) // trapped: must not reach the input
+	if got := m.keyInput.Value(); got != "sk-new-999" {
+		t.Fatalf("input mutated under the modal: %q", got)
+	}
+	m, _ = press(t, m, "enter") // Cancel (default cursor)
+	if m.confirm != nil || !m.keyEditing {
+		t.Fatalf("cancel should close the modal and return to the edit, confirmOpen=%v editing=%v", m.confirm != nil, m.keyEditing)
+	}
+	if got := m.keyInput.Value(); got != "sk-new-999" {
+		t.Fatalf("input lost its value across the cancel: %q", got)
+	}
+	if m.keys[0].Key != "sk-old-111" {
+		t.Fatal("cancel must not change the stored key")
+	}
+}
+
+// TestKeyReplaceMismatchEndsEdit: a keyset refresh that replaces the target under the
+// open modal makes the confirm a no-op (identity check) and ends the edit.
+func TestKeyReplaceMismatchEndsEdit(t *testing.T) {
+	m := keysModel(t, "glm", "off",
+		secrets.KeyEntry{Label: "a", Key: "sk-old-111", Enabled: true})
+	m, _ = press(t, m, "e")
+	m, _ = step(t, m, keyMsg("sk-new-999"))
+	m, _ = press(t, m, "enter")
+	m, _ = step(t, m, keysetMsg{keys: []secrets.KeyEntry{{Label: "a", Key: "sk-other-222", Enabled: true}}})
+	m, _ = press(t, m, "right")
+	m, cmd := press(t, m, "enter")
+	if cmd != nil {
+		t.Fatal("a mismatched confirm must not save")
+	}
+	if m.keys[0].Key != "sk-other-222" {
+		t.Fatalf("mismatched confirm replaced a key: %q", m.keys[0].Key)
+	}
+	if m.keyEditing || m.confirm != nil || m.keyErr == "" {
+		t.Fatalf("mismatch should end the edit + surface keyErr, editing=%v confirmOpen=%v err=%q", m.keyEditing, m.confirm != nil, m.keyErr)
 	}
 }
 
@@ -1895,14 +2024,78 @@ func TestKeyManagerDeleteKeyAndClamp(t *testing.T) {
 	)
 	m, _ = press(t, m, "down") // cursor 1 = key b
 	m, cmd := press(t, m, "d")
+	if cmd != nil || m.confirm == nil || m.confirm.kind != confirmDeleteKey {
+		t.Fatalf("d should open the delete modal without saving, cmd=%v kind=%q", cmd, modalKind(m))
+	}
+	if m.confirm.danger {
+		t.Fatal("deleting one of two enabled keys is not a danger ask")
+	}
+	if len(m.keys) != 2 {
+		t.Fatal("nothing may be deleted before the confirm")
+	}
+	m, _ = press(t, m, "right")
+	m, cmd = press(t, m, "enter")
 	if cmd == nil {
-		t.Fatal("delete should dispatch a save cmd")
+		t.Fatal("confirming the delete should dispatch a save cmd")
 	}
 	if len(m.keys) != 1 || m.keys[0].Label != "a" {
-		t.Fatalf("after delete: keys=%+v, want [a]", m.keys)
+		t.Fatalf("after delete: %d keys, first label %q, want 1 + a", len(m.keys), m.keys[0].Label)
 	}
 	if m.keyCursor != 1 { // now the Add row (len==1)
 		t.Fatalf("cursor = %d, want 1 (clamped onto the Add row)", m.keyCursor)
+	}
+}
+
+// TestKeyDeleteCancelKeepsKey: enter on the default Cancel closes the modal and keeps
+// the key; the list keys stay trapped while the modal is open.
+func TestKeyDeleteCancelKeepsKey(t *testing.T) {
+	m := keysModel(t, "glm", "off",
+		secrets.KeyEntry{Label: "a", Key: "sk-aaa", Enabled: true},
+		secrets.KeyEntry{Label: "b", Key: "sk-bbb", Enabled: true},
+	)
+	m, _ = press(t, m, "d")
+	m, _ = press(t, m, "d") // trapped — must not splice or stack a second modal
+	if m.confirm == nil || len(m.keys) != 2 {
+		t.Fatalf("d under the modal should be swallowed, confirmOpen=%v keys=%d", m.confirm != nil, len(m.keys))
+	}
+	m, cmd := press(t, m, "enter") // Cancel
+	if cmd != nil || m.confirm != nil || len(m.keys) != 2 {
+		t.Fatalf("cancel should keep both keys, cmd=%v confirmOpen=%v keys=%d", cmd, m.confirm != nil, len(m.keys))
+	}
+}
+
+// TestKeyDeleteLastEnabledIsDanger: deleting the only enabled key warns in the danger
+// frame and names the consequence.
+func TestKeyDeleteLastEnabledIsDanger(t *testing.T) {
+	m := keysModel(t, "glm", "off",
+		secrets.KeyEntry{Label: "a", Key: "sk-aaa", Enabled: true},
+		secrets.KeyEntry{Label: "b", Key: "sk-bbb", Enabled: false},
+	)
+	m, _ = press(t, m, "d") // cursor 0 = the only enabled key
+	if m.confirm == nil || !m.confirm.danger {
+		t.Fatalf("deleting the last enabled key should be a danger ask, confirm=%v", m.confirm != nil)
+	}
+	if !strings.Contains(m.confirm.prompt, "last enabled key") {
+		t.Fatalf("danger prompt = %q, want last-enabled wording", m.confirm.prompt)
+	}
+}
+
+// TestKeyDeleteMismatchIsNoOp: a keyset refresh under the open modal fails the identity
+// check — nothing is deleted.
+func TestKeyDeleteMismatchIsNoOp(t *testing.T) {
+	m := keysModel(t, "glm", "off",
+		secrets.KeyEntry{Label: "a", Key: "sk-aaa", Enabled: true},
+		secrets.KeyEntry{Label: "b", Key: "sk-bbb", Enabled: true},
+	)
+	m, _ = press(t, m, "d") // targets key a
+	m, _ = step(t, m, keysetMsg{keys: []secrets.KeyEntry{
+		{Label: "a", Key: "sk-ccc", Enabled: true},
+		{Label: "b", Key: "sk-bbb", Enabled: true},
+	}})
+	m, _ = press(t, m, "right")
+	m, cmd := press(t, m, "enter")
+	if cmd != nil || len(m.keys) != 2 || m.keyErr == "" {
+		t.Fatalf("mismatched delete must no-op + surface keyErr, cmd=%v keys=%d err=%q", cmd, len(m.keys), m.keyErr)
 	}
 }
 
@@ -2053,6 +2246,16 @@ func TestAsyncMsg_NonOwningScreenDrop(t *testing.T) {
 	}
 	if m.modelsErr != nil {
 		t.Fatalf("non-owning screen overwrote modelsErr = %v", m.modelsErr)
+	}
+}
+
+// TestAsyncMsg_PaneVisOffBoardDrop: a hide/show outcome landing after the user left the
+// board is dropped — it must not open its info modal over a hub screen.
+func TestAsyncMsg_PaneVisOffBoardDrop(t *testing.T) {
+	m := withVendors(t, userops.VendorView{Name: "glm"})
+	m, _ = step(t, m, paneVisMsg{res: panevis.Result{OK: true, Action: "hide", Name: "alice"}})
+	if m.confirm != nil {
+		t.Fatal("an off-board paneVisMsg must not open a modal on the hub")
 	}
 }
 
@@ -2266,8 +2469,10 @@ func TestKeyMgr_DeleteFailureReloadsFromDisk(t *testing.T) {
 		secrets.KeyEntry{Label: "b", Key: "sk-bbb", Enabled: true},
 	)
 
-	m, _ = press(t, m, "down") // cursor 1 = key b
-	m, _ = press(t, m, "d")    // delete key b in memory
+	m, _ = press(t, m, "down")  // cursor 1 = key b
+	m, _ = press(t, m, "d")     // delete modal opens
+	m, _ = press(t, m, "right") // -> Confirm
+	m, _ = press(t, m, "enter") // delete key b in memory
 	if len(m.keys) != 1 {
 		t.Fatalf("delete: m.keys len = %d, want 1", len(m.keys))
 	}

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -2,13 +2,38 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/permmode"
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
+
+// The run-permission value colors mirror Claude Code's own permission-mode indicator;
+// default/off stay in the plain body color.
+func TestPermModeStyleMapping(t *testing.T) {
+	want := map[string]lipgloss.Color{
+		permmode.Plan:              "66",
+		permmode.AcceptEdits:       "141",
+		permmode.Auto:              "214",
+		permmode.BypassPermissions: "203",
+	}
+	for mode, c := range want {
+		if got := permModeStyle(mode).GetForeground(); got != c {
+			t.Errorf("permModeStyle(%s) = %v, want %v", mode, got, c)
+		}
+	}
+	for _, plain := range []string{"off", permmode.Default, ""} {
+		if got := permModeStyle(plain).GetForeground(); got != contentStyle.GetForeground() {
+			t.Errorf("permModeStyle(%q) = %v, want the plain body color", plain, got)
+		}
+	}
+}
 
 // Flat-picker item indices (cursor walks the selectable rows across all groups).
 func firstOpenAIIdx() int { return len(Templates) + 1 } // after the Anthropic seeds + their Custom
@@ -94,6 +119,15 @@ func TestAddPicker_CodexRowNoSourceGoesToConsent(t *testing.T) {
 	m, cmd := press(t, m, "enter")               // submit -> commit the row first
 	if cmd == nil || m.codexCommittedName == "" {
 		t.Fatalf("no-source codex submit must commit first: cmd=%v committed=%q", cmd, m.codexCommittedName)
+	}
+	// The committing stage owns the screen for the async add: the form can no longer
+	// be escaped or repopulated, so the login modal's underlay stays the submitted form.
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthCommitting {
+		t.Fatalf("submit must park on committing: screen=%d stage=%d", m.screen, m.codexAuthStage)
+	}
+	m, cmd = press(t, m, "esc") // trapped — no abandon, no form
+	if cmd != nil || m.screen != screenCodexAuth || m.codexCommittedName == "" {
+		t.Fatalf("keys during committing must be swallowed: cmd=%v screen=%d", cmd, m.screen)
 	}
 	m, _ = step(t, m, opDoneMsg{verb: "add", name: m.codexCommittedName}) // add landed -> consent
 	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent {
@@ -221,8 +255,8 @@ func TestCodexAbandonCancelsAndDropsStalePoll(t *testing.T) {
 	if ctx.Err() == nil {
 		t.Fatal("abandon must cancel the session context so an in-flight poll cannot persist a token")
 	}
-	// The in-flight poll's stale-epoch result must be dropped — no success screen.
-	if m2, _ := step(t, m, codexAuthPollMsg{epoch: 3, done: true}); m2.screen == screenResult {
+	// The in-flight poll's stale-epoch result must be dropped — no success outcome.
+	if m2, _ := step(t, m, codexAuthPollMsg{epoch: 3, done: true}); m2.screen != screenCodexAuth || m2.confirm != nil {
 		t.Fatal("a stale-epoch poll-done after abandon must be dropped, not shown as success")
 	}
 }
@@ -240,14 +274,106 @@ func TestCodexChooseSourceBranches(t *testing.T) {
 		m.codexAddRef = codexproxy.SecretRef
 		return m
 	}
-	if m, cmd := press(t, base(), "r"); cmd == nil || !m.loading || m.codexPendingAdd != nil || m.codexCommittedName != "" {
-		t.Fatalf("reuse must commit with no follow-up login: cmd=%v loading=%v pending=%v committed=%q", cmd, m.loading, m.codexPendingAdd, m.codexCommittedName)
+	// enter on the default cursor (0 = reuse) commits with no follow-up login.
+	if m, cmd := press(t, base(), "enter"); cmd == nil || !m.loading || m.codexPendingAdd != nil || m.codexCommittedName != "" || m.codexAuthStage != codexAuthCommitting {
+		t.Fatalf("reuse must commit with no follow-up login and park on committing: cmd=%v loading=%v pending=%v committed=%q stage=%d",
+			cmd, m.loading, m.codexPendingAdd, m.codexCommittedName, m.codexAuthStage)
 	}
-	if m, cmd := press(t, base(), "s"); cmd == nil || m.codexPendingAdd != nil || m.codexCommittedName != "codex" {
-		t.Fatalf("separate login must commit the row first and mark it: cmd=%v pending=%v committed=%q", cmd, m.codexPendingAdd, m.codexCommittedName)
+	// ↓ then enter (cursor 1 = separate login) commits the row first and marks it.
+	m := base()
+	m, _ = press(t, m, "down")
+	if m.codexSourceCursor != 1 {
+		t.Fatalf("down should move the source cursor to 1, got %d", m.codexSourceCursor)
+	}
+	m, _ = press(t, m, "down") // clamped at the last option
+	if m.codexSourceCursor != 1 {
+		t.Fatalf("down past the end should clamp, got %d", m.codexSourceCursor)
+	}
+	m, cmd := press(t, m, "enter")
+	if cmd == nil || m.codexPendingAdd != nil || m.codexCommittedName != "codex" || m.codexAuthStage != codexAuthCommitting {
+		t.Fatalf("separate login must commit the row first, mark it, and park on committing: cmd=%v pending=%v committed=%q stage=%d",
+			cmd, m.codexPendingAdd, m.codexCommittedName, m.codexAuthStage)
 	}
 	if m, _ := press(t, base(), "esc"); m.screen != screenForm || m.codexPendingAdd != nil {
 		t.Fatalf("esc must return to the form and drop the pending add: screen=%d", m.screen)
+	}
+}
+
+// A failed add during the committing stage falls through to the failure modal exactly
+// like any other failed op — no consent detour, marker cleared.
+func TestCodexCommittingFailureRoutesToResult(t *testing.T) {
+	m := NewModel()
+	m.screen = screenCodexAuth
+	m.codexAuthStage = codexAuthCommitting
+	m.codexCommittedName = "codex"
+	m.loading = true
+	m, _ = step(t, m, opDoneMsg{verb: "add", name: "codex", err: errors.New("boom")})
+	if m.screen != screenList || m.confirm == nil || !m.confirm.resultErr || m.codexCommittedName != "" {
+		t.Fatalf("failed committing add: screen=%d confirmOpen=%v committed=%q, want list+red modal+cleared",
+			m.screen, m.confirm != nil, m.codexCommittedName)
+	}
+}
+
+// An opDoneMsg from an earlier, unrelated op (a stale dispatch) arriving during a marked
+// codex commit is dropped outright — the user stays parked on committing (so a second
+// codex commit can never overwrite the marker) and only the committed add's own result
+// drives the flow.
+func TestCodexCommittingIgnoresUnrelatedOpDone(t *testing.T) {
+	m := NewModel()
+	m.screen = screenCodexAuth
+	m.codexAuthStage = codexAuthCommitting
+	m.codexCommittedName = "codex"
+	m.loading = true
+	m, _ = step(t, m, opDoneMsg{verb: "add", name: "other"})
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthCommitting || !m.loading {
+		t.Fatalf("an unrelated result must be dropped, not leave committing: screen=%d stage=%d loading=%v",
+			m.screen, m.codexAuthStage, m.loading)
+	}
+	if m.codexCommittedName != "codex" {
+		t.Fatalf("an unrelated result cleared the marker: %q", m.codexCommittedName)
+	}
+	m, _ = step(t, m, opDoneMsg{verb: "add", name: "codex"})
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent {
+		t.Fatalf("the committed add's result must route to consent: screen=%d stage=%d", m.screen, m.codexAuthStage)
+	}
+	// The guard covers the whole marked flow: a stale unrelated result arriving on the
+	// consent (or device) stage is dropped the same way.
+	m, _ = step(t, m, opDoneMsg{verb: "add", name: "other"})
+	if m.screen != screenCodexAuth || m.codexAuthStage != codexAuthConsent || m.codexCommittedName != "codex" {
+		t.Fatalf("an unrelated result on consent must be dropped: screen=%d stage=%d marker=%q",
+			m.screen, m.codexAuthStage, m.codexCommittedName)
+	}
+}
+
+// The codex login renders as a centered modal over the form base: the device stage shows
+// the verify URL + user code inside the box, the consent stage the risk notice, and the
+// base's footer no longer advertises the form's own keys.
+func TestCodexAuthModalContent(t *testing.T) {
+	m := NewModel()
+	m.screen = screenCodexAuth
+	m.form = newAddForm(Templates[0])
+	m.codexAuthStage = codexAuthDevice
+	m.codexAuth = &codexproxy.LoginSession{VerifyURL: "https://auth.openai.com/codex/device", UserCode: "ABCD-1234"}
+	out := m.View()
+	for _, want := range []string{"https://auth.openai.com/codex/device", "ABCD-1234", "waiting for authorization…"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("device modal missing %q", want)
+		}
+	}
+	if strings.Contains(out, "enter on [Add] submits") {
+		t.Fatal("the form footer must be blanked under the login modal")
+	}
+
+	m.codexAuthStage = codexAuthConsent
+	m.codexAuth = nil
+	out = m.View()
+	if !strings.Contains(out, "device-code login") {
+		t.Fatal("consent modal missing the risk/consent hint")
+	}
+
+	m.codexAuthStage = codexAuthCommitting
+	if out = m.View(); !strings.Contains(out, "adding provider…") {
+		t.Fatal("committing modal missing its wait line")
 	}
 }
 

--- a/internal/tui/screen_handlers.go
+++ b/internal/tui/screen_handlers.go
@@ -21,17 +21,15 @@ type screenHandler struct {
 // package must appear exactly once; TestHandlersRegistry_AllScreensRegistered
 // enumerates the constants and fails if any are missing.
 var handlers = map[screen]screenHandler{
-	screenList:          {update: Model.updateList, view: Model.viewList},
-	screenSpawn:         {update: Model.updateSpawn, view: Model.viewSpawn},
-	screenPickTemplate:  {update: Model.updatePickTemplate, view: Model.viewPickTemplate},
-	screenForm:          {update: Model.updateForm, view: Model.viewForm},
-	screenModelPick:     {update: Model.updateModelPick, view: Model.viewModelPick},
-	screenRemoveConfirm: {update: Model.updateRemoveConfirm, view: Model.viewRemoveConfirm},
-	screenResult:        {update: Model.updateResult, view: Model.viewResult},
-	screenKeys:          {update: Model.updateKeys, view: Model.viewKeys},
-	screenSetupTmux:     {update: Model.updateSetupTmux, view: Model.viewSetupTmux},
-	screenSetup:         {update: Model.updateSetup, view: Model.viewSetup},
-	screenCodexAuth:     {update: Model.updateCodexAuth, view: Model.viewCodexAuth},
+	screenList:         {update: Model.updateList, view: Model.viewList},
+	screenSpawn:        {update: Model.updateSpawn, view: Model.viewSpawn},
+	screenPickTemplate: {update: Model.updatePickTemplate, view: Model.viewPickTemplate},
+	screenForm:         {update: Model.updateForm, view: Model.viewForm},
+	screenModelPick:    {update: Model.updateModelPick, view: Model.viewModelPick},
+	screenKeys:         {update: Model.updateKeys, view: Model.viewKeys},
+	screenSetupTmux:    {update: Model.updateSetupTmux, view: Model.viewSetupTmux},
+	screenSetup:        {update: Model.updateSetup, view: Model.viewSetup},
+	screenCodexAuth:    {update: Model.updateCodexAuth, view: Model.viewCodexAuth},
 }
 
 // allScreens returns every screen constant defined in this package, in the
@@ -44,8 +42,6 @@ func allScreens() []screen {
 		screenPickTemplate,
 		screenForm,
 		screenModelPick,
-		screenRemoveConfirm,
-		screenResult,
 		screenKeys,
 		screenSetupTmux,
 		screenSetup,

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/permmode"
 	"github.com/ethanhq/cc-fleet/internal/pinned"
 	"github.com/ethanhq/cc-fleet/internal/secrets"
 	"github.com/ethanhq/cc-fleet/internal/sessiontitle"
@@ -40,6 +41,23 @@ var (
 // footer renders a dim key-hint line.
 func footer(s string) string { return faintStyle.Render(s) }
 
+// permModeStyle colors a run-permission value the way Claude Code's own permission-mode
+// indicator does: plan teal, acceptEdits violet, auto amber, bypassPermissions the error
+// red; default/off stay in the plain body color.
+func permModeStyle(mode string) lipgloss.Style {
+	switch mode {
+	case permmode.Plan:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("66"))
+	case permmode.AcceptEdits:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("141"))
+	case permmode.Auto:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	case permmode.BypassPermissions:
+		return errStyle
+	}
+	return contentStyle
+}
+
 // View satisfies tea.Model.
 func (m Model) View() string {
 	if m.quitting {
@@ -47,7 +65,11 @@ func (m Model) View() string {
 	}
 	switch m.screen {
 	case screenList:
-		return m.viewList()
+		s := m.viewList()
+		if m.confirm != nil {
+			s = overlayCenter(s, m.renderConfirmBox(), m.width) // remove-provider confirm
+		}
+		return s
 	case screenSpawn:
 		s := m.viewSpawn()
 		switch {
@@ -63,12 +85,12 @@ func (m Model) View() string {
 		return m.viewForm()
 	case screenModelPick:
 		return m.viewModelPick()
-	case screenRemoveConfirm:
-		return m.viewRemoveConfirm()
-	case screenResult:
-		return m.viewResult()
 	case screenKeys:
-		return m.viewKeys()
+		s := m.viewKeys()
+		if m.confirm != nil {
+			s = overlayCenter(s, m.renderConfirmBox(), m.width) // key delete/replace confirm
+		}
+		return s
 	case screenSetup:
 		return m.viewSetup()
 	case screenSetupTmux:
@@ -274,7 +296,7 @@ func vendorDetailLines(v userops.VendorView, rightW int) []string {
 	detailField(&lines, "strong", resolvedSlot(v.StrongModel, v.DefaultModel), rightW)
 	detailField(&lines, "fast", resolvedSlot(v.FastModel, v.DefaultModel), rightW)
 	detailField(&lines, "effort", orOff(v.Effort), rightW)
-	detailField(&lines, "run perm", orOff(v.DefaultPerm), rightW)
+	detailFieldStyled(&lines, "run perm", orOff(v.DefaultPerm), rightW, permModeStyle(v.DefaultPerm))
 	detailField(&lines, "cache", vendorCacheFig(v), rightW)
 	key := v.SecretBackend
 	if v.SecretRef != "" {
@@ -371,11 +393,18 @@ func (m Model) vendorFlowView(ctx, ctxRight, active, rightTitle, hint string, ri
 // viewForm renders the add/edit form inside the hub box: the rail stays put, the right
 // pane is the form, the header carries the form title and the footer its key hints.
 func (m Model) viewForm() string {
+	return m.formBase(m.form.intro)
+}
+
+// formBase renders the form chrome with the given footer hint. The codex login modal
+// overlays this base with a blank hint — the form's own hints would advertise keys the
+// modal has trapped.
+func (m Model) formBase(hint string) string {
 	active, rightTitle := "+", "add provider"
 	if m.formMode == modeEdit {
 		active, rightTitle = m.editName, "edit "+trunc(m.editName, 20)
 	}
-	return m.vendorFlowView(m.form.title, "", active, rightTitle, m.form.intro,
+	return m.vendorFlowView(m.form.title, "", active, rightTitle, hint,
 		func(rightW int) []string { return m.form.viewLines(rightW) })
 }
 
@@ -2279,6 +2308,12 @@ func (m Model) entityDetailLines(rightW int) []string {
 // detailField renders one "key  value" card line set, wrapping a long value to the pane
 // (continuation lines indent under the value column) — the card never truncates a field.
 func detailField(lines *[]string, k, v string, rightW int) {
+	detailFieldStyled(lines, k, v, rightW, contentStyle)
+}
+
+// detailFieldStyled is detailField with a caller-chosen value style (e.g. the
+// permission-mode color on the run-perm row).
+func detailFieldStyled(lines *[]string, k, v string, rightW int, style lipgloss.Style) {
 	if v == "" {
 		v = "—"
 	}
@@ -2287,7 +2322,7 @@ func detailField(lines *[]string, k, v string, rightW int) {
 		if fi > 0 {
 			key = strings.Repeat(" ", 8)
 		}
-		*lines = append(*lines, " "+faintStyle.Render(key)+"  "+contentStyle.Render(w))
+		*lines = append(*lines, " "+faintStyle.Render(key)+"  "+style.Render(w))
 	}
 }
 
@@ -2848,67 +2883,94 @@ func (m Model) addItemDetail() []string {
 	}
 }
 
+// viewCodexAuth renders the codex login flow as a centered modal over the still-populated
+// add form; the base's footer hint is blanked so it can't advertise keys the modal traps.
 func (m Model) viewCodexAuth() string {
-	if m.codexAuthStage == codexAuthChooseSource {
-		return m.vendorFlowView("Add codex provider · source", "", "+", "codex login",
-			"r reuse · s separate login · esc cancel", func(rightW int) []string {
-				detected := "A codex subscription is signed in on this system"
-				if m.codexAuthAccount != "" {
-					detected += " (account " + m.codexAuthAccount + ")"
-				}
-				return []string{
-					contentStyle.Render(detected + "."), "",
-					contentStyle.Render("  r  reuse it — no separate login needed"),
-					contentStyle.Render("  s  log in separately — cc-fleet keeps its own login"),
-				}
-			})
-	}
-	if m.codexAuthStage == codexAuthDevice {
-		return m.vendorFlowView("Add codex provider · authorize", "", "+", "device login",
-			"esc cancel", func(rightW int) []string {
-				var lines []string
-				if m.codexAuth != nil {
-					lines = append(lines,
-						contentStyle.Render("Open this URL and enter the code:"), "",
-						"  "+selectedStyle.Render(m.codexAuth.VerifyURL),
-						"  code: "+selectedStyle.Render(m.codexAuth.UserCode), "",
-						faintStyle.Render("  waiting for authorization…"))
-				} else {
-					lines = append(lines, faintStyle.Render("  starting device login…"))
-				}
-				if m.codexAuthErr != "" {
-					lines = append(lines, "", errStyle.Render("  "+m.codexAuthErr))
-				}
-				return lines
-			})
-	}
-	return m.vendorFlowView("Add codex provider · consent", "", "+", "account risk",
-		"enter accept · esc cancel", func(rightW int) []string {
-			var lines []string
-			for _, seg := range strings.Split(codexproxy.RiskNotice, "\n") {
-				for _, w := range wrapTo(seg, rightW-2) {
-					lines = append(lines, contentStyle.Render(w))
-				}
-			}
-			lines = append(lines, "", faintStyle.Render("enter starts the device-code login · esc cancels"))
-			if m.codexAuthErr != "" {
-				lines = append(lines, "", errStyle.Render(m.codexAuthErr))
-			}
-			return lines
-		})
+	return overlayCenter(m.formBase(""), m.renderCodexAuthBox(), m.width)
 }
 
-func (m Model) viewRemoveConfirm() string {
-	return m.vendorFlowView("Remove provider", "", m.removeName, "confirm "+trunc(m.removeName, 18),
-		"y confirm · n/esc cancel", func(rightW int) []string {
-			msg := "Remove " + m.removeName +
-				" from vendors.toml, delete its profile, and (for file backend) its secret?"
-			var lines []string
-			for _, w := range wrapTo(msg, rightW-2) {
-				lines = append(lines, contentStyle.Render(w))
+// renderCodexAuthBox is the codex login modal's bordered body, branched on the stage:
+// the committing wait, the source choice, the risk-notice consent, or the device-code
+// display with its polling line. Stage key hints live inside the box; a login error
+// appends in red and re-tints the border.
+func (m Model) renderCodexAuthBox() string {
+	// Inner width budget: wide enough that the fixed verify URL never wraps (38 cols),
+	// capped so the box stays a modal on wide terminals.
+	w := m.width - 12
+	if w < 40 {
+		w = 40
+	}
+	if w > 64 {
+		w = 64
+	}
+	var lines []string
+	body := func(s string) {
+		for _, l := range wrapTo(s, w) {
+			lines = append(lines, contentStyle.Render(l))
+		}
+	}
+	switch m.codexAuthStage {
+	case codexAuthCommitting:
+		lines = append(lines, faintStyle.Render("adding provider…"))
+	case codexAuthChooseSource:
+		detected := "A codex subscription is signed in on this system"
+		if m.codexAuthAccount != "" {
+			detected += " (account " + m.codexAuthAccount + ")"
+		}
+		body(detected + ".")
+		lines = append(lines, "")
+		opts := []string{
+			"reuse it — no separate login needed",
+			"log in separately — cc-fleet keeps its own login",
+		}
+		for i, opt := range opts {
+			sel := i == m.codexSourceCursor
+			st := contentStyle
+			if sel {
+				st = selectedStyle
 			}
-			return lines
-		})
+			for j, l := range wrapTo(opt, w-2) {
+				marker := "  "
+				if sel && j == 0 {
+					marker = cursorStyle.Render("> ")
+				}
+				lines = append(lines, marker+st.Render(l))
+			}
+		}
+		lines = append(lines, "",
+			faintStyle.Render("↑/↓ move · enter select · esc cancel"))
+	case codexAuthDevice:
+		if m.codexAuth != nil {
+			lines = append(lines,
+				contentStyle.Render("Open this URL and enter the code:"), "",
+				"  "+selectedStyle.Render(m.codexAuth.VerifyURL),
+				"  code: "+selectedStyle.Render(m.codexAuth.UserCode), "",
+				faintStyle.Render("waiting for authorization…"))
+		} else {
+			lines = append(lines, faintStyle.Render("starting device login…"))
+		}
+		lines = append(lines, "", faintStyle.Render("esc cancel"))
+	default: // codexAuthConsent
+		for _, seg := range strings.Split(codexproxy.RiskNotice, "\n") {
+			body(seg)
+		}
+		lines = append(lines, "", faintStyle.Render("enter starts the device-code login · esc cancels"))
+	}
+	if m.codexAuthErr != "" {
+		lines = append(lines, "")
+		for _, l := range wrapTo(m.codexAuthErr, w) {
+			lines = append(lines, errStyle.Render(l))
+		}
+	}
+	border := confirmAmber
+	if m.codexAuthErr != "" {
+		border = lipgloss.Color("203")
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(border).
+		Padding(0, 3).
+		Render(strings.Join(lines, "\n"))
 }
 
 // tmuxOptions are the two choices on the tmux setup screen, in cursor order
@@ -2976,25 +3038,6 @@ func (m Model) viewSetup() string {
 	b.WriteString(renderSetupOptions(setupOptions, m.setupCursor))
 	b.WriteString("\n" + footer("↑/↓ move · enter select · esc skip"))
 	return b.String()
-}
-
-func (m Model) viewResult() string {
-	return m.vendorFlowView("", "", "", "result", "press any key to return",
-		func(rightW int) []string {
-			mark, style := "✓ ", okStyle
-			if m.resultErr {
-				mark, style = "✗ ", errStyle
-			}
-			var lines []string
-			for fi, w := range wrapTo(m.result, rightW-4) {
-				if fi == 0 {
-					lines = append(lines, style.Render(mark+w))
-				} else {
-					lines = append(lines, style.Render("  "+w))
-				}
-			}
-			return lines
-		})
 }
 
 func (m Model) viewModelPick() string {


### PR DESCRIPTION
The provider hub still carried full-screen takeover prompts and inline destructive actions from before the board's centered modal system existed. This PR routes them all through the same modal, so every transient prompt and outcome in the TUI behaves one way.

- The codex device login renders as a centered modal over the still-populated add form: a new committing stage owns the screen while the row commits (closing a window where the form could be escaped or repopulated mid-commit), then consent and the device-code wait follow in the same box. The source choice (reuse a detected ~/.codex login vs a separate login) is a cursor-selected list. The login state machine, message ownership, epoch gating, and the commit-before-login/rollback ordering are unchanged.
- Removing a provider asks through the standard confirm modal over the list; the dedicated full-screen confirm screen is gone, and the prompt states the real consequences per provider class (a codex remove tears down cc-fleet's own login when unreferenced and never touches ~/.codex).
- API-key delete and replace confirm before acting — previously `d` deleted immediately and an edit commit overwrote the unrecoverable value with no prompt. Deleting the last enabled key warns in the danger frame, and the confirmed action re-validates the target by index plus the captured key value so a keyset refresh under the modal can't hit the wrong row; the captured value never renders.
- Operation outcomes (add/edit/remove results, codex login success) pop as green/red info modals over the reloading provider list; the result screen is deleted. Ask-openers that could race an in-flight mutation's outcome are gated so no result is silently swallowed.
- Run-permission values render in Claude Code's own permission-indicator palette (plan teal, acceptEdits violet, auto amber, bypassPermissions red) on the form's choice row and the preview card.
- paneVisMsg becomes screen-owned like every other board outcome message, so a hide/show result landing after leaving the board can't pop a stale modal on the hub.

No spawn, lock, or network surface is touched — the change is internal/tui only. Full -race across all packages, gofmt/vet, darwin and windows cross-compiles, and live tmux passes of every modal surface (including a real device-code begin with esc rollback) are green.