### PR TITLE
chore(ci): bump goreleaser-action to v7 for the Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
The release run warned that `goreleaser/goreleaser-action@v6` executes on the deprecated node20 runtime; GitHub forces JavaScript actions onto Node 24 from June 16 and removes Node 20 from runners on September 16. v7 is the Node 24 line (`v7.0.0` is exactly the node24/ESM bump; the action's inputs are unchanged), so this moves the release workflow to `@v7`. The job only executes on a version tag — verified here by config review; the next release exercises it for real.