### PR TITLE
workflow stop/restart --leaf accepts an agent label

### DIFF
--- a/cmd/cc-fleet/workflow.go
+++ b/cmd/cc-fleet/workflow.go
@@ -142,6 +142,13 @@ func newWorkflowRestartCmd() *cobra.Command {
 			if rerr != nil {
 				return reportWorkflowErr(rerr, asJSON)
 			}
+			if leaf != "" {
+				id, lerr := resolveLeafArg(runID, leaf)
+				if lerr != nil {
+					return reportWorkflowErr(lerr, asJSON)
+				}
+				leaf = id
+			}
 			if run.Status == "running" {
 				switch {
 				case cmd.Flags().Changed("phase"):
@@ -201,7 +208,7 @@ func newWorkflowRestartCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&leaf, "leaf", "", "Restart just this agent (job id)")
+	cmd.Flags().StringVar(&leaf, "leaf", "", "Restart just this agent (job id, or its label when unique)")
 	cmd.Flags().StringVar(&phase, "phase", "", "Restart every agent in this phase title")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit a machine-readable JSON envelope")
 	return cmd
@@ -588,13 +595,17 @@ func newWorkflowStopCmd() *cobra.Command {
 			// kills that leaf's attempt and HOLDS it (the run keeps running; restart the
 			// leaf to resume it). No run lock — the engine's poller owns the application.
 			if leaf != "" {
-				if err := workflow.SendLeafCommand(args[0], "stop", leaf); err != nil {
+				id, rerr := resolveLeafArg(args[0], leaf)
+				if rerr != nil {
+					return reportWorkflowErr(rerr, asJSON)
+				}
+				if err := workflow.SendLeafCommand(args[0], "stop", id); err != nil {
 					return reportWorkflowErr(err, asJSON)
 				}
 				if asJSON {
 					return emitWorkflow(workflowEnvelope{OK: true, RunID: args[0], Status: "running"})
 				}
-				fmt.Printf("stop sent for agent %s of %s (it holds until you restart it)\n", leaf, args[0])
+				fmt.Printf("stop sent for agent %s of %s (it holds until you restart it)\n", id, args[0])
 				return nil
 			}
 			// Serialize stop against a concurrent restart/resume of the same run via the per-run
@@ -615,10 +626,47 @@ func newWorkflowStopCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&leaf, "leaf", "", "Stop just this agent (job id) and hold it in place")
+	cmd.Flags().StringVar(&leaf, "leaf", "", "Stop just this agent (job id, or its label when unique) and hold it in place")
 	cmd.Flags().StringVar(&phase, "phase", "", "Stop every agent in this phase title and hold them")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit a machine-readable JSON envelope")
 	return cmd
+}
+
+// resolveLeafArg maps a --leaf argument onto one of the run's job ids via
+// matchLeaf, so stop/restart accept either spelling the board shows.
+func resolveLeafArg(runID, arg string) (string, error) {
+	_, jobs, err := subagent.RunStatus(runID)
+	if err != nil {
+		return "", err
+	}
+	id, err := matchLeaf(jobs, arg)
+	if err != nil {
+		return "", fmt.Errorf("run %s: %w", runID, err)
+	}
+	return id, nil
+}
+
+// matchLeaf resolves a --leaf argument against a run's jobs: an exact job-id
+// match passes through; otherwise the argument is a label — unique within the
+// run resolves to that job's id, ambiguous errors listing every candidate id,
+// and no match names both interpretations.
+func matchLeaf(jobs []subagent.Result, arg string) (string, error) {
+	var labelled []string
+	for _, j := range jobs {
+		if j.JobID == arg {
+			return arg, nil
+		}
+		if j.Label == arg {
+			labelled = append(labelled, j.JobID)
+		}
+	}
+	switch len(labelled) {
+	case 0:
+		return "", fmt.Errorf("no agent with job id or label %q", arg)
+	case 1:
+		return labelled[0], nil
+	}
+	return "", fmt.Errorf("label %q is ambiguous — pass a job id: %s", arg, strings.Join(labelled, ", "))
 }
 
 // emitWorkflow marshals one envelope to stdout and returns nil (cobra then exits

--- a/cmd/cc-fleet/workflow_leaf_test.go
+++ b/cmd/cc-fleet/workflow_leaf_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// matchLeaf accepts either spelling the board shows: a job id passes through,
+// a unique label resolves to its job's id, an ambiguous label lists every
+// candidate, and no match names both interpretations.
+func TestMatchLeaf(t *testing.T) {
+	jobs := []subagent.Result{
+		{JobID: "aaaa-1", Label: "scan"},
+		{JobID: "bbbb-2", Label: "verify"},
+		{JobID: "cccc-3", Label: "verify"},
+	}
+
+	if id, err := matchLeaf(jobs, "aaaa-1"); err != nil || id != "aaaa-1" {
+		t.Fatalf("job-id passthrough = (%q, %v), want (aaaa-1, nil)", id, err)
+	}
+	if id, err := matchLeaf(jobs, "scan"); err != nil || id != "aaaa-1" {
+		t.Fatalf("unique label = (%q, %v), want (aaaa-1, nil)", id, err)
+	}
+	if _, err := matchLeaf(jobs, "verify"); err == nil ||
+		!strings.Contains(err.Error(), "bbbb-2") || !strings.Contains(err.Error(), "cccc-3") {
+		t.Fatalf("ambiguous label must list both candidates, got %v", err)
+	}
+	if _, err := matchLeaf(jobs, "absent"); err == nil ||
+		!strings.Contains(err.Error(), "job id or label") {
+		t.Fatalf("no match must name both interpretations, got %v", err)
+	}
+	if _, err := matchLeaf(nil, "anything"); err == nil {
+		t.Fatalf("empty job list must not resolve")
+	}
+}

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -47,8 +47,8 @@ RUN=$(cc-fleet workflow run audit.js)        # detached; prints ONLY the bare ru
 cc-fleet workflow status "$RUN" --json       # manifest + every tagged leaf (run→phase→agent)
 cc-fleet workflow list --json                # all runs, newest first
 cc-fleet workflow stop "$RUN"                # reap a running run (engine + in-flight leaves)
-cc-fleet workflow stop "$RUN" --leaf <job>   # hold ONE agent in place (run keeps going); --phase <title> holds a phase
-cc-fleet workflow restart "$RUN" --leaf <job>  # re-run a held/running agent in place; --phase <title> a phase;
+cc-fleet workflow stop "$RUN" --leaf <job|label>  # hold ONE agent in place (run keeps going); --phase <title> holds a phase
+cc-fleet workflow restart "$RUN" --leaf <job|label>  # re-run a held/running agent in place; --phase <title> a phase;
                                              # on a FINISHED run: keyed re-run (whole run, --leaf, or --phase)
 # or watch the board's Dynamic Workflows view: live log, token/cost columns, prompt/answer drill-in.
 # x/r there are level-scoped: run row = the run, Phases pane = the phase, agent pane = the leaf


### PR DESCRIPTION
The board's agent rows lead with labels, but `workflow stop/restart --leaf` keyed strictly on job ids — passing the label you see got loudly dropped by the engine's control plane. The flag now accepts either spelling: an exact job id passes through, a label unique within the run resolves to its job id, an ambiguous label errors listing every candidate id, and no match names both interpretations. Resolution happens CLI-side; the control plane still receives only job ids.

Verified by a unit table over the resolver plus a live run: stop by label → `held`, restart by label → completed, with the absent-label error path exercised. Full race suite, gofmt/vet, and the skill drift check are green; the workflow skill's command block now reads `--leaf <job|label>`.
