### PR TITLE
Deep-review fixes: hold-protocol race, stream/daemon edges, dead code

### DIFF
--- a/cmd/cc-fleet/default.go
+++ b/cmd/cc-fleet/default.go
@@ -14,7 +14,7 @@ import (
 type defaultJSONEnvelope struct {
 	OK         bool     `json:"ok"`
 	Provider   string   `json:"provider"`
-	Source     string   `json:"source"`     // configured | auto | unset
+	Source     string   `json:"source"`     // configured | auto | disabled | unknown | unset
 	Configured string   `json:"configured"` // the pinned value ("" = not pinned)
 	Candidates []string `json:"candidates"`
 }

--- a/internal/codexproxy/openai_chat_stream.go
+++ b/internal/codexproxy/openai_chat_stream.go
@@ -226,13 +226,17 @@ func (c *chatStreamConverter) toolDelta(tc chatToolCallDelta) error {
 
 // applyFinish maps a Chat finish_reason to an Anthropic stop_reason. stop /
 // content_filter / absent leave the current reason (end_turn, or tool_use if a
-// tool block opened); length and tool_calls override explicitly.
+// tool block opened); length overrides explicitly. tool_calls maps to tool_use
+// only when a tool block actually opened — a finish_reason carrying zero
+// streamed tool_call deltas must not stop tool_use with no tool_use block.
 func (c *chatStreamConverter) applyFinish(reason string) {
 	switch reason {
 	case "length":
 		c.stopReason = "max_tokens"
 	case "tool_calls":
-		c.stopReason = "tool_use"
+		if len(c.tools) > 0 {
+			c.stopReason = "tool_use"
+		}
 	}
 }
 

--- a/internal/codexproxy/openai_chat_test.go
+++ b/internal/codexproxy/openai_chat_test.go
@@ -264,3 +264,14 @@ func TestChatFixture_ErrorRedacted(t *testing.T) {
 		t.Fatal("open text block must be closed before the error event")
 	}
 }
+
+// A finish_reason of tool_calls with NO streamed tool_call deltas (a malformed /
+// empty upstream turn) must not stop tool_use — a tool_use stop with zero
+// tool_use blocks would hand the client an unkeepable promise.
+func TestChatFixture_ToolCallsFinishWithoutToolBlocks(t *testing.T) {
+	sink := replayChat(t, "chat_tool_calls_empty")
+	assertGrammar(t, sink)
+	if sr := stopReason(t, sink); sr != "end_turn" {
+		t.Fatalf("stop_reason = %q, want end_turn (no tool block ever opened)", sr)
+	}
+}

--- a/internal/codexproxy/serve.go
+++ b/internal/codexproxy/serve.go
@@ -29,12 +29,17 @@ func Serve(port int, protocol, upstreamURL, ref string) error {
 	}
 	// codex gates /v1/messages on the handshake secret (its OAuth bearer lives
 	// only here); an openai-* daemon takes the real key per request, so it needs
-	// none. Read it lock-free: EnsureDaemon created it under the global secret
-	// lock before spawning this daemon. A manual `serve` falls back to creating it.
+	// none. The create-once runs under the global secret lock on every path that
+	// may be the first creator: a manual `serve` racing a first-time EnsureDaemon
+	// must not interleave two creations.
 	var secret string
 	if protocol == config.ProtocolCodexOAuth {
-		if secret, err = loadOrCreateSecret(); err != nil {
-			return err
+		if lerr := withSecretLock(func() error {
+			var serr error
+			secret, serr = loadOrCreateSecret()
+			return serr
+		}); lerr != nil {
+			return lerr
 		}
 	}
 	srv := newServer(up, protocol, secret)

--- a/internal/codexproxy/testdata/chat_tool_calls_empty.sse
+++ b/internal/codexproxy/testdata/chat_tool_calls_empty.sse
@@ -1,0 +1,5 @@
+data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"plain"},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]

--- a/internal/leadsession/detect.go
+++ b/internal/leadsession/detect.go
@@ -38,17 +38,11 @@ func DetectFromPID(pid int) string {
 	return id
 }
 
