### PR TITLE
fix: make install.ps1 latest-version resolution robust across PowerShell editions

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -51,15 +51,18 @@ if ($VERSION -and ($VERSION -notlike 'v*')) { $VERSION = "v$VERSION" }
 
 if (-not $VERSION -and -not $env:CCF_BASE_URL) {
     # Read the tag from the /releases/latest redirect — no JSON parsing needed.
-    # A 3xx with -MaximumRedirection 0 throws, so the Location usually arrives on
-    # the exception's response: a WebException carries a header collection (5.1),
-    # an HttpResponseException a typed Location property (7+).
+    # -MaximumRedirection 0 stops at the 3xx and returns the response carrying the
+    # Location header; 5.1 also emits a non-terminating error we suppress with
+    # -ErrorAction so the script's 'Stop' preference can't abort the call. Should
+    # only an exception carry the response, read .Response defensively: its shape
+    # varies across editions and an unguarded read throws under StrictMode (#54).
     $loc = $null
     try {
-        $resp = Invoke-WebRequest -Uri "https://github.com/$REPO/releases/latest" -MaximumRedirection 0 -UseBasicParsing
-        $loc = $resp.Headers['Location']
+        $resp = Invoke-WebRequest -Uri "https://github.com/$REPO/releases/latest" -MaximumRedirection 0 -UseBasicParsing -ErrorAction SilentlyContinue
+        if ($resp) { $loc = $resp.Headers['Location'] }
     } catch {
-        $r = $_.Exception.Response
+        $r = $null
+        if ($_.Exception.PSObject.Properties['Response']) { $r = $_.Exception.Response }
         if ($r -is [System.Net.HttpWebResponse]) {
             $loc = $r.Headers['Location']
         } elseif ($r) {


### PR DESCRIPTION
## What
The Windows one-liner `irm .../install.ps1 | iex` aborted before downloading anything while resolving the latest release tag:

> The property 'Response' cannot be found on this object.

## Why
The `/releases/latest` redirect resolver had two edition-specific faults:

1. **StrictMode crash.** Under `Set-StrictMode -Version Latest` the `catch` block read `$_.Exception.Response` unguarded. The exception shape differs between Windows PowerShell 5.1 and PowerShell 7+, so when the caught exception lacks a `Response` property the read itself throws — this is the error in the title.
2. **Resolution still failed after guarding (5.1).** On 5.1 the `-MaximumRedirection 0` call emits a *non-terminating* error that the script's `$ErrorActionPreference = 'Stop'` promoted to terminating. The redirect `Location` actually lives on the **returned response**, while the thrown exception is an `InvalidOperationException` (MaximumRedirectExceeded) with **no `.Response`** — so version resolution failed even once the crash was guarded away.

## Fix
Two minimal changes to the same resolver block:

- Suppress the non-terminating error with `-ErrorAction SilentlyContinue` and read `$resp.Headers['Location']` from the returned response (restores 5.1 resolution; `'Stop'` can no longer abort the call).
- Guard the exception path with `$_.Exception.PSObject.Properties['Response']` before reading `.Response` (no StrictMode crash; the existing 5.1 `HttpWebResponse` / 7+ branches still handle editions whose exception *does* carry the response).

The stale comment describing the old "the 3xx always throws" assumption is updated to match.

## Evidence (reproduced → fixed, Windows PowerShell 5.1)
Running the resolver block under `Set-StrictMode -Version Latest` + `$ErrorActionPreference = 'Stop'`:

| | Before | After |
|---|---|---|
| StrictMode read of `.Response` | throws `The property 'Response' cannot be found on this object.` | guarded — no throw |
| Resolved version | *(crash / empty → `Die`)* | `v0.2.3` |

A full end-to-end run of the patched script also installed cleanly: `==> Downloading cc-fleet-windows-amd64.zip (v0.2.3)` → checksum OK → installed. `install.ps1` parses clean via `[System.Management.Automation.Language.Parser]::ParseFile(...)`. The change is PowerShell-only; no Go files are touched.

Closes #54
