### PR TITLE
feat(tui): light-background palette + --verbose step tracing

### DIFF
--- a/cmd/cc-fleet/main.go
+++ b/cmd/cc-fleet/main.go
@@ -7,8 +7,22 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ethanhq/cc-fleet/internal/diag"
 	"github.com/ethanhq/cc-fleet/internal/version"
 )
+
+// verboseFlag backs the root --verbose persistent flag. Commands read it at
+// RunE time through diagLogger; it is never consulted before Execute parses.
+var verboseFlag bool
+
+// diagLogger returns the command's --verbose diagnostic sink: stderr when the
+// flag is set, else nil (a nil *diag.Logger is a no-op everywhere downstream).
+func diagLogger(cmd *cobra.Command) *diag.Logger {
+	if !verboseFlag {
+		return nil
+	}
+	return diag.New(cmd.ErrOrStderr())
+}
 
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
@@ -27,7 +41,7 @@ teammate Claude Code sessions inside tmux windows.`,
 		// falls through to help so scripts and agents never block. Subcommands
 		// bypass this entirely — cobra only calls root Run when none matched.
 		Run: func(cmd *cobra.Command, args []string) {
-			handled, err := runTUIIfInteractive(args)
+			handled, err := runTUIIfInteractive(args, verboseFlag)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "cc-fleet:", err)
 				os.Exit(1)
@@ -38,6 +52,8 @@ teammate Claude Code sessions inside tmux windows.`,
 			_ = cmd.Help()
 		},
 	}
+	root.PersistentFlags().BoolVar(&verboseFlag, "verbose", false,
+		"step-trace diagnostics: stderr for commands, a 0600 log file for the TUI")
 	root.AddCommand(newKeygetCmd())
 	root.AddCommand(newRefreshFingerprintCmd())
 	root.AddCommand(newSpawnCmd())

--- a/cmd/cc-fleet/spawn.go
+++ b/cmd/cc-fleet/spawn.go
@@ -91,6 +91,7 @@ profile that lazily fetches the vendor key.`,
 				LeadSessionID:          leadSessionID,
 				PermissionModeOverride: permOverride,
 				Verify:                 verify,
+				Diag:                   diagLogger(cmd),
 			}
 			res := spawn.Spawn(req)
 			return reportSpawn(res, asJSON)

--- a/cmd/cc-fleet/subagent.go
+++ b/cmd/cc-fleet/subagent.go
@@ -178,6 +178,7 @@ suggestion names the spent cost and how to retry (raise the cap or switch model)
 				NoSkills:       noSkills,
 				MCP:            mcp,
 				PersistIO:      !noPersistIO,
+				Diag:           diagLogger(cmd),
 			}
 			if req.PersistIO {
 				// The .prompt sidecar needs the text in hand; a --prompt-file /

--- a/cmd/cc-fleet/teardown.go
+++ b/cmd/cc-fleet/teardown.go
@@ -44,7 +44,7 @@ skill flows don't fail on retries.`,
 			target := args[0]
 			var res teardown.Result
 			if strings.HasPrefix(target, "%") {
-				res = teardown.TeardownPane(target)
+				res = teardown.TeardownPane(target, diagLogger(cmd))
 			} else {
 				// Team names flow into filesystem paths; reject path traversal /
 				// separators / absolute paths via the typed constructor before
@@ -57,7 +57,7 @@ skill flows don't fail on retries.`,
 						ErrorMsg:  err.Error(),
 					}
 				} else {
-					res = teardown.TeardownTeam(target)
+					res = teardown.TeardownTeam(target, diagLogger(cmd))
 				}
 			}
 			return reportTeardown(res, asJSON)