-// DetectPID walks upward from the current parent PID and returns the first
-// ancestor PID whose Claude session registry entry validates (same fail-closed
-// PID-reuse check Detect() uses). Returns 0 when no validated ancestor exists.
-// Used by spawn-time permission inheritance to read the lead's cmdline.
-func DetectPID() int {
-	pid, _ := DetectPIDWithStart()
-	return pid
-}
-
-// DetectPIDWithStart is DetectPID plus the lead PID's validated /proc start
-// time. Returns (0, "") when no validated ancestor exists.
+// DetectPIDWithStart walks upward from the current parent PID and returns the
+// first ancestor PID whose Claude session registry entry validates (same
+// fail-closed PID-reuse check Detect() uses), plus that PID's validated /proc
+// start time. Returns (0, "") when no validated ancestor exists. Used by
+// spawn-time permission inheritance to read the lead's cmdline.
 //
 // The caller reads the lead's cmdline by bare PID AFTER this detect; the PID can
 // be recycled in between (TOCTOU). Returning the detect-time procStart lets the
@@ -79,7 +73,7 @@ func RevalidateProcStart(pid int, want string) bool {
 	return ok && st == want
 }
 
-// walk is the shared ancestor walk used by Detect/DetectFromPID and DetectPID.
+// walk is the shared ancestor walk used by Detect/DetectFromPID and DetectPIDWithStart.
 // It returns the (sessionID, pid) of the first ancestor whose session file
 // validates. When nothing validates it returns ("", 0). The walk stops at
 // init, on cycles, or after maxAncestorDepth steps.

--- a/internal/leadsession/detect_test.go
+++ b/internal/leadsession/detect_test.go
@@ -194,19 +194,19 @@ func detectPIDWithStartFrom(start int) (int, string) {
 	return p, st
 }
 
-// TestDetectPID_UnsupportedPlatform_ReturnsZero locks the auto-degrade guarantee
+// TestPIDWalk_UnsupportedPlatform_ReturnsZero locks the auto-degrade guarantee
 // for platforms with NO process introspection (procintrospect's "other" build —
 // e.g. windows): parentPID/procStart return (_,false) so walk bails on the first
 // step. darwin and linux have process introspection, so they're excluded here
 // and covered by their own tests.
-func TestDetectPID_UnsupportedPlatform_ReturnsZero(t *testing.T) {
+func TestPIDWalk_UnsupportedPlatform_ReturnsZero(t *testing.T) {
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		t.Skip("introspection-capable platform; degrade is asserted on 'other' (e.g. windows) only")
 	}
 	// On an unsupported host parentPID returns (0,false) for any pid; walk falls
 	// out before reaching any session file lookup.
 	if got := walkPIDFrom(os.Getpid()); got != 0 {
-		t.Fatalf("DetectPID walk on an unsupported platform = %d, want 0", got)
+		t.Fatalf("PID walk on an unsupported platform = %d, want 0", got)
 	}
 }
 

