### PR TITLE
chore(release): bump the plugin and npm versions to 0.2.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) as real Claude Code agent-team teammates or one-shot subagents — driven exactly like native teammates. Your main session's own auth is untouched (OAuth subscription or API key, either works); provider workers bill the provider API key via apiKeyHelper (the key never enters env/argv/history). Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API as real Claude Code agent-team teammates or one-shot subagents. The main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
Sets `.claude-plugin/plugin.json` and `npm/package.json` to 0.2.2 ahead of the v0.2.2 tag. The release carries the native `claude` leaf for the subagent and workflow lanes, the provider-form `[1m]` fixes, the tmux-less board degradation, the native Windows installer, and the plugin command trim.