### PR TITLE
fix: keep install.ps1 banners ASCII to avoid cp936 mojibake

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -144,7 +144,7 @@ if (Get-Command claude -ErrorAction SilentlyContinue) {
         Write-Host "    claude plugin install $PLUGIN@$MARKETPLACE --scope $SCOPE"
     }
 } else {
-    Write-Host "==> 'claude' not on PATH — skipped plugin install. To add the skill later:"
+    Write-Host "==> 'claude' not on PATH - skipped plugin install. To add the skill later:"
     Write-Host "    claude plugin marketplace add $REPO --scope $SCOPE"
     Write-Host "    claude plugin install $PLUGIN@$MARKETPLACE --scope $SCOPE"
 }
@@ -154,7 +154,7 @@ if (Get-Command claude -ErrorAction SilentlyContinue) {
 if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
     Write-Host ""
     Write-Host "==> Note: Claude Code ('claude') was not found on PATH."
-    Write-Host "    cc-fleet drives Claude Code — install it to run subagents / workflows:"
+    Write-Host "    cc-fleet drives Claude Code - install it to run subagents / workflows:"
     Write-Host "    https://docs.anthropic.com/claude-code"
 }
 
@@ -179,7 +179,7 @@ if ($onPath) {
 Write-Host ""
 Write-Host "==> Next steps"
 Write-Host ""
-Write-Host "   cc-fleet             # launch the interactive TUI — register a provider and get started"
+Write-Host "   cc-fleet             # launch the interactive TUI - register a provider and get started"
 Write-Host "                        #   (config is auto-created on first save; no init needed)"
 Write-Host "   cc-fleet doctor      # optional: run the health checks"
 Write-Host ""

--- a/release/install.ps1
+++ b/release/install.ps1
@@ -32,7 +32,7 @@ if ($env:CCF_PREFIX) {
 
 $srcExe = Join-Path $SCRIPT_DIR 'cc-fleet.exe'
 if (-not (Test-Path -Path $srcExe -PathType Leaf)) {
-    Write-Host "  (expected $srcExe — is this the extracted release archive?)"
+    Write-Host "  (expected $srcExe - is this the extracted release archive?)"
     Die "prebuilt 'cc-fleet.exe' not found next to this script"
 }
 
@@ -68,7 +68,7 @@ if (Get-Command claude -ErrorAction SilentlyContinue) {
         Write-Host "    claude plugin install $PLUGIN@$MARKETPLACE --scope $SCOPE"
     }
 } else {
-    Write-Host "==> 'claude' not on PATH — skipped plugin install. To add the skill later:"
+    Write-Host "==> 'claude' not on PATH - skipped plugin install. To add the skill later:"
     Write-Host "    claude plugin marketplace add $REPO --scope $SCOPE"
     Write-Host "    claude plugin install $PLUGIN@$MARKETPLACE --scope $SCOPE"
 }
@@ -78,7 +78,7 @@ if (Get-Command claude -ErrorAction SilentlyContinue) {
 if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
     Write-Host ""
     Write-Host "==> Note: Claude Code ('claude') was not found on PATH."
-    Write-Host "    cc-fleet drives Claude Code — install it to run subagents / workflows:"
+    Write-Host "    cc-fleet drives Claude Code - install it to run subagents / workflows:"
     Write-Host "    https://docs.anthropic.com/claude-code"
 }
 
@@ -105,7 +105,7 @@ if ($onPath) {
 Write-Host ""
 Write-Host "==> Next steps"
 Write-Host ""
-Write-Host "   cc-fleet             # launch the interactive TUI — register a provider and get started"
+Write-Host "   cc-fleet             # launch the interactive TUI - register a provider and get started"
 Write-Host "                        #   (config is auto-created on first save; no init needed)"
 Write-Host "   cc-fleet doctor      # optional: run the health checks"
 Write-Host ""


### PR DESCRIPTION
## Summary

`install.ps1` ships as UTF-8 **without a BOM**, so Windows PowerShell 5.1 reads it with the system ANSI code page (e.g. cp936) instead of UTF-8. The em-dashes in the printed "Next steps" banners then decode to mojibake. This replaces the em-dashes in the printed `Write-Host` strings with an ASCII hyphen so the banners are readable under every code page. `release/install.ps1` (shipped in the tarball and read from disk) gets the same treatment.

## Type of change

- [x] Bug fix

## Related issue

Closes #57

## Screenshots / recording

Encoding-only banner change — no UI/TUI surface. Reproduced-then-fixed by decoding the file bytes through cp936 the way PS 5.1 does when there is no BOM:

```
BEFORE (em-dash, UTF-8 no BOM):  ... interactive TUI 鈥?register a provider ...
AFTER  (ASCII hyphen):           ... interactive TUI - register a provider ...
```

The AFTER line is pure ASCII (0 non-ASCII bytes), so it renders identically under every code page **and** on the `irm | iex` path.

## Why ASCII and not a BOM

A UTF-8 BOM would make PS 5.1 read the file as UTF-8 — but `install.ps1` is the `irm | iex` one-liner, and PS 5.1's `irm` can keep the BOM in the fetched content; a leading `U+FEFF` then makes `iex` fail to recognize the first token, which would regress the **primary** install path. ASCII output is unconditionally safe on every read path. Comments keep their em-dashes — they are never printed, so they cause no user-visible mojibake.

## Checklist

- [x] No Go changed — `go test -race ./...`, `gofmt -l .`, `go vet ./...`, `make build` are unaffected
- [x] Not a plugin/skill change — `claude plugin validate` N/A
- [x] Commits follow Conventional Commits; the AI-assisted commit carries a `Co-Authored-By` trailer