--- a/internal/spawn/inherit_test.go
+++ b/internal/spawn/inherit_test.go
@@ -114,8 +114,8 @@ func TestInheritPermissionFlags_LeadDefault_NoFlag(t *testing.T) {
 }
 
 func TestInheritPermissionFlags_FrozenTemplate_NoLead(t *testing.T) {
-	// DetectPID() == 0 → frozen-template (covers macOS / out-of-tmux / external
-	// shell where the ancestor walk finds no validated Claude session).
+	// DetectPIDWithStart() == 0 → frozen-template (covers macOS / out-of-tmux /
+	// external shell where the ancestor walk finds no validated Claude session).
 	setLead(t, 0, nil)
 
 	flags, src := inheritPermissionFlags("")
@@ -125,8 +125,8 @@ func TestInheritPermissionFlags_FrozenTemplate_NoLead(t *testing.T) {
 }
 
 func TestInheritPermissionFlags_FrozenTemplate_CmdlineUnreadable(t *testing.T) {
-	// DetectPID() succeeds but readLeadCmdline fails → frozen-template (pure β,
-	// no γ split: we do NOT downgrade to default-safe on a read failure).
+	// DetectPIDWithStart() succeeds but readLeadCmdline fails → frozen-template
+	// (pure β, no γ split: we do NOT downgrade to default-safe on a read failure).
 	setLead(t, 4249, nil)
 
 	flags, src := inheritPermissionFlags("")

--- a/internal/spawn/teamfs.go
+++ b/internal/spawn/teamfs.go
@@ -51,12 +51,6 @@ func TeamConfigPath(team string) (string, error) {
 	return filepath.Join(dir, "config.json"), nil
 }
 
-// TeamsDir returns $HOME/.claude/teams — the root every team directory lives
-// under. Exported for callers (panevis) that need to glob across teams.
-func TeamsDir() (string, error) {
-	return teamsRoot()
-}
-
 // FindMemberByPane scans every team's config.json for a member whose
 // tmuxPaneId == paneID and returns its (team, name). found=false (with nil
 // error) means no team claims the pane — including the case where the teams

--- a/internal/subagent/held_test.go
+++ b/internal/subagent/held_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/ethanhq/cc-fleet/internal/pinned"
@@ -141,5 +142,77 @@ func TestRequeueLeaf(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, jobID+".answer")); err == nil {
 		t.Error("stale answer sidecar should be dropped on requeue")
+	}
+}
+
+// TestRegisterAfterHold_PreservesHold: a registration racing in AFTER the engine's
+// kill-and-HOLD pre-mark must not clobber the held meta back to running — it returns
+// registerHeld so the attempt exits without ever finalizing.
+func TestRegisterAfterHold_PreservesHold(t *testing.T) {
+	jobID := mintHeldFixture(t)
+	if got := registerSyncJob(jobID, Request{Provider: "v", RunID: "run-h"}, "m", "", ""); got != registerHeld {
+		t.Fatalf("registerSyncJob on a held meta = %v, want registerHeld", got)
+	}
+	if res := StatusFor(jobID); res.Status != "held" {
+		t.Fatalf("status = %q, want held (register must not clobber the pre-mark)", res.Status)
+	}
+	dir, _ := jobsDir()
+	if _, err := os.Stat(filepath.Join(dir, jobID+".result.json")); err == nil {
+		t.Fatal("no terminal cache may exist for a held leaf")
+	}
+}
+
+// TestHoldAfterSettle_NoOps: a directive landing after the attempt already cached a
+// terminal result must not flip the settled job to held (success-beats-kill stays
+// authoritative; no terminal cache may sit under a held meta).
+func TestHoldAfterSettle_NoOps(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	jobID := MintQueuedLeaf(Request{Provider: "v", RunID: "run-s"}, "m")
+	if jobID == "" {
+		t.Fatal("mint failed")
+	}
+	if got := registerSyncJob(jobID, Request{Provider: "v", RunID: "run-s"}, "m", "", ""); got != registerOK {
+		t.Fatalf("registerSyncJob = %v, want registerOK", got)
+	}
+	finalizeSyncJob(jobID, Result{OK: true, NumTurns: 1})
+	HoldLeaf(jobID)
+	if res := StatusFor(jobID); res.Status != "done" {
+		t.Fatalf("status = %q, want done (a settled job must not be re-held)", res.Status)
+	}
+}
+
+// TestHoldVsFinalize_NeverTerminalCacheUnderHold races the engine's pre-mark against
+// the leaf's finalize: whichever order the mutex serializes, a held meta and a terminal
+// cache must never coexist.
+func TestHoldVsFinalize_NeverTerminalCacheUnderHold(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		jobID := MintQueuedLeaf(Request{Provider: "v", RunID: "run-r"}, "m")
+		if jobID == "" {
+			t.Fatal("mint failed")
+		}
+		if got := registerSyncJob(jobID, Request{Provider: "v", RunID: "run-r"}, "m", "", ""); got != registerOK {
+			t.Fatalf("registerSyncJob = %v, want registerOK", got)
+		}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); HoldLeaf(jobID) }()
+		go func() {
+			defer wg.Done()
+			finalizeSyncJob(jobID, Result{ErrorCode: ErrCodeStopped, ErrorMsg: "kill"})
+		}()
+		wg.Wait()
+		meta, merr := readMeta(dir, jobID)
+		if merr != nil {
+			t.Fatal(merr)
+		}
+		_, cerr := os.Stat(filepath.Join(dir, jobID+".result.json"))
+		if meta.Status == "held" && cerr == nil {
+			t.Fatal("terminal cache exists under a held meta")
+		}
 	}
 }

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -1045,6 +1046,30 @@ func mintSyncJobID() string {
 	return uuid.NewString()
 }
 