--- a/cmd/cc-fleet/tui.go
+++ b/cmd/cc-fleet/tui.go
@@ -32,7 +32,7 @@ func shouldEnterTUI(args []string, stdinTTY, stdoutTTY bool) bool {
 // tui.NewModel opens on a setup screen when needed. Because the TUI is gated here
 // to the bare-interactive both-TTY path, spawn/subagent/piped/agent callers never
 // see the setup screens.
-func runTUIIfInteractive(args []string) (handled bool, err error) {
+func runTUIIfInteractive(args []string, verbose bool) (handled bool, err error) {
 	stdinTTY := term.IsTerminal(os.Stdin.Fd())
 	stdoutTTY := term.IsTerminal(os.Stdout.Fd())
 	if !shouldEnterTUI(args, stdinTTY, stdoutTTY) {
@@ -42,5 +42,5 @@ func runTUIIfInteractive(args []string) (handled bool, err error) {
 	// newer release is cached. Gated to exactly this bare-interactive path, so
 	// keyget / subagent / spawn / --json / non-TTY callers never reach it.
 	maybePromptUpdate()
-	return true, tui.Run()
+	return true, tui.Run(verbose)
 }

--- a/internal/codexproxy/daemon.go
+++ b/internal/codexproxy/daemon.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/childenv"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/diag"
 	"github.com/ethanhq/cc-fleet/internal/fileutil"
 	"github.com/ethanhq/cc-fleet/internal/procintrospect"
 )
@@ -146,14 +147,15 @@ func EnsureForVendorName(name string) error {
 	if err != nil {
 		return err
 	}
-	return EnsureForVendor(cfg.Vendors[name])
+	return EnsureForVendor(cfg.Vendors[name], nil)
 }
 
 // EnsureForVendor ensures the proxy daemon is up for a daemon-backed provider (a
 // no-op for an Anthropic-native vendor). Call it after the fingerprint gate and
 // before the profile write. Keys on the normalized protocol so a codex row
 // predating the protocol field (codex-oauth backend, no protocol) is recognized.
-func EnsureForVendor(v *config.Vendor) error {
+// dg is the --verbose step-trace sink (nil = silent).
+func EnsureForVendor(v *config.Vendor, dg *diag.Logger) error {
 	if v == nil || !v.DaemonBacked() {
 		return nil
 	}
@@ -172,7 +174,7 @@ func EnsureForVendor(v *config.Vendor) error {
 			}
 		}
 	}
-	return EnsureDaemon(port, v.EffectiveProtocol(), v.UpstreamURL, ref)
+	return EnsureDaemon(port, v.EffectiveProtocol(), v.UpstreamURL, ref, dg)
 }
 
 // EnsureDaemon makes the proxy daemon for (port, protocol, upstreamURL) reachable,
@@ -181,7 +183,7 @@ func EnsureForVendor(v *config.Vendor) error {
 // visible. A live daemon is reused only if its persisted identity matches; a
 // mismatch is torn down and restarted. Slot it after the fingerprint gate and
 // before the profile-write side effect.
-func EnsureDaemon(port int, protocol, upstreamURL, ref string) error {
+func EnsureDaemon(port int, protocol, upstreamURL, ref string, dg *diag.Logger) error {
 	if protocol == config.ProtocolCodexOAuth {
 		if err := withSecretLock(func() error { _, e := loadOrCreateSecret(); return e }); err != nil {
 			return err
@@ -189,13 +191,18 @@ func EnsureDaemon(port int, protocol, upstreamURL, ref string) error {
 	}
 	return withProxyLock(port, func() error {
 		if !healthy(port, protocol, upstreamURL, ref) {
+			dg.Logf("daemon: port %d not serving this identity — (re)starting", port)
 			stopStaleDaemon(port)
 			if err := startDetached(port, protocol, upstreamURL, ref); err != nil {
 				return err
 			}
+			dg.Logf("daemon: started detached on port %d", port)
 			if err := waitReady(port); err != nil {
 				return err
 			}
+			dg.Logf("daemon: ready on port %d", port)
+		} else {
+			dg.Logf("daemon: reusing live daemon on port %d", port)
 		}
 		return registerLease(port)
 	})

--- a/internal/codexproxy/misc_test.go
+++ b/internal/codexproxy/misc_test.go
@@ -119,13 +119,13 @@ func TestEnsureForVendor_RejectsNonLoopback(t *testing.T) {
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			v := &config.Vendor{SecretBackend: SecretBackend, BaseURL: c.base, ModelsEndpoint: c.models}
-			if err := EnsureForVendor(v); (err != nil) != c.wantErr {
+			if err := EnsureForVendor(v, nil); (err != nil) != c.wantErr {
 				t.Fatalf("EnsureForVendor err=%v, wantErr=%v", err, c.wantErr)
 			}
 		})
 	}
 	// A non-codex vendor is always a no-op, even with a remote base_url.
-	if err := EnsureForVendor(&config.Vendor{SecretBackend: "file", BaseURL: "https://api.example.com/"}); err != nil {
+	if err := EnsureForVendor(&config.Vendor{SecretBackend: "file", BaseURL: "https://api.example.com/"}, nil); err != nil {
 		t.Fatalf("non-codex vendor must be a no-op, got %v", err)
 	}
 }

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,50 @@
+// Package diag is the --verbose diagnostic sink: a tiny injected logger that
+// timestamps, redacts, and serializes step-trace lines. It is dependency-injected
+// (never a package global) so one process can hold different sinks — the CLI
+// writes stderr, the TUI a 0600 log file. A nil *Logger is a no-op, so callers
+// thread it unguarded; a nil logger and a discard-backed one are behaviorally
+// identical except for the writes.
+package diag
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/redact"
+)
+
+// Logger writes one redacted, timestamped line per Logf call. The mutex
+// serializes concurrent Logf calls so their lines never interleave — the
+// spawn / subagent / teardown orchestrators thread one Logger across
+// concurrent leaves. The Logger never closes its writer; whoever opened the
+// underlying file owns its lifecycle.
+type Logger struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// New returns a Logger over w, or nil for a nil writer.
+func New(w io.Writer) *Logger {
+	if w == nil {
+		return nil
+	}
+	return &Logger{w: w}
+}
+
+// Logf formats one diagnostic line, masks key-like material, prefixes a
+// wall-clock timestamp, and writes it under the lock. Write errors are
+// dropped — diagnostics never fail the operation they trace. Callers start
+// format with a short component tag ("spawn: …") so interleaved traces stay
+// legible.
+func (l *Logger) Logf(format string, args ...any) {
+	if l == nil {
+		return
+	}
+	line := redact.MaskKeyLikeString(fmt.Sprintf(format, args...))
+	stamp := time.Now().Format("15:04:05.000")
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(l.w, "%s %s\n", stamp, line)
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,66 @@
+package diag
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var lineRE = regexp.MustCompile(`^\d{2}:\d{2}:\d{2}\.\d{3} spawn: step$`)
+
+func TestLogfFormat(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf)
+	l.Logf("spawn: %s", "step")
+	got := strings.TrimSuffix(buf.String(), "\n")
+	if !lineRE.MatchString(got) {
+		t.Fatalf("line %q does not match timestamp+message shape", got)
+	}
+}
+
+func TestLogfMasksKeyLike(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf)
+	l.Logf("probe with sk-abcdef1234567890")
+	if strings.Contains(buf.String(), "sk-abcdef1234567890") {
+		t.Fatalf("key-like material leaked: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "sk-[REDACTED]") {
+		t.Fatalf("expected redaction placeholder, got %q", buf.String())
+	}
+}
+
+func TestNilLoggerNoOp(t *testing.T) {
+	var l *Logger
+	l.Logf("never written %s", "anywhere") // must not panic
+	if New(nil) != nil {
+		t.Fatal("New(nil) must return a nil Logger")
+	}
+}
+
+func TestConcurrentLogfLinesIntact(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				l.Logf("worker line")
+			}
+		}()
+	}
+	wg.Wait()
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if len(lines) != 16*50 {
+		t.Fatalf("expected %d lines, got %d", 16*50, len(lines))
+	}
+	for _, ln := range lines {
+		if !strings.HasSuffix(ln, " worker line") {
+			t.Fatalf("interleaved/corrupt line: %q", ln)
+		}
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -107,7 +107,7 @@ func Run(req Request) error {
 	// For a codex provider, ensure the conversion daemon is up before the profile
 	// write (and before the exec that replaces this process — there is no
 	// after-exec hook), fail-before-mutation.
-	if err := codexproxy.EnsureForVendor(v); err != nil {
+	if err := codexproxy.EnsureForVendor(v, nil); err != nil {
 		return fmt.Errorf("codex proxy unavailable: %w", err)
 	}
 

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -165,11 +165,13 @@ func Spawn(req Request) Result {
 	//    lazily-started conversion daemon, so probing here (before 5c starts it)
 	//    would always fail — daemon readiness at 5c is the real health signal. An
 	//    openai-* provider still probes (its models_endpoint is the real upstream).
+	dg := req.Diag
 	if req.Probe && v.EffectiveProtocol() != config.ProtocolCodexOAuth {
 		if res := probeVendor(v); res != nil {
 			res.Vendor = req.Vendor
 			return *res
 		}
+		dg.Logf("spawn: probe %s ok", req.Vendor)
 	}
 
 	// 5. Resolve the spawn recipe: the user's probed fingerprint if present,
@@ -206,6 +208,7 @@ func Spawn(req Request) Result {
 			req.Vendor,
 			"Skill's self-heal probe re-captures the recipe")
 	}
+	dg.Logf("spawn: fingerprint gate ok (binary %s)", binPath)
 	// The post-spawn settle check runs only when the caller opted in (req.Verify)
 	// AND the live CC is newer than the recipe (then a flag/env may have drifted).
 	// Short-circuit on req.Verify first so a --no-verify spawn never pays for
@@ -216,7 +219,7 @@ func Spawn(req Request) Result {
 	// 5c. For a codex provider, ensure the conversion daemon is up — after the
 	//     fingerprint gate, before the profile write and the tmux split, so a
 	//     daemon failure is fail-before-mutation (no profile, no pane).
-	if err := ensureVendorProxy(v); err != nil {
+	if err := ensureVendorProxy(v, dg); err != nil {
 		return fail(ErrCodeProxyUnavailable, err.Error(), req.Vendor,
 			"Conversion daemon failed to start — for codex run cc-fleet codex login (add --credential <name> for an extra one); otherwise free the base_url port, then retry")
 	}
@@ -228,6 +231,7 @@ func Spawn(req Request) Result {
 			fmt.Sprintf("write profile for %s: %v", req.Vendor, err),
 			req.Vendor, "")
 	}
+	dg.Logf("spawn: profile written %s", profilePath)
 
 	// 7. Resolve the tmux split target. Priority:
 	//      1. req.Target (--target) — explicit caller override, highest.
@@ -294,7 +298,9 @@ func Spawn(req Request) Result {
 	// permSource escapes the lock so the success Result can report where the
 	// teammate's permission flags came from.
 	var permSource string
+	dg.Logf("spawn: target %q (swarm=%v)", tmuxSession, swarm)
 	lockErr := config.WithTeamLock(req.Team, func() error {
+		dg.Logf("spawn: team lock acquired %s", req.Team)
 		// 8a. Ensure team dir + config.json. ErrTeamNotFound is fine if
 		//     AutoTeam is true — we create the team config below.
 		tc, loadErr := LoadTeamConfig(req.Team)
@@ -398,6 +404,7 @@ func Spawn(req Request) Result {
 		}); splitErr != nil {
 			return fmt.Errorf("split-window: %w", splitErr)
 		}
+		dg.Logf("spawn: pane %s split (socket %q)", paneID, swarmSocket)
 
 		// Persist the swarm socket name into the team config (under Raw) so a
 		// later teardown / ps can find the private server and reap it — without
@@ -451,13 +458,16 @@ func Spawn(req Request) Result {
 		// KillServer for swarm, and reap any reparented claude process by agent id.
 		// The lock is still held so no concurrent spawn can grab the same pane id.
 		if err := writeTeamConfigFn(req.Team, tc); err != nil {
+			dg.Logf("spawn: team config write failed — rolling back pane %s", paneID)
 			rollbackPane(paneID, swarm, swarmSocket, agentID, swarmCreatedServer)
 			return fmt.Errorf("write team config: %w", err)
 		}
+		dg.Logf("spawn: member %s recorded", agentID)
 
 		// 8g. Pre-create the inbox file so the new teammate's first
 		//     SendMessage doesn't race against an empty path.
 		if err := ensureInboxFn(req.Team, req.AgentName); err != nil {
+			dg.Logf("spawn: inbox ensure failed — rolling back pane %s", paneID)
 			rollbackPane(paneID, swarm, swarmSocket, agentID, swarmCreatedServer)
 			// WriteTeamConfig already persisted the new member + (swarm)
 			// tmuxSocket to disk. rollbackPane only undoes live pane / process
@@ -516,6 +526,7 @@ func Spawn(req Request) Result {
 		settleSocket = swarmSocket
 	}
 	if runSettle && !settleOK(settleSocket, paneID) {
+		dg.Logf("spawn: settle failed — rolling back %s", agentID)
 		rollbackSpawnedMember(req.Team, req.AgentName, paneID, swarm, swarmSocket, agentID, swarmCreatedServer)
 		return fail(ErrCodeSpawnDidNotSettle,
 			fmt.Sprintf("teammate %s exited during startup — likely a spawn-recipe mismatch on a Claude Code newer than the bundled recipe (%s)",
@@ -524,6 +535,7 @@ func Spawn(req Request) Result {
 			"Run the skill's self-heal probe to capture the current recipe, then retry the spawn")
 	}
 
+	dg.Logf("spawn: ok %s pane %s", agentID, paneID)
 	res := Result{
 		OK:                    true,
 		AgentID:               agentID,

--- a/internal/spawn/spawn_codex_test.go
+++ b/internal/spawn/spawn_codex_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/diag"
 )
 
 // codexStanza returns a vendors.toml stanza for a codex provider whose
@@ -44,7 +45,7 @@ func TestSpawn_CodexSkipsProbe_EnsuresDaemon(t *testing.T) {
 	f.writeFingerprint()
 
 	var ensured atomic.Int32
-	ensureVendorProxy = func(v *config.Vendor) error {
+	ensureVendorProxy = func(v *config.Vendor, _ *diag.Logger) error {
 		if v == nil || v.SecretBackend != codexproxy.SecretBackend {
 			t.Errorf("ensureVendorProxy got a non-codex vendor: %+v", v)
 		}
@@ -72,7 +73,7 @@ func TestSpawn_CodexDaemonFailure_FailsBeforeMutation(t *testing.T) {
 	f.writeVendorsTOML(codexStanza("http://127.0.0.1:17222"))
 	f.writeFingerprint()
 
-	ensureVendorProxy = func(*config.Vendor) error {
+	ensureVendorProxy = func(*config.Vendor, *diag.Logger) error {
 		return fmt.Errorf("codex proxy did not become ready on port 17222")
 	}
 	t.Cleanup(func() { ensureVendorProxy = codexproxy.EnsureForVendor })

--- a/internal/spawn/types.go
+++ b/internal/spawn/types.go
@@ -7,6 +7,8 @@
 // Keep the JSON tags stable — they are part of the spawn contract.
 package spawn
 
+import "github.com/ethanhq/cc-fleet/internal/diag"
+
 // Request is the input to Spawn. Zero values for optional fields fall back to
 // the documented defaults.
 type Request struct {
@@ -64,6 +66,10 @@ type Request struct {
 	// the value and rejects --permission-mode + --dangerously-skip-permissions
 	// together before this reaches Spawn.
 	PermissionModeOverride string
+
+	// Diag is the --verbose step-trace sink. nil (the default) is a no-op;
+	// a logger changes nothing but the diagnostic writes.
+	Diag *diag.Logger
 }
 
 // Result is the structured outcome of Spawn. On success ok=true and the

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -215,6 +215,9 @@ func launchBackground(req Request, binaryPath, profilePath, model, effective, do
 		return fail(ErrCodeFailed, fmt.Sprintf("start background subagent: %v", err), req.Vendor, "")
 	}
 	pid := cmd.Process.Pid
+	// Launch metadata only: the parent Releases the child below and never
+	// observes its reap/finalize/classify.
+	req.Diag.Logf("subagent: background job %s started (pid %d, captures %s)", jobID, pid, outPath)
 
 	meta := jobMeta{
 		JobID:     jobID,
@@ -261,6 +264,7 @@ func launchBackground(req Request, binaryPath, profilePath, model, effective, do
 
 	// Detach: stop tracking the child so the parent can exit cleanly.
 	_ = cmd.Process.Release()
+	req.Diag.Logf("subagent: background job %s detached", jobID)
 
 	return Result{
 		OK:            true,

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -106,6 +106,7 @@ func Run(parent context.Context, req Request) Result {
 	if errRes := validateSlimArgs(req); errRes != nil {
 		return *errRes
 	}
+	dg := req.Diag
 
 	// 1. Load vendor config.
 	cfg, err := config.Load()
@@ -153,11 +154,12 @@ func Run(parent context.Context, req Request) Result {
 			err.Error(),
 			req.Vendor, suggestionFor(ErrCodeFingerprintStale))
 	}
+	dg.Logf("subagent: fingerprint gate ok (binary %s)", binPath)
 
 	// 3b. For a codex provider, ensure the conversion daemon is up — after the
 	//     fingerprint gate, before the profile write, so a daemon failure is
 	//     fail-before-mutation and leaves no profile behind.
-	if err := ensureVendorProxy(v); err != nil {
+	if err := ensureVendorProxy(v, dg); err != nil {
 		return fail(ErrCodeProxyUnavailable, err.Error(), req.Vendor, suggestionFor(ErrCodeProxyUnavailable))
 	}
 
@@ -173,6 +175,7 @@ func Run(parent context.Context, req Request) Result {
 		return fail(ErrCodeFailed, fmt.Sprintf("write profile for %s: %v", req.Vendor, err),
 			req.Vendor, "")
 	}
+	dg.Logf("subagent: profile written %s", profilePath)
 
 	// 5. Optional reachability probe (default OFF). Shares spawn's classifier;
 	//    on Block we abort, on Warn we note and proceed.
@@ -231,7 +234,12 @@ func Run(parent context.Context, req Request) Result {
 		return res
 	}
 	argv := buildArgv(fp.BinaryPath, profilePath, model, req, slim)
-	env := childenv.Clean(os.Environ())
+	hostEnv := os.Environ()
+	env := childenv.Clean(hostEnv)
+	// Counts only — argv carries the prompt/schema and env carries arbitrary
+	// user values, so neither is ever logged.
+	dg.Logf("subagent: job %s argv %d args; env %d→%d after cred/marker scrub",
+		jobID, len(argv), len(hostEnv), len(env))
 	if effective == ProfileSlimRO {
 		env = append(env, "CLAUDE_CODE_DISABLE_CLAUDE_MDS=1")
 	}
@@ -273,6 +281,7 @@ func Run(parent context.Context, req Request) Result {
 	defer cancel()
 	stdout, stderr, exitCode, runErr := runClaude(ctx, fp.BinaryPath, argv, env, req.PromptReader, req.WorkingDir, act)
 	timedOut := errors.Is(ctx.Err(), context.DeadlineExceeded)
+	dg.Logf("subagent: claude exited code %d (timeout=%v)", exitCode, timedOut)
 
 	// A cancelled parent (the workflow engine aborting its run) is a STOP, not a
 	// failure or a timeout — classify it ahead of everything else so the job

--- a/internal/subagent/subagent_codex_test.go
+++ b/internal/subagent/subagent_codex_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/diag"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 )
 
@@ -52,7 +53,7 @@ added_at        = 2026-06-08T05:00:00Z
 		t.Fatal(err)
 	}
 
-	ensureVendorProxy = func(*config.Vendor) error {
+	ensureVendorProxy = func(*config.Vendor, *diag.Logger) error {
 		return errors.New("codex proxy did not become ready on port 17222")
 	}
 	t.Cleanup(func() { ensureVendorProxy = codexproxy.EnsureForVendor })

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"io"
 	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/diag"
 )
 
 // Request is the input to Run. Zero values fall back to the documented
@@ -110,6 +112,10 @@ type Request struct {
 	// an older claude fails the leaf with the ordinary classified usage error.
 	// Workflow-engine-only: the bare CLI exposes no schema flag.
 	JSONSchema string
+
+	// Diag is the --verbose step-trace sink. nil (the default) is a no-op;
+	// a logger changes nothing but the diagnostic writes.
+	Diag *diag.Logger
 }
 
 // Usage mirrors the token-usage subset of claude's inner envelope we surface.

--- a/internal/subagent/verbose_unix_test.go
+++ b/internal/subagent/verbose_unix_test.go
@@ -1,0 +1,118 @@
+//go:build !windows
+
+package subagent
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/diag"
+	"github.com/ethanhq/cc-fleet/internal/fingerprint"
+)
+
+// A verbose sync run traces its steps WITHOUT leaking the prompt, argv values,
+// or any secret — including a key that matches none of the redact patterns
+// (the allowlist, not the regex, is the guarantee).
+func TestRun_VerboseTraceAllowlist(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	writeMinimalVendors(t, xdg)
+
+	// A non-pattern canary secret on disk where the vendor's secret_ref points.
+	const canaryKey = "TOPSECRET-nonpattern-9f7e2b"
+	secretsDir := filepath.Join(xdg, "cc-fleet", "secrets")
+	if err := os.MkdirAll(secretsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretsDir, "glm.key"), []byte(canaryKey), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeClaude := writeFakeBin(t, "#!/bin/sh\nprintf '%s' '"+smokeSuccessJSON+"'\nexit 0\n")
+	orig := loadFP
+	loadFP = func() (*fingerprint.Fingerprint, error) {
+		return &fingerprint.Fingerprint{BinaryPath: fakeClaude}, nil
+	}
+	t.Cleanup(func() { loadFP = orig })
+
+	const promptCanary = "prompt-text-canary-31c8"
+	var buf bytes.Buffer
+	res := Run(context.Background(), Request{
+		Vendor: "glm", Prompt: promptCanary, JSON: true, Diag: diag.New(&buf),
+	})
+	if !res.OK {
+		t.Fatalf("sync run failed: %+v", res)
+	}
+
+	out := buf.String()
+	for _, marker := range []string{
+		"subagent: fingerprint gate ok",
+		"subagent: profile written",
+		"argv",
+		"subagent: claude exited code 0",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Fatalf("verbose trace missing %q:\n%s", marker, out)
+		}
+	}
+	for _, leak := range []string{canaryKey, promptCanary} {
+		if strings.Contains(out, leak) {
+			t.Fatalf("verbose trace leaked %q:\n%s", leak, out)
+		}
+	}
+}
+
+// A verbose run with a nil logger is the default path: same Result, no trace.
+func TestRun_NilDiagIsNoOp(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	writeMinimalVendors(t, xdg)
+
+	fakeClaude := writeFakeBin(t, "#!/bin/sh\nprintf '%s' '"+smokeSuccessJSON+"'\nexit 0\n")
+	orig := loadFP
+	loadFP = func() (*fingerprint.Fingerprint, error) {
+		return &fingerprint.Fingerprint{BinaryPath: fakeClaude}, nil
+	}
+	t.Cleanup(func() { loadFP = orig })
+
+	if res := Run(context.Background(), Request{Vendor: "glm", Prompt: "hi", JSON: true}); !res.OK {
+		t.Fatalf("nil-diag run failed: %+v", res)
+	}
+}
+
+// A verbose background launch traces only launch metadata (job id, pid,
+// capture path, detach) — the parent releases the child and observes no more.
+func TestLaunchBackground_VerboseLaunchMetadata(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	writeMinimalVendors(t, xdg)
+
+	fakeClaude := writeFakeBin(t, "#!/bin/sh\nprintf '%s' '"+smokeSuccessJSON+"'\nexit 0\n")
+	orig := loadFP
+	loadFP = func() (*fingerprint.Fingerprint, error) {
+		return &fingerprint.Fingerprint{BinaryPath: fakeClaude}, nil
+	}
+	t.Cleanup(func() { loadFP = orig })
+
+	var buf bytes.Buffer
+	res := Run(context.Background(), Request{
+		Vendor: "glm", Prompt: "hi", JSON: true, Background: true, Diag: diag.New(&buf),
+	})
+	if !res.OK || res.JobID == "" {
+		t.Fatalf("background launch failed: %+v", res)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "background job "+res.JobID+" started") {
+		t.Fatalf("missing launch-metadata line:\n%s", out)
+	}
+	if !strings.Contains(out, "background job "+res.JobID+" detached") {
+		t.Fatalf("missing detach line:\n%s", out)
+	}
+}

--- a/internal/teardown/hidden_test.go
+++ b/internal/teardown/hidden_test.go
@@ -107,7 +107,7 @@ func TestTeardownTeam_KillsHiddenPane(t *testing.T) {
 		{Name: "alice", AgentID: "alice@alpha", TmuxPaneID: "%55", AgentType: "general-purpose", Hidden: true, OriginWindow: "main:0"},
 	})
 
-	res := TeardownTeam("alpha")
+	res := TeardownTeam("alpha", nil)
 	if !res.OK {
 		t.Fatalf("teardown: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}

--- a/internal/teardown/teardown.go
+++ b/internal/teardown/teardown.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/diag"
 	"github.com/ethanhq/cc-fleet/internal/spawn"
 	"github.com/ethanhq/cc-fleet/internal/tmux"
 )
@@ -90,7 +91,7 @@ func configFreeReap(team string) (agentIDs []string, warnings []string) {
 // derivable from the team name alone, so recovery runs config-free — and under
 // WithTeamLock, so it serializes with a concurrent spawn into the same team
 // (the lock recreates the absent dir; RemoveAll cleans it back up).
-func TeardownTeam(team string) Result {
+func TeardownTeam(team string, dg *diag.Logger) Result {
 	if team == "" {
 		return Result{
 			OK:        false,
@@ -124,6 +125,7 @@ func TeardownTeam(team string) Result {
 	// sleep.
 	var reapIDs []string
 	lockErr := config.WithTeamLock(team, func() error {
+		dg.Logf("teardown: team lock acquired %s", team)
 		// Load member list — failure here is non-fatal because we can still
 		// rm -rf the team dir, which is the primary cleanup goal. We just
 		// won't know which pane ids to kill or member names to report.
@@ -153,6 +155,7 @@ func TeardownTeam(team string) Result {
 						res.Warnings = append(res.Warnings,
 							fmt.Sprintf("kill pane %s: %v", m.TmuxPaneID, err))
 					} else {
+						dg.Logf("teardown: killed pane %s (socket %q)", m.TmuxPaneID, sock)
 						res.Panes = append(res.Panes, m.TmuxPaneID)
 					}
 				}
@@ -175,6 +178,8 @@ func TeardownTeam(team string) Result {
 				if err := tmux.NewServer(sock).KillServer(); err != nil {
 					res.Warnings = append(res.Warnings,
 						fmt.Sprintf("kill swarm server %s: %v", sock, err))
+				} else {
+					dg.Logf("teardown: killed swarm server %s", sock)
 				}
 			}
 		case loadErr != nil && !errors.Is(loadErr, spawn.ErrTeamNotFound):
@@ -204,6 +209,7 @@ func TeardownTeam(team string) Result {
 		if err := os.RemoveAll(dir); err != nil {
 			return fmt.Errorf("remove team dir: %w", err)
 		}
+		dg.Logf("teardown: team dir removed (existed=%v)", dirExisted)
 		if dirExisted {
 			res.TeamRemoved = true
 		}
@@ -214,6 +220,9 @@ func TeardownTeam(team string) Result {
 	// Outside the lock and best-effort: warnings only, never flips OK.
 	for _, id := range reapIDs {
 		killed, warns := reapTeammateProcess(id)
+		if len(killed) > 0 {
+			dg.Logf("teardown: reaped %s (pids %v)", id, killed)
+		}
 		res.KilledPIDs = append(res.KilledPIDs, killed...)
 		res.Warnings = append(res.Warnings, warns...)
 	}
@@ -237,7 +246,7 @@ func TeardownTeam(team string) Result {
 // paneID must be a tmux pane id like "%42" — the leading "%" is the only
 // shape we recognize; callers that mix in team names should use
 // TeardownTeam instead.
-func TeardownPane(paneID string) Result {
+func TeardownPane(paneID string, dg *diag.Logger) Result {
 	if paneID == "" {
 		return Result{
 			OK:        false,

--- a/internal/teardown/teardown_parsefail_test.go
+++ b/internal/teardown/teardown_parsefail_test.go
@@ -29,7 +29,7 @@ func TestTeardownTeam_ParseFailureStillKillsSwarmServer(t *testing.T) {
 		t.Fatalf("corrupt config: %v", err)
 	}
 
-	res := TeardownTeam("brokt")
+	res := TeardownTeam("brokt", nil)
 	if !res.OK {
 		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -84,7 +84,7 @@ func TestTeardownTeam_ParseFailureReapsGhostProcess(t *testing.T) {
 		t.Fatalf("corrupt config: %v", err)
 	}
 
-	res := TeardownTeam("brokt")
+	res := TeardownTeam("brokt", nil)
 	if !res.OK {
 		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}

--- a/internal/teardown/teardown_per_member_socket_test.go
+++ b/internal/teardown/teardown_per_member_socket_test.go
@@ -44,7 +44,7 @@ func TestTeardownTeam_MixedMode_PerMemberSocket(t *testing.T) {
 		t.Fatalf("WriteTeamConfig: %v", err)
 	}
 
-	res := TeardownTeam("mix")
+	res := TeardownTeam("mix", nil)
 	if !res.OK {
 		t.Fatalf("teardown failed: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -87,7 +87,7 @@ func TestTeardownTeam_LegacyTeamSocketFallback(t *testing.T) {
 		{Name: "w2", AgentID: "w2@legacy", TmuxPaneID: "%301", AgentType: "general-purpose"},
 	})
 
-	res := TeardownTeam("legacy")
+	res := TeardownTeam("legacy", nil)
 	if !res.OK {
 		t.Fatalf("teardown failed: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}

--- a/internal/teardown/teardown_recovery_test.go
+++ b/internal/teardown/teardown_recovery_test.go
@@ -35,7 +35,7 @@ func TestTeardownTeam_DirGoneRecoversSwarmServer(t *testing.T) {
 	h.pids[ghostID] = []int{ghostPID}
 
 	// Deliberately do NOT seed the team — the dir is absent.
-	res := TeardownTeam("gonet")
+	res := TeardownTeam("gonet", nil)
 	if !res.OK {
 		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -92,7 +92,7 @@ func TestTeardownTeam_DirGoneIdempotentNoop(t *testing.T) {
 	t.Cleanup(func() { discoverTeamAgentIDsFn = orig })
 	discoverTeamAgentIDsFn = func(string) []string { return nil }
 
-	res := TeardownTeam("nobody")
+	res := TeardownTeam("nobody", nil)
 	if !res.OK {
 		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}

--- a/internal/teardown/teardown_test.go
+++ b/internal/teardown/teardown_test.go
@@ -217,7 +217,7 @@ func TestTeardownTeam_RemovesEverything(t *testing.T) {
 		{Name: "a2", AgentID: "a2@alpha", TmuxPaneID: "%11", AgentType: "general-purpose"},
 	})
 
-	res := TeardownTeam("alpha")
+	res := TeardownTeam("alpha", nil)
 	if !res.OK {
 		t.Fatalf("TeardownTeam: ok=false code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -254,7 +254,7 @@ func TestTeardownTeam_SwarmSocketKillAndKillServer(t *testing.T) {
 		{Name: "w2", AgentID: "w2@swarmt", TmuxPaneID: "%1", AgentType: "general-purpose"},
 	})
 
-	res := TeardownTeam("swarmt")
+	res := TeardownTeam("swarmt", nil)
 	if !res.OK {
 		t.Fatalf("teardown ok=false: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -280,7 +280,7 @@ func TestTeardownTeam_InTmuxNoKillServer(t *testing.T) {
 	seedTeam(t, "alpha", []spawn.Member{
 		{Name: "a1", AgentID: "a1@alpha", TmuxPaneID: "%10", AgentType: "general-purpose"},
 	})
-	res := TeardownTeam("alpha")
+	res := TeardownTeam("alpha", nil)
 	if !res.OK {
 		t.Fatalf("teardown ok=false: %s", res.ErrorMsg)
 	}
@@ -297,7 +297,7 @@ func TestTeardownTeam_MissingIsIdempotent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	installFakeTmux(t)
 
-	res := TeardownTeam("never-existed")
+	res := TeardownTeam("never-existed", nil)
 	if !res.OK {
 		t.Fatalf("idempotent teardown should return OK: code=%s msg=%s",
 			res.ErrorCode, res.ErrorMsg)
@@ -311,7 +311,7 @@ func TestTeardownTeam_MissingIsIdempotent(t *testing.T) {
 }
 
 func TestTeardownTeam_EmptyName(t *testing.T) {
-	res := TeardownTeam("")
+	res := TeardownTeam("", nil)
 	if res.OK {
 		t.Fatal("empty team name should fail")
 	}
@@ -337,7 +337,7 @@ func TestTeardownTeam_TmuxKillFailureIsWarning(t *testing.T) {
 		{Name: "b1", AgentID: "b1@beta", TmuxPaneID: "%20", AgentType: "general-purpose"},
 	})
 
-	res := TeardownTeam("beta")
+	res := TeardownTeam("beta", nil)
 	if !res.OK {
 		t.Fatalf("tmux kill warning should not fail teardown: code=%s msg=%s",
 			res.ErrorCode, res.ErrorMsg)
@@ -360,7 +360,7 @@ func TestTeardownPane_HappyPath(t *testing.T) {
 		{Name: "g2", AgentID: "g2@gamma", TmuxPaneID: "%31", AgentType: "general-purpose"},
 	})
 
-	res := TeardownPane("%30")
+	res := TeardownPane("%30", nil)
 	if !res.OK {
 		t.Fatalf("TeardownPane: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -399,7 +399,7 @@ func TestTeardownPane_PaneNotFoundIsIdempotent(t *testing.T) {
 	_ = os.WriteFile(errOut, []byte("can't find pane: %99\n"), 0o644)
 	t.Setenv("MOCK_OUTPUT_FILE", errOut)
 
-	res := TeardownPane("%99")
+	res := TeardownPane("%99", nil)
 	if !res.OK {
 		t.Fatalf("nonexistent pane should be OK (idempotent): code=%s msg=%s",
 			res.ErrorCode, res.ErrorMsg)
@@ -411,7 +411,7 @@ func TestTeardownPane_NoOwningTeamStillKillsPane(t *testing.T) {
 	installFakeTmux(t)
 	// No teams seeded; just call TeardownPane.
 
-	res := TeardownPane("%50")
+	res := TeardownPane("%50", nil)
 	if !res.OK {
 		t.Fatalf("orphan pane teardown should be OK: code=%s msg=%s",
 			res.ErrorCode, res.ErrorMsg)
@@ -422,7 +422,7 @@ func TestTeardownPane_NoOwningTeamStillKillsPane(t *testing.T) {
 }
 
 func TestTeardownPane_EmptyPaneID(t *testing.T) {
-	res := TeardownPane("")
+	res := TeardownPane("", nil)
 	if res.OK {
 		t.Fatal("empty pane id should fail")
 	}
@@ -431,7 +431,7 @@ func TestTeardownPane_EmptyPaneID(t *testing.T) {
 func TestTeardownPane_RejectsBareName(t *testing.T) {
 	// Bare names (no leading %) must be rejected — they would otherwise
 	// silently look up no team and "succeed" misleadingly.
-	res := TeardownPane("alpha")
+	res := TeardownPane("alpha", nil)
 	if res.OK {
 		t.Fatal("non-% pane id should fail")
 	}
@@ -581,7 +581,7 @@ func TestTeardownTeam_ReapsMemberProcesses(t *testing.T) {
 		{Name: "a2", AgentID: "a2@alpha", TmuxPaneID: "%11", AgentType: "general-purpose"},
 	})
 
-	res := TeardownTeam("alpha")
+	res := TeardownTeam("alpha", nil)
 	if !res.OK {
 		t.Fatalf("ok=false code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}
@@ -606,7 +606,7 @@ func TestTeardownPane_ReapsOnlyItsMember(t *testing.T) {
 		{Name: "g2", AgentID: "g2@gamma", TmuxPaneID: "%31", AgentType: "general-purpose"},
 	})
 
-	res := TeardownPane("%30")
+	res := TeardownPane("%30", nil)
 	if !res.OK {
 		t.Fatalf("ok=false code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 	}

--- a/internal/teardown/teardown_traversal_test.go
+++ b/internal/teardown/teardown_traversal_test.go
@@ -57,7 +57,7 @@ func TestTeardownTeam_RejectsPathTraversal(t *testing.T) {
 	for _, name := range traversalCases {
 		name := name
 		t.Run("name="+name, func(t *testing.T) {
-			res := TeardownTeam(name)
+			res := TeardownTeam(name, nil)
 			if res.OK {
 				t.Fatalf("TeardownTeam(%q): want OK=false, got OK=true (path traversal not blocked!)", name)
 			}
@@ -90,7 +90,7 @@ func TestTeardownTeam_AcceptsLegitName(t *testing.T) {
 	if err := os.WriteFile(cfgPath, []byte(`{"members":[]}`), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	res := TeardownTeam("real-team")
+	res := TeardownTeam("real-team", nil)
 	if !res.OK {
 		t.Fatalf("TeardownTeam(real-team): code=%s msg=%s — should accept normal name",
 			res.ErrorCode, res.ErrorMsg)
@@ -120,7 +120,7 @@ func TestSpawnPaths_RejectInvalidNames(t *testing.T) {
 	// surface for the path-traversal guard. InboxPath / TeamDir name validation
 	// is covered by internal/spawn unit tests.
 	for _, bad := range []string{"..", "../x", "/abs"} {
-		res := TeardownTeam(bad)
+		res := TeardownTeam(bad, nil)
 		if res.OK {
 			t.Fatalf("TeardownTeam(%q): OK=true; validator missing for low-level path build", bad)
 		}

--- a/internal/teardown/verbose_test.go
+++ b/internal/teardown/verbose_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package teardown
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/diag"
+	"github.com/ethanhq/cc-fleet/internal/spawn"
+)
+
+// A verbose teardown traces lock acquisition, pane kills, and the dir removal.
+func TestTeardownTeam_VerboseTrace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	installFakeTmux(t)
+	installReapHarness(t)
+
+	seedTeam(t, "vtrace", []spawn.Member{
+		{Name: "a1", AgentID: "a1@vtrace", TmuxPaneID: "%10", AgentType: "general-purpose"},
+	})
+
+	var buf bytes.Buffer
+	res := TeardownTeam("vtrace", diag.New(&buf))
+	if !res.OK {
+		t.Fatalf("teardown failed: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
+	}
+	out := buf.String()
+	for _, marker := range []string{
+		"teardown: team lock acquired vtrace",
+		"teardown: killed pane %10",
+		"teardown: team dir removed (existed=true)",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Fatalf("verbose trace missing %q:\n%s", marker, out)
+		}
+	}
+}

--- a/internal/tui/confirm.go
+++ b/internal/tui/confirm.go
@@ -122,6 +122,7 @@ func (m Model) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // workflowCtlMsg resolves the result. A delete dispatches and closes; its outcome pops via withInfo.
 func (m Model) runConfirmed() (tea.Model, tea.Cmd) {
 	c := *m.confirm // work on a copy; the new phase/result is published back via m.confirm = &c
+	m.diag.Logf("tui: confirmed %s %q", c.kind, c.id)
 	switch c.kind {
 	case confirmClear:
 		c.phase = modalResult

--- a/internal/tui/confirm.go
+++ b/internal/tui/confirm.go
@@ -70,7 +70,7 @@ const (
 
 // confirmAmber is the modal's confirm-phase accent: the border AND the Cancel/Confirm buttons share
 // it. A finished result re-tints the border green (ok) / red (err); the buttons are gone by then.
-const confirmAmber lipgloss.Color = "220"
+var confirmAmber = lipgloss.AdaptiveColor{Light: "136", Dark: "220"}
 
 // openConfirm opens a centered confirm modal (cursor defaulting to Cancel) for a destructive action.
 func (m Model) openConfirm(kind, id, prompt string) (tea.Model, tea.Cmd) {
@@ -251,16 +251,16 @@ func (m Model) withInfo(msg string, isErr bool) Model {
 	return m
 }
 
-// confirmBorder frames the modal: amber (220) while asking or running, green (78) on a successful
-// result, red (203) on a failed one — and red while asking/running a danger action (a heavy delete).
-func (m Model) confirmBorder() lipgloss.Color {
+// confirmBorder frames the modal: amber while asking or running, green on a successful
+// result, red on a failed one — and red while asking/running a danger action (a heavy delete).
+func (m Model) confirmBorder() lipgloss.AdaptiveColor {
 	switch {
 	case m.confirm.phase == modalResult && m.confirm.resultErr:
-		return lipgloss.Color("203")
+		return errColor
 	case m.confirm.phase == modalResult:
-		return lipgloss.Color("78")
+		return okColor
 	case m.confirm.danger:
-		return lipgloss.Color("203")
+		return errColor
 	default:
 		return confirmAmber
 	}
@@ -307,7 +307,7 @@ func (m Model) renderConfirmBox() string {
 // confirmButtons renders the Cancel / Confirm pair in the given accent — matching the modal frame
 // (amber normally, red for a danger ask) — the cursor's choice highlighted (bold, in ‹ ›), the other
 // plain.
-func confirmButtons(cursor int, accent lipgloss.Color) string {
+func confirmButtons(cursor int, accent lipgloss.AdaptiveColor) string {
 	style := lipgloss.NewStyle().Foreground(accent)
 	btn := func(label string, selected bool) string {
 		if selected {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -9,6 +9,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/diag"
 	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/models"
 	"github.com/ethanhq/cc-fleet/internal/onboarding"
@@ -293,6 +295,10 @@ type Model struct {
 
 	loading  bool
 	quitting bool
+
+	// diag is the --verbose step-trace sink (nil when verbose is off); Update
+	// writes the dispatched-op trace to it.
+	diag *diag.Logger
 }
 
 // NewModel returns the initial model. It normally parks on the Model Providers list
@@ -1595,6 +1601,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case opDoneMsg:
+		m.diag.Logf("tui: op %s %q done (err=%v)", msg.verb, msg.name, msg.err != nil)
 		// While a marked codex login flow owns the screen (committing, consent, or
 		// device), a stale result from an earlier, unrelated op is dropped outright:
 		// yanking the user to an outcome modal would free them to start another codex
@@ -3346,6 +3353,7 @@ func (m Model) updateCodexAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.codexSourceCursor == 1 {
 				m.codexCommittedName = req.Name
 			}
+			m.diag.Logf("tui: codex auth → committing (source choice %d)", m.codexSourceCursor)
 			m.codexAuthStage = codexAuthCommitting
 			m.loading = true
 			return m, addVendorCmd(req)
@@ -3360,6 +3368,7 @@ func (m Model) updateCodexAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.codexAuthCancel != nil {
 				m.codexAuthCancel() // tear down any prior session before starting a fresh one
 			}
+			m.diag.Logf("tui: codex auth → device login")
 			m.codexAuthStage = codexAuthDevice
 			m.codexAuthErr = ""
 			m.loading = true
@@ -3974,6 +3983,7 @@ func (m Model) submitAddCodex() (tea.Model, tea.Cmd) {
 		m.codexPendingAdd = &req
 		m.codexAuthAccount = st.Account
 		m.screen = screenCodexAuth
+		m.diag.Logf("tui: codex auth → choose source")
 		m.codexAuthStage = codexAuthChooseSource
 		m.codexSourceCursor = 0
 		return m, nil
@@ -3986,6 +3996,7 @@ func (m Model) submitAddCodex() (tea.Model, tea.Cmd) {
 		// login modal's underlay stays the form that was submitted.
 		m.codexCommittedName = req.Name
 		m.screen = screenCodexAuth
+		m.diag.Logf("tui: codex auth → committing (no source)")
 		m.codexAuthStage = codexAuthCommitting
 		m.loading = true
 		return m, addVendorCmd(req)
@@ -4110,13 +4121,38 @@ func missingLabels(values map[string]string, order []string) []string {
 
 // Run starts the bubbletea program against stdin/stdout. The caller is
 // responsible for ensuring those are a terminal (see cmd/cc-fleet/tui.go).
-func Run() error {
+// verbose routes the session's step trace to a per-pid 0600 log file.
+func Run(verbose bool) error {
 	// Resolve the terminal background (light vs dark) before bubbletea owns
 	// stdin: the adaptive palette's first render would otherwise race the
 	// terminal's color-query reply against the program's input reader.
 	lipgloss.HasDarkBackground()
-	final, err := tea.NewProgram(NewModel()).Run()
+	model := NewModel()
+	// The --verbose sink: stderr would corrupt the alternate screen, so the TUI
+	// step trace goes to a per-pid 0600 log file. Open failure degrades to a
+	// silent session (the note below tells the user), never a blocked TUI.
+	var logFile *os.File
+	var logPath string
+	if verbose {
+		f, path, err := openVerboseLog()
+		if err != nil {
+			logPath = "unavailable: " + err.Error()
+		} else {
+			logFile, logPath = f, path
+			model.diag = diag.New(f)
+			model.diag.Logf("tui: session start")
+		}
+	}
+	final, err := tea.NewProgram(model).Run()
+	if logFile != nil {
+		_ = logFile.Close()
+	}
 	if err != nil {
+		// Surface the trace path on failure too — it is most useful exactly when
+		// the TUI crashed.
+		if verbose {
+			fmt.Println("verbose log:", logPath)
+		}
 		return err
 	}
 	// The tmux setup screen's "install it" choice leaves a note to print AFTER
@@ -4124,6 +4160,9 @@ func Run() error {
 	// final model; read the note off it.
 	if m, ok := final.(Model); ok && m.postQuitNote != "" {
 		fmt.Println(m.postQuitNote)
+	}
+	if verbose {
+		fmt.Println("verbose log:", logPath)
 	}
 	return nil
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
 	"github.com/ethanhq/cc-fleet/internal/config"
@@ -4110,6 +4111,10 @@ func missingLabels(values map[string]string, order []string) []string {
 // Run starts the bubbletea program against stdin/stdout. The caller is
 // responsible for ensuring those are a terminal (see cmd/cc-fleet/tui.go).
 func Run() error {
+	// Resolve the terminal background (light vs dark) before bubbletea owns
+	// stdin: the adaptive palette's first render would otherwise race the
+	// terminal's color-query reply against the program's input reader.
+	lipgloss.HasDarkBackground()
 	final, err := tea.NewProgram(NewModel()).Run()
 	if err != nil {
 		return err

--- a/internal/tui/pin.go
+++ b/internal/tui/pin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
-// pinSuffix is the fixed-width trailing pin indicator a row appends at its right edge: a yellow ★
+// pinSuffix is the fixed-width trailing pin indicator a row appends at its right edge: a gold ★
 // when (kind,id) is pinned, else two spaces. The slot is ALWAYS reserved so toggling a pin never
 // shifts the row's left content — it only fills or clears the rightmost cell.
 func (m Model) pinSuffix(kind pinned.Kind, id string) string {

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -14,14 +14,14 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
 
-// The run-permission value colors mirror Claude Code's own permission-mode indicator;
-// default/off stay in the plain body color.
+// The run-permission value colors mirror Claude Code's own permission-mode indicator
+// on both backgrounds; default/off stay in the plain body color.
 func TestPermModeStyleMapping(t *testing.T) {
-	want := map[string]lipgloss.Color{
-		permmode.Plan:              "66",
-		permmode.AcceptEdits:       "141",
-		permmode.Auto:              "214",
-		permmode.BypassPermissions: "203",
+	want := map[string]lipgloss.AdaptiveColor{
+		permmode.Plan:              {Light: "23", Dark: "66"},
+		permmode.AcceptEdits:       {Light: "93", Dark: "141"},
+		permmode.Auto:              {Light: "94", Dark: "214"},
+		permmode.BypassPermissions: {Light: "160", Dark: "203"},
 	}
 	for mode, c := range want {
 		if got := permModeStyle(mode).GetForeground(); got != c {

--- a/internal/tui/verbose.go
+++ b/internal/tui/verbose.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// openVerboseLog creates the TUI's --verbose sink: <ConfigDir>/tui-verbose-<pid>.log,
+// 0600, truncated. Per-pid names keep concurrent verbose sessions from truncating
+// each other; the sweep below bounds accumulation.
+func openVerboseLog() (*os.File, string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return nil, "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, "", err
+	}
+	sweepStaleVerboseLogs(dir, os.Getpid())
+	path := filepath.Join(dir, fmt.Sprintf("tui-verbose-%d.log", os.Getpid()))
+	// Always write to a fresh private inode. This pid's own file is never swept
+	// (and a pre-reboot pid's may linger), so the predictable path can already
+	// exist — possibly a symlink or a broader-mode file. Remove it first, then
+	// O_EXCL-create: a symlink is unlinked (not followed into its target), and a
+	// retained reader of the old inode keeps the orphaned file, never our writes.
+	_ = os.Remove(path)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, "", err
+	}
+	return f, path, nil
+}
+
+// sweepStaleVerboseLogs removes tui-verbose-<pid>.log siblings whose embedded pid
+// is no longer alive — sequential use leaves exactly one file, while a live
+// concurrent session's file (its printed path must stay inspectable) is never
+// touched. Best-effort: parse and remove failures are ignored.
+func sweepStaleVerboseLogs(dir string, selfPID int) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "tui-verbose-") || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(name, "tui-verbose-"), ".log"))
+		if err != nil || pid <= 0 || pid == selfPID || pidAliveForSweep(pid) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, name))
+	}
+}

--- a/internal/tui/verbose_unix.go
+++ b/internal/tui/verbose_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package tui
+
+import (
+	"errors"
+	"syscall"
+)
+
+// pidAliveForSweep reports whether pid is a live process: signal 0 probes
+// existence without delivering anything; EPERM means alive-but-foreign,
+// which still must not be swept.
+func pidAliveForSweep(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/tui/verbose_unix_test.go
+++ b/internal/tui/verbose_unix_test.go
@@ -1,0 +1,145 @@
+//go:build !windows
+
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenVerboseLog_PerPid0600Truncated(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	f, path, err := openVerboseLog()
+	if err != nil {
+		t.Fatalf("openVerboseLog: %v", err)
+	}
+	if want := fmt.Sprintf("tui-verbose-%d.log", os.Getpid()); filepath.Base(path) != want {
+		t.Fatalf("path %q, want basename %q", path, want)
+	}
+	if _, err := f.WriteString("session one\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("perm %o, want 0600", fi.Mode().Perm())
+	}
+
+	// A second open of the same pid's path starts a fresh, empty trace.
+	f2, _, err := openVerboseLog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2.Close()
+	if data, _ := os.ReadFile(path); len(data) != 0 {
+		t.Fatalf("reopen did not start fresh: %q", data)
+	}
+}
+
+// A pre-existing broad-mode file at this pid's path (its file is never swept; a
+// pre-reboot pid's can linger) is replaced by a fresh private 0600 inode.
+func TestOpenVerboseLog_ReplacesBroadFileWithPrivateInode(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfgDir := filepath.Join(dir, "cc-fleet")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfgDir, fmt.Sprintf("tui-verbose-%d.log", os.Getpid()))
+	if err := os.WriteFile(path, []byte("stale 0644 content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, got, err := openVerboseLog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if got != path {
+		t.Fatalf("path %q, want %q", got, path)
+	}
+	if fi, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("reused log perm %o, want 0600", fi.Mode().Perm())
+	}
+}
+
+// A symlink planted at this pid's path is unlinked, not followed: the symlink
+// target is left untouched and a fresh regular file takes the path.
+func TestOpenVerboseLog_DoesNotFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfgDir := filepath.Join(dir, "cc-fleet")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "victim.txt")
+	if err := os.WriteFile(target, []byte("do not truncate me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfgDir, fmt.Sprintf("tui-verbose-%d.log", os.Getpid()))
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+
+	f, _, err := openVerboseLog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if data, _ := os.ReadFile(target); string(data) != "do not truncate me" {
+		t.Fatalf("symlink target was truncated/followed: %q", data)
+	}
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("path is still a symlink; want a fresh regular file")
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("fresh log perm %o, want 0600", fi.Mode().Perm())
+	}
+}
+
+func TestSweepStaleVerboseLogs_DeadOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	// A dead pid: run-and-reap a trivial child.
+	c := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := c.Run(); err != nil {
+		t.Fatal(err)
+	}
+	deadPID := c.Process.Pid
+
+	dead := filepath.Join(dir, fmt.Sprintf("tui-verbose-%d.log", deadPID))
+	live := filepath.Join(dir, fmt.Sprintf("tui-verbose-%d.log", os.Getpid())) // this test process is alive
+	other := filepath.Join(dir, "unrelated.log")
+	for _, p := range []string{dead, live, other} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// selfPID=1 so the live file is judged purely by pid liveness, not self-skip.
+	sweepStaleVerboseLogs(dir, 1)
+
+	if _, err := os.Stat(dead); !os.IsNotExist(err) {
+		t.Fatalf("dead-pid log not swept (err=%v)", err)
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("live-pid log was swept: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Fatalf("non-matching file was touched: %v", err)
+	}
+}

--- a/internal/tui/verbose_windows.go
+++ b/internal/tui/verbose_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package tui
+
+import "os"
+
+// pidAliveForSweep reports whether pid is live. os.FindProcess on Windows
+// opens the process and errors when it does not exist; erring toward "alive"
+// only delays a sweep, never removes a live session's file.
+func pidAliveForSweep(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	_ = p.Release()
+	return true
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -20,23 +20,31 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/userops"
 )
 
-// Shared lipgloss styles. Colors are ANSI 256 indices so they degrade
-// gracefully on limited terminals.
+// errColor and okColor are shared beyond their styles: the confirm-modal and
+// codex-auth borders re-tint on the outcome.
 var (
-	titleStyle      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
-	cursorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
-	selectedStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
-	faintStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	contentStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("245")) // board body text — softer than the bright default, above faint
-	liveStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("252")) // active (done/running) labels + the answer body — bright, below the frame
-	modalBodyStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("255")) // centered-modal body text — full contrast; a modal floats over the board and must outshine it
-	borderStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("255")) // master-detail box frame — the strongest line (near-white, like native)
-	sessionHdrStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+	errColor = lipgloss.AdaptiveColor{Light: "160", Dark: "203"}
+	okColor  = lipgloss.AdaptiveColor{Light: "28", Dark: "78"}
+)
+
+// Shared lipgloss styles. Colors are AdaptiveColor pairs of ANSI 256 indices —
+// Dark is the dark-background palette, Light a darker counterpart that stays
+// legible on white terminals — so they degrade gracefully on limited terminals.
+var (
+	titleStyle      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.AdaptiveColor{Light: "32", Dark: "39"})
+	cursorStyle     = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "198", Dark: "212"})
+	selectedStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.AdaptiveColor{Light: "198", Dark: "212"})
+	faintStyle      = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "247", Dark: "241"})
+	contentStyle    = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "242", Dark: "245"}) // board body text — softer than the full-contrast tone, above faint
+	liveStyle       = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "237", Dark: "252"}) // active (done/running) labels + the answer body — strong, below the frame
+	modalBodyStyle  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "233", Dark: "255"}) // centered-modal body text — full contrast; a modal floats over the board and must outshine it
+	borderStyle     = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "233", Dark: "255"}) // master-detail box frame — the strongest line (full contrast, like native)
+	sessionHdrStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.AdaptiveColor{Light: "32", Dark: "39"})
 	teamHdrStyle    = lipgloss.NewStyle().Bold(true) // team section header (flush-left bold title)
-	errStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-	okStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
-	noteStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // contextual Note hints — a warm tone above the gray body
-	pinStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("220")) // the kept/pinned ★ — yellow, trailing the row
+	errStyle        = lipgloss.NewStyle().Foreground(errColor)
+	okStyle         = lipgloss.NewStyle().Foreground(okColor)
+	noteStyle       = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "94", Dark: "214"})  // contextual Note hints — a warm tone above the gray body
+	pinStyle        = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "136", Dark: "220"}) // the kept/pinned ★ — gold, trailing the row
 )
 
 // footer renders a dim key-hint line.
@@ -48,11 +56,11 @@ func footer(s string) string { return faintStyle.Render(s) }
 func permModeStyle(mode string) lipgloss.Style {
 	switch mode {
 	case permmode.Plan:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("66"))
+		return lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "23", Dark: "66"})
 	case permmode.AcceptEdits:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("141"))
+		return lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "93", Dark: "141"})
 	case permmode.Auto:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+		return lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "94", Dark: "214"})
 	case permmode.BypassPermissions:
 		return errStyle
 	}
@@ -3012,7 +3020,7 @@ func (m Model) renderCodexAuthBox() string {
 	}
 	border := confirmAmber
 	if m.codexAuthErr != "" {
-		border = lipgloss.Color("203")
+		border = errColor
 	}
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).


### PR DESCRIPTION
This branch carries two independent TUI/diagnostics improvements, each its own commit.

`feat(tui): adapt the palette to light terminal backgrounds` — the shared TUI palette used fixed ANSI-256 grays tuned for a dark background, so on a white/light terminal the board, the provider hub, and every form washed out to near-invisible. Every color is now a `lipgloss.AdaptiveColor{Light, Dark}` pair: the Dark variant keeps today's values byte-identical, and the Light variant is a darker counterpart that stays legible on white. The run-permission tiers mirror Claude Code's own permission-mode indicator on both backgrounds (plan teal, acceptEdits violet, auto amber, bypass red). `Run` resolves the terminal background once before bubbletea takes over stdin so the first frame never races the color query against the input reader.

`feat(diag): add --verbose step tracing across the CLI and TUI` — the spawn, subagent, teardown, and conversion-daemon pipelines ran silent, so a stall gave no visibility into which step it died on. A new root `--verbose` flag turns on a step trace: CLI verbs write it to stderr, while the interactive TUI (where stderr would corrupt the screen) writes it to a per-pid `tui-verbose-<pid>.log` under the config dir at mode 0600, replacing the path with a fresh private inode on each session and printing the path on exit. The sink is an injected, nil-safe logger that masks every line through the key sanitizer and logs argv/env as counts only — prompts, schemas, keys, tokens, request bodies, and request structs are never logged. With the flag off the logger is nil and behavior is byte-identical.

Both features are gated green: `gofmt`, `go vet`, `go test -race ./...`, and the Windows + macOS cross-compiles all pass, with new unit tests for the adaptive permission palette, the diag logger (masking, nil-receiver, concurrent-write integrity), the TUI log file's permissions and symlink/sweep safety, and the spawn/subagent/teardown trace points.