+// jobMetaMu serializes the hold-protocol meta read-modify-writes: the engine
+// loop's kill-and-HOLD pre-mark (HoldLeaf) and the leaf goroutine's
+// register/finalize would otherwise interleave — a register landing after the
+// pre-mark clobbers `held` back to `running`, and a hold landing between
+// finalize's meta read and its cache write strands a terminal cache under a
+// hold; either hands GC an authoritative "finished" for a live frame. Every
+// hold-protocol writer runs in the engine process while the engine lives
+// (cross-process writers like StopRun's release walk run only against a dead
+// engine), so an in-process mutex closes both windows.
+var jobMetaMu sync.Mutex
+
+// registerOutcome is registerSyncJob's tri-state result: the running meta was
+// written (registerOK); a kill-and-HOLD pre-mark owns the job, so the caller
+// must stop immediately and leave the held meta untouched (registerHeld); or
+// board bookkeeping is unavailable and the run proceeds unrecorded
+// (registerFailed).
+type registerOutcome int
+
+const (
+	registerFailed registerOutcome = iota
+	registerHeld
+	registerOK
+)
+
 // registerSyncJob records a SYNCHRONOUS Run on the Agents Board so it is
 // visible WHILE it executes. It writes only a running jobMeta — NO prompt /
 // answer text (key-safety, same discipline as background). PID is the
@@ -1056,16 +1081,25 @@ func mintSyncJobID() string {
 // any error proceeds unrecorded — board bookkeeping must never fail the run or
 // change its returned Result.
 //
-// It returns whether the meta was written: a FAILED registration must skip
-// finalizeSyncJob (which would otherwise write an orphan .result.json with no
-// backing meta) and let Run reap the slim sidecar instead.
-func registerSyncJob(jobID string, req Request, model string, effective, downgrade string) bool {
+// registerFailed must skip finalizeSyncJob (which would otherwise write an
+// orphan .result.json with no backing meta) and let Run reap the slim sidecar
+// instead.
+func registerSyncJob(jobID string, req Request, model string, effective, downgrade string) registerOutcome {
 	if jobID == "" {
-		return false
+		return registerFailed
 	}
 	dir, err := jobsDir()
 	if err != nil {
-		return false
+		return registerFailed
+	}
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
+	// A held meta means the engine's kill-and-HOLD pre-marked this job and
+	// cancelled the very attempt now registering: writing `running` here would
+	// clobber the hold and let the attempt's finalize cache a terminal result
+	// for a live held frame. The caller stops instead.
+	if prev, perr := readMeta(dir, jobID); perr == nil && prev.Status == "held" {
+		return registerHeld
 	}
 	meta := jobMeta{
 		JobID:         jobID,
@@ -1096,7 +1130,7 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 		_ = os.Remove(filepath.Join(dir, jobID+ext))
 	}
 	if err := writeMetaFn(dir, meta); err != nil {
-		return false
+		return registerFailed
 	}
 	// Opt-in board drill-in: persist the prompt to a 0600 side file. Content-privacy,
 	// not key-safety (the provider key never enters the prompt). Best-effort — a write
@@ -1104,7 +1138,7 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 	if req.PersistIO && req.IOPrompt != "" {
 		_ = os.WriteFile(filepath.Join(dir, jobID+".prompt"), []byte(req.IOPrompt), 0o600)
 	}
-	return true
+	return registerOK
 }
 
 // MintQueuedLeaf records a leaf the workflow engine has admitted but not yet given a pool slot:
@@ -1166,14 +1200,21 @@ func FinalizeQueuedLeafFailed(jobID string, res Result) {
 // Status="held" with PID/PGID cleared, so StatusFor's held branch — not the PID
 // fallthrough — classifies it. The engine flips the meta BEFORE cancelling the attempt;
 // finalizeSyncJob then SUPPRESSES the killed attempt's terminal cache, so no terminal
-// cache ever exists during a hold and GC keeps treating the job as live. No-op for an
-// empty id or an unreadable meta.
+// cache ever exists during a hold and GC keeps treating the job as live. A job whose
+// terminal cache already exists settled before the directive (success-beats-kill):
+// the hold is a no-op, keeping the no-cache-under-hold invariant from the other
+// direction. No-op for an empty id or an unreadable meta.
 func HoldLeaf(jobID string) {
 	if jobID == "" {
 		return
 	}
 	dir, err := jobsDir()
 	if err != nil {
+		return
+	}
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
+	if _, serr := os.Stat(filepath.Join(dir, jobID+".result.json")); serr == nil {
 		return
 	}
 	meta, err := readMeta(dir, jobID)
@@ -1186,8 +1227,10 @@ func HoldLeaf(jobID string) {
 }
 
 // ReleaseHeldLeafStopped terminal-stops a HELD leaf (the run is aborting and nothing
-// will ever wake it): the meta leaves `held` FIRST — otherwise finalizeSyncJob's hold
-// suppression would swallow the stopped cache this release exists to write.
+// will ever wake it): the meta leaves `held` FIRST — otherwise the finalize's hold
+// suppression would swallow the stopped cache this release exists to write. The
+// transition and the finalize run under ONE jobMetaMu acquisition (the Locked body —
+// the public wrapper would deadlock).
 func ReleaseHeldLeafStopped(jobID, msg string) {
 	if jobID == "" {
 		return
@@ -1196,13 +1239,15 @@ func ReleaseHeldLeafStopped(jobID, msg string) {
 	if err != nil {
 		return
 	}
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
 	meta, err := readMeta(dir, jobID)
 	if err != nil {
 		return
 	}
 	meta.Status = "stopped"
 	_ = writeMetaFn(dir, meta)
-	finalizeSyncJob(jobID, fail(ErrCodeStopped, msg, meta.Provider, ""))
+	finalizeSyncJobLocked(jobID, fail(ErrCodeStopped, msg, meta.Provider, ""))
 }
 
 // NormalizeHeldLeaf clears a held pre-mark that lost its race: the directive landed
@@ -1217,6 +1262,8 @@ func NormalizeHeldLeaf(jobID string) {
 	if err != nil {
 		return
 	}
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
 	meta, err := readMeta(dir, jobID)
 	if err != nil || meta.Status != "held" {
 		return
@@ -1245,6 +1292,8 @@ func RequeueLeaf(jobID string, attempt int) {
 	if err != nil {
 		return
 	}
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
 	meta, err := readMeta(dir, jobID)
 	if err != nil {
 		return
@@ -1280,22 +1329,31 @@ func NormalizeStaleHolds(runID string) {
 			continue
 		}
 		jobID := strings.TrimSuffix(name, ".json")
-		meta, merr := readMeta(dir, jobID)
-		if merr != nil || meta.RunID != runID || meta.Status != "held" {
-			continue
-		}
-		if data, cerr := os.ReadFile(filepath.Join(dir, jobID+".result.json")); cerr == nil {
-			var r Result
-			if json.Unmarshal(data, &r) == nil && r.Status != "" {
-				meta.Status = r.Status
-				_ = writeMetaFn(dir, meta)
-				continue
-			}
-		}
-		meta.Status = "stopped" // ahead of the finalize so the suppression branch can't fire
-		_ = writeMetaFn(dir, meta)
-		finalizeSyncJob(jobID, fail(ErrCodeStopped, "run restarted while the leaf was held", meta.Provider, ""))
+		normalizeStaleHold(dir, runID, jobID)
 	}
+}
+
+// normalizeStaleHold is one job's sweep step, holding jobMetaMu across the whole
+// read→transition→finalize so nothing interleaves (the finalize goes through the
+// Locked body — the public wrapper would deadlock).
+func normalizeStaleHold(dir, runID, jobID string) {
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
+	meta, merr := readMeta(dir, jobID)
+	if merr != nil || meta.RunID != runID || meta.Status != "held" {
+		return
+	}
+	if data, cerr := os.ReadFile(filepath.Join(dir, jobID+".result.json")); cerr == nil {
+		var r Result
+		if json.Unmarshal(data, &r) == nil && r.Status != "" {
+			meta.Status = r.Status
+			_ = writeMetaFn(dir, meta)
+			return
+		}
+	}
+	meta.Status = "stopped" // ahead of the finalize so the suppression branch can't fire
+	_ = writeMetaFn(dir, meta)
+	finalizeSyncJobLocked(jobID, fail(ErrCodeStopped, "run restarted while the leaf was held", meta.Provider, ""))
 }
 
 // finalizeSyncJob flips a sync job from running → done/failed by writing a
@@ -1306,8 +1364,17 @@ func NormalizeStaleHolds(runID string) {
 // STRIPPED so no provider reply is ever persisted to disk for a sync run (the caller
 // already got it on stdout). A subsequent StatusFor/ListJobs serves this cache.
 // jobID=="" (register failed) is a no-op; it is called from a defer so it runs on
-// the normal return path that produced res.
+// the normal return path that produced res. The read→suppress-or-write section runs
+// under jobMetaMu (a HoldLeaf landing between the meta read and the cache write
+// would otherwise strand a terminal cache under a hold); lifecycle paths already
+// holding the mutex call finalizeSyncJobLocked directly.
 func finalizeSyncJob(jobID string, res Result) {
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
+	finalizeSyncJobLocked(jobID, res)
+}
+
+func finalizeSyncJobLocked(jobID string, res Result) {
 	if jobID == "" {
 		return
 	}

--- a/internal/subagent/queued_test.go
+++ b/internal/subagent/queued_test.go
@@ -24,7 +24,7 @@ func TestMintQueuedLeafThenStatusForQueued(t *testing.T) {
 		t.Errorf("queued placeholder lost its run grouping: %+v", st)
 	}
 	// Flip queued→running (subagent.Run reuses the id via registerSyncJob).
-	if !registerSyncJob(jobID, req, "m", "", "") {
+	if registerSyncJob(jobID, req, "m", "", "") != registerOK {
 		t.Fatal("registerSyncJob(reuse) failed")
 	}
 	if st := StatusFor(jobID); st.Status != "running" {
@@ -52,7 +52,7 @@ func TestRegisterSyncJobClearsStaleCacheOnReuse(t *testing.T) {
 	// Re-registering the SAME id must clear the stale done cache.
 	req2 := req
 	req2.Attempt = 2
-	if !registerSyncJob(jobID, req2, "m", "", "") {
+	if registerSyncJob(jobID, req2, "m", "", "") != registerOK {
 		t.Fatal("re-register failed")
 	}
 	st := StatusFor(jobID)

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -255,7 +255,23 @@ func Run(parent context.Context, req Request) Result {
 	// would otherwise write an orphan .result.json with no backing meta — and a
 	// slim sidecar already written by buildSlimArgv is reaped after the child
 	// exits, since GC keys on the (absent) meta and would never find it.
-	registered := registerSyncJob(jobID, req, model, effective, downgrade)
+	//
+	// registerHeld means the engine's kill-and-HOLD pre-marked this job and
+	// cancelled this very attempt before it registered: the held meta survives
+	// untouched, no cache is written, and the attempt exits as the stop the
+	// cancel asked for.
+	reg := registerSyncJob(jobID, req, model, effective, downgrade)
+	if reg == registerHeld {
+		if slim.promptFile != "" {
+			_ = os.Remove(slim.promptFile)
+		}
+		res := fail(ErrCodeStopped, "leaf held while the attempt was starting", req.Provider, "")
+		res.LeadSessionID = req.LeadSessionID
+		res.RunID, res.Phase, res.Label = req.RunID, req.Phase, req.Label
+		res.PromptProfile, res.SlimDowngrade = effective, downgrade
+		return res
+	}
+	registered := reg == registerOK
 	var res Result
 	if registered {
 		defer func() { finalizeSyncJob(jobID, res) }()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -226,7 +226,7 @@ type Model struct {
 	// no-op until the first completes (and a restart shows a transient "restarting …" status meanwhile).
 	wfRestarting map[string]bool
 	// Save-workflow name prompt: `s` on a run row opens wfSaveInput (prefilled with the run name);
-	// while wfSaving, keys route to the input (enter saves to ~/.config/cc-fleet/workflows/<name>.star,
+	// while wfSaving, keys route to the input (enter saves to ~/.config/cc-fleet/workflows/<name>.js,
 	// esc cancels). wfSaveRun pins the TARGET run at open time — the board keeps refreshing under the
 	// prompt and a reanchor could move the cursor, so enter must not re-resolve it from the row.
 	wfSaveInput textinput.Model

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2145,30 +2145,6 @@ func teamAggregateDot(members []teardown.Teammate) string {
 	return faintStyle.Render("◌")
 }
 
-// jobsAggregateDot rolls the session's jobs up to the rail — a failure is never masked:
-// any failed → ● (err), else any running → ● (accent), else all done → ● (green), else ◌.
-func jobsAggregateDot(jobs []subagent.Result) string {
-	running, done := false, 0
-	for _, j := range jobs {
-		switch j.Status {
-		case "failed":
-			return errStyle.Render("●")
-		case "running":
-			running = true
-		case "done":
-			done++
-		}
-	}
-	switch {
-	case running:
-		return cursorStyle.Render("●")
-	case len(jobs) > 0 && done == len(jobs):
-		return okStyle.Render("●")
-	default:
-		return faintStyle.Render("◌")
-	}
-}
-
 // renderTeammateRowFull is one teammate row (right pane): "<dot> <name>  <model>" left,
 // "<status>[ · hidden] · up <uptime>" right-aligned. The status word stays canonical even on
 // a hidden row (every row carries its `ps --check` health); hidden adds the suffix and the

--- a/internal/workflow/watch.go
+++ b/internal/workflow/watch.go
@@ -168,26 +168,14 @@ func RenderEventLine(ev EventRecord) string {
 // EventTail is the incremental-tail state for a run's events file: the byte offset already
 // consumed, a torn trailing partial line carried across reads, the identity of the generation
 // being tailed, the seq of the last consumed event (contiguity check + reattach hint), and a
-// one-time skip threshold (SinceSeq, for a clean reattach).
-//
-// Watch holds a long-lived *EventTail and calls read directly; the TUI board, which threads
-// per-run tail state by value through its refresh loop, drives the same logic via TailEvents.
+// one-time skip threshold (SinceSeq, for a clean reattach). Watch holds a long-lived
+// *EventTail across its loop and calls read on it.
 type EventTail struct {
 	offset    int64
 	partial   string
 	info      os.FileInfo // generation identity (os.SameFile); nil before the first read
 	cursorSeq int64       // seq of the last consumed event; the reattach hint
 	since     int64       // skip-PRINTING events with Seq <= since (cleared on a generation reset)
-}
-
-// TailEvents is the value-threaded façade over (*EventTail).read for a caller that keeps per-run
-// tail state in a map passed through its own refresh loop (the TUI board): it advances a COPY of
-// prev and returns the new events, the advanced tail to store back, and whether a generation
-// reset was detected. The caller passes the zero EventTail on the first read. (Watch instead
-// holds a *EventTail across its loop and calls read directly.)
-func TailEvents(path string, prev EventTail) (evs []EventRecord, next EventTail, reset bool) {
-	evs, reset = (&prev).read(path)
-	return evs, prev, reset
 }
 
 // read returns the events appended since the last read that are PRINTABLE (Seq > since), plus

--- a/internal/workflow/watch_test.go
+++ b/internal/workflow/watch_test.go
@@ -275,27 +275,29 @@ func TestWatchSinceSeq(t *testing.T) {
 	}
 }
 
-// TestTailEvents exercises the value-threaded façade the board uses: a zero EventTail reads the
-// whole file (reset=false), the returned tail reads only newly-appended events, and an absent
-// file degrades to no events.
-func TestTailEvents(t *testing.T) {
+// TestEventTailIncrementalRead exercises (*EventTail).read directly: a zero EventTail reads
+// the whole file (reset=false), a subsequent read returns only newly-appended events, and an
+// absent file degrades to no events.
+func TestEventTailIncrementalRead(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/x.events"
 	if err := os.WriteFile(path, []byte(eventsJSONL(t, EventRecord{Seq: 1, Kind: "leaf", Label: "a"})), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	evs, tail, reset := TailEvents(path, EventTail{})
+	var tail EventTail
+	evs, reset := tail.read(path)
 	if len(evs) != 1 || reset {
 		t.Fatalf("first read: %d evs, reset=%v; want 1, false", len(evs), reset)
 	}
 	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
 	f.WriteString(eventsJSONL(t, EventRecord{Seq: 2, Kind: "leaf", Label: "b"}))
 	f.Close()
-	evs, _, reset = TailEvents(path, tail)
+	evs, reset = tail.read(path)
 	if len(evs) != 1 || evs[0].Seq != 2 || reset {
 		t.Fatalf("incremental: %d evs (seq %v), reset=%v; want 1 (seq 2), false", len(evs), seqsOf(evs), reset)
 	}
-	if evs, _, reset := TailEvents(dir+"/absent.events", EventTail{}); len(evs) != 0 || reset {
+	var absent EventTail
+	if evs, reset := absent.read(dir + "/absent.events"); len(evs) != 0 || reset {
 		t.Fatalf("absent file: %d evs, reset=%v; want 0, false", len(evs), reset)
 	}
 }


### PR DESCRIPTION
A full-repo review pass on the renamed tree, every finding adversarially verified before being fixed; twenty other candidate findings were refuted during verification and dropped.

The substantial fix closes a hold-protocol race in `internal/subagent`: the engine's kill-and-HOLD pre-marks a leaf's meta `held` and then cancels the attempt, but the attempt's own registration could land inside that window and clobber the meta back to `running`, after which its finalize cached a terminal `stopped` result for a leaf the engine still holds live — handing GC an authoritative "finished" for a live frame. A package mutex now serializes every hold-protocol meta read-modify-write; registration is tri-state (`registerHeld` exits the attempt before `runClaude`, leaving the held meta untouched); `finalizeSyncJob` splits into a locking wrapper over a `Locked` body so lifecycle paths that transition-then-finalize take the mutex exactly once; and `HoldLeaf` no-ops when a terminal cache already exists (success-beats-kill stays authoritative). New interleaving tests pin each ordering, and a live run was stopped into `held` (no terminal cache on disk) and restarted to completion.

The smaller fixes: the openai-chat stream converter no longer emits a `tool_use` stop when no tool block ever opened (a malformed upstream finish could previously promise a block that never existed); a manual `codex-proxy serve` now creates the handshake secret under the same lock `EnsureDaemon` uses, closing a first-creation race; four dead helpers with comments claiming phantom callers are removed (`jobsAggregateDot`, the `TailEvents` façade, `spawn.TeamsDir`, `leadsession.DetectPID`); and two stale comments are corrected (the `default` command's source values, the saved-workflow `.js` extension).
