### PR TITLE
feat: show live token usage on the Agents Board while a task runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,11 @@ dev version.
 - **Name validation before use** (`internal/ids`). Provider/team/agent names reach file paths
   and the `apiKeyHelper` string — `ValidateProviderName`/`ValidateTeamName`/
   `ValidateMemberName` + `EnsureUnderRoot`, re-validated in `config.Load` and `profile`.
-- **Nine flock scopes; the nesting trio in order.** `WithProvidersConfigLock` →
-  `WithTeamLock` → `WithServerLock` when combined; the other six (workflow per-run, codexproxy
-  per-port, per-credential token, handshake-secret, selfupdate update, update-check cache) are
-  standalone — held with no other scope. See `docs/architecture.md`.
+- **Ten flock scopes; the nesting trio in order.** `WithProvidersConfigLock` →
+  `WithTeamLock` → `WithServerLock` when combined; the other seven (workflow per-run, codexproxy
+  per-port, per-credential token, handshake-secret, selfupdate update, update-check cache,
+  subagent per-job live-scan checkpoint) are standalone — held with no other scope. See
+  `docs/architecture.md`.
 - **Single outlets.** Every tmux call goes through `tmux.Server`; every atomic write through
   `fileutil.AtomicWrite`. Pane identity is (socket, pane id), never (team, name).
 - **`config.Load` is strict.** Invalid `key_rotation` / unknown `secret_backend` / wrong

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,13 +55,13 @@ Live control runs over a polled per-run control file: `stop --leaf` pre-marks th
 
 ## Concurrency: flock scopes (`config/lock.go` and friends)
 
-Nine scopes. Three nest, strictly in this order when combined:
+Ten scopes. Three nest, strictly in this order when combined:
 
 1. `WithProvidersConfigLock` — the `providers.toml` load→mutate→save cycle (outermost).
 2. `WithTeamLock(team)` — every mutation of per-team state.
 3. `WithServerLock` — global tmux split/layout races (innermost).
 
-The other six are standalone, each held with no other scope: the per-run workflow lifecycle lock; codexproxy's per-port daemon lock; codexproxy's per-credential token lock (read → refresh → persist); the create-once handshake-secret lock; selfupdate's whole-run update lock; and the update-check cache lock.
+The other seven are standalone, each held with no other scope: the per-run workflow lifecycle lock; codexproxy's per-port daemon lock; codexproxy's per-credential token lock (read → refresh → persist); the create-once handshake-secret lock; selfupdate's whole-run update lock; the update-check cache lock; and the subagent per-job live-scan checkpoint lock (a dedicated `<jobID>.scan.lock` file) that serializes a detached background job's incremental token-scan read-modify-write so concurrent board polls can't tick the persisted floor backward.
 
 ## The JSON envelope contract
 

--- a/internal/subagent/activity.go
+++ b/internal/subagent/activity.go
@@ -184,38 +184,42 @@ type streamContent struct {
 	Input json.RawMessage `json:"input"`
 }
 
-// streamAccum carries the running token figure across a leaf's stream-json lines. Output is APPROXIMATE
-// while a message streams and reconciles to the EXACT provider count as each message completes:
-// doneOut is the summed real output of finalized prior messages, curOut is the current message's real
-// cumulative output (set from its message_delta — cumulative, so the latest value wins; multiple deltas
-// in one message never double-count), and turnRunes is a conservative runes estimate used only until
-// curOut is known, so the figure climbs during a long turn instead of jumping only at the end. It is
-// NOT strictly monotonic: an over-running estimate yields DOWN to the authoritative count when
-// message_delta lands. Input is seeded from the prompt estimate and superseded by a real, larger
-// usage.input_tokens; cache is the latest non-zero reported. The exact final arrives from Result.Usage.
+// streamAccum carries a leaf's running token figure across its stream-json lines. ACCOUNTING is exact:
+// doneOut sums each finalized message's REAL output (curOut, from its message_delta — cumulative, so the
+// latest value wins and multiple deltas never double-count), falling back to a conservative runes
+// estimate only for a message that streamed text but reported NO message_delta (some third-party
+// Anthropic-compatible providers). DISPLAY is monotonic: maybeEmitUsage floors the emitted value at the
+// max already shown (lastEmit), so a low real count landing after a higher estimate never dips the board
+// — without inflating the accounting. Input is the peak (grows with context); cache the latest non-zero.
+// The exact final still arrives from Result.Usage at completion.
 type streamAccum struct {
-	inTok     int // latest input tokens (prompt seed, then real)
-	cache     int // latest cache-read input tokens
-	doneOut   int // summed real output of finalized prior messages
-	curOut    int // current message's real cumulative output (0 until its message_delta)
-	turnRunes int // streamed text runes of the current message (estimate source until curOut is known)
-	lastEmit  int // last emitted output (throttle baseline only — not a floor)
+	inTok       int  // latest input tokens (prompt seed, then real)
+	cache       int  // latest cache-read input tokens
+	doneOut     int  // exact summed output of finalized prior messages (real, or estimate when unmeasured)
+	curOut      int  // current message's real cumulative output (0 until its message_delta)
+	curMeasured bool // the current message reported a message_delta (its real output is known)
+	turnRunes   int  // streamed text runes of the current message (estimate source when unmeasured)
+	lastEmit    int  // max output already shown (display floor + throttle baseline)
 }
 
-// runesPerTokenEstimate converts streamed output runes into a CONSERVATIVE token estimate for the
-// in-flight message. It biases low (real output runs ≈4 chars/token, sometimes more) so the live
-// figure tends to settle UP to the exact provider count when message_delta lands rather than snapping
-// down — a clean "finishing" motion instead of a backward step.
+// runesPerTokenEstimate converts streamed output runes into a CONSERVATIVE token estimate for an
+// unmeasured in-flight message. It biases low (real output runs ≈4 chars/token, sometimes more) so the
+// estimate usually sits under the real count and the figure settles UP to the exact total at completion.
 const runesPerTokenEstimate = 5
 
-// estOut is the running output figure: finalized prior messages' real output, plus the current
-// message's real cumulative once message_delta reports it, else the conservative runes estimate.
-func (a *streamAccum) estOut() int {
-	if a.curOut > 0 {
-		return a.doneOut + a.curOut
+// curContribution is the current message's output so far for the ACCOUNTING total: its real cumulative
+// count once message_delta reported it, else the conservative runes estimate (so an unmeasured message
+// still contributes). The real count wins for a measured message; the display floor (lastEmit) handles
+// any visual dip separately, so the accounting is never inflated by an over-running estimate.
+func (a *streamAccum) curContribution() int {
+	if a.curMeasured {
+		return a.curOut
 	}
-	return a.doneOut + a.turnRunes/runesPerTokenEstimate
+	return a.turnRunes / runesPerTokenEstimate
 }
+
+// estOut is the running output figure: finalized prior messages plus the current message's contribution.
+func (a *streamAccum) estOut() int { return a.doneOut + a.curContribution() }
 
 // foldInputCache lifts input/cache from a usage object (message_start, message_delta, or the
 // assembled assistant line): input is the peak (it only grows with context), cache the latest
@@ -241,6 +245,9 @@ const activityUsageStep = 24
 // climbing estimate grew past the throttle. Nil-safe for the writer (scanLiveUsage accumulates only).
 func maybeEmitUsage(w *activityWriter, a *streamAccum, force bool) {
 	out := a.estOut()
+	if out < a.lastEmit {
+		out = a.lastEmit // display floor: never show less than already shown, even when a real count is lower
+	}
 	if a.inTok == 0 && out == 0 && a.cache == 0 {
 		return
 	}
@@ -283,8 +290,13 @@ func parseStreamLine(line []byte, w *activityWriter, a *streamAccum) {
 		}
 		switch sl.Event.Type {
 		case "message_start":
-			a.doneOut += a.curOut // finalize the prior message's real output
+			// Finalize the prior message into the exact accounting total: its REAL count when it reported
+			// a message_delta, else its runes estimate (an unmeasured provider's output isn't lost). The
+			// display floor in maybeEmitUsage keeps the board from dipping; it never feeds back here, so a
+			// measured message is never overcounted. A new message restarts at 0.
+			a.doneOut += a.curContribution()
 			a.curOut = 0
+			a.curMeasured = false
 			a.turnRunes = 0
 			if sl.Event.Message != nil {
 				a.foldInputCache(sl.Event.Message.Usage)
@@ -299,52 +311,105 @@ func parseStreamLine(line []byte, w *activityWriter, a *streamAccum) {
 			a.foldInputCache(sl.Event.Usage)
 			if sl.Event.Usage != nil {
 				a.curOut = sl.Event.Usage.OutputTokens // this message's cumulative output — latest wins, never summed
+				a.curMeasured = true
 			}
 			maybeEmitUsage(w, a, true)
 		}
 	}
 }
 
-// maxLiveScan bounds the per-poll running-status scan of a detached job's .out (StatusFor runs every
-// board tick). A normal output is far smaller; only a multi-MiB output is tail-truncated, where the
-// live figure is best-effort anyway and the terminal classify still reads the whole file.
-const maxLiveScan = 4 << 20 // 4 MiB
-
-// readTailCapped returns up to the last max bytes of the file (the whole file when smaller). The read
-// is HARD-capped via io.LimitReader, so a child appending to the same .out between the stat and the
-// read can never make this poll read more than max — the extra bytes are picked up on the next poll.
-// A tail cut may split the first line; scanLiveUsage skips an unparseable line, so it loses that one.
-func readTailCapped(path string, max int64) []byte {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > max {
-		if _, seekErr := f.Seek(fi.Size()-max, io.SeekStart); seekErr != nil {
-			return nil
-		}
-	}
-	data, _ := io.ReadAll(io.LimitReader(f, max))
-	return data
+// scanState is a detached job's persisted scan checkpoint (<jobID>.scan): the byte offset consumed so
+// far plus the running accumulator. Each StatusFor poll parses ONLY the .out bytes appended since the
+// last one, so the per-poll cost is bounded to the new bytes and the running total is kept for the
+// whole capture no matter how large it grows. Best-effort: a missing/torn checkpoint just restarts the
+// scan from offset 0 — the figure is always re-derivable from (off, accumulator) + the bytes after off,
+// so concurrent pollers need no lock (a raced stale write only makes the next poll re-parse a little).
+type scanState struct {
+	Off       int64 `json:"off"`
+	DoneOut   int   `json:"done_out"`
+	CurOut    int   `json:"cur_out"`
+	Measured  bool  `json:"measured"` // the in-flight message has reported a message_delta
+	TurnRunes int   `json:"turn_runes"`
+	InTok     int   `json:"in_tok"`
+	Cache     int   `json:"cache"`
+	LastOut   int   `json:"last_out"` // display floor: the max output already shown (never dips across polls)
 }
 
-// scanLiveUsage runs the same accumulation as the live sink over a (possibly partial) stream-json
-// capture and returns the running usage, or nil when nothing has been reported yet. The background
-// lane has no live writer (its child is detached), so StatusFor calls this each poll to fill a running
-// job's Usage from its growing .out — making its board token count climb without a sidecar.
-func scanLiveUsage(stdout []byte) *Usage {
-	a := &streamAccum{}
-	sc := bufio.NewScanner(bytes.NewReader(stdout))
-	sc.Buffer(make([]byte, 0, 64*1024), maxChildOutput)
-	for sc.Scan() {
-		parseStreamLine(sc.Bytes(), nil, a) // nil writer: accumulate only, never emit
+func (st scanState) accum() *streamAccum {
+	return &streamAccum{inTok: st.InTok, cache: st.Cache, doneOut: st.DoneOut, curOut: st.CurOut,
+		curMeasured: st.Measured, turnRunes: st.TurnRunes, lastEmit: st.LastOut}
+}
+
+// usage is the figure shown to the board: the exact accounting total, floored at LastOut so it never
+// dips across polls (a low real count never undoes a higher figure already shown). nil until anything
+// has been reported.
+func (st scanState) usage() *Usage {
+	out := st.accum().estOut()
+	if out < st.LastOut {
+		out = st.LastOut
 	}
-	out := a.estOut()
-	if a.inTok == 0 && out == 0 && a.cache == 0 {
+	if st.InTok == 0 && out == 0 && st.Cache == 0 {
 		return nil
 	}
-	return &Usage{InputTokens: a.inTok, OutputTokens: out, CacheReadInputTokens: a.cache}
+	return &Usage{InputTokens: st.InTok, OutputTokens: out, CacheReadInputTokens: st.Cache}
+}
+
+// scanLiveUsage updates a detached job's running usage by parsing only the stream-json .out bytes
+// appended since the last poll (tracked by the <jobID>.scan checkpoint) and persisting the advanced
+// checkpoint. The background lane has no live writer (its child is detached), so StatusFor calls this
+// each poll to make the job's board token count climb without a sidecar. Returns nil when nothing has
+// been reported yet.
+func scanLiveUsage(outPath, statePath string) *Usage {
+	st := loadScanState(statePath)
+	f, err := os.Open(outPath)
+	if err != nil {
+		return st.usage()
+	}
+	defer f.Close()
+	if fi, statErr := f.Stat(); statErr != nil || st.Off > fi.Size() {
+		st = scanState{} // unreadable, or the capture is shorter than our offset (rotated) → restart
+	}
+	if _, err := f.Seek(st.Off, io.SeekStart); err != nil {
+		return st.usage()
+	}
+	data, err := io.ReadAll(f) // only the new bytes since st.Off
+	if err != nil {
+		return st.usage()
+	}
+	a := st.accum()
+	// Parse only COMPLETE lines (through the last newline); a partial trailing line still being written
+	// is left for the next poll, so a delta is never half-counted.
+	if nl := bytes.LastIndexByte(data, '\n'); nl >= 0 {
+		for _, line := range bytes.Split(data[:nl], []byte{'\n'}) {
+			parseStreamLine(line, nil, a) // nil writer: accumulate only, never emit
+		}
+		floor := a.estOut()
+		if floor < st.LastOut {
+			floor = st.LastOut // carry the display floor forward — the shown figure never dips
+		}
+		st = scanState{Off: st.Off + int64(nl) + 1, DoneOut: a.doneOut, CurOut: a.curOut, Measured: a.curMeasured,
+			TurnRunes: a.turnRunes, InTok: a.inTok, Cache: a.cache, LastOut: floor}
+		saveScanState(statePath, st)
+	}
+	return st.usage()
+}
+
+// loadScanState reads a job's scan checkpoint; a missing or torn file degrades to the zero state
+// (a full re-scan), so a crash mid-write never corrupts the count.
+func loadScanState(path string) scanState {
+	var st scanState
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &st)
+	}
+	return st
+}
+
+// saveScanState persists the advanced checkpoint, best-effort: the checkpoint is a regenerable cache
+// (re-derivable from the .out), so a lost or torn write just costs the next poll a re-parse.
+func saveScanState(path string, st scanState) {
+	if data, err := json.Marshal(st); err == nil {
+		_ = os.WriteFile(path, data, 0o600)
+	}
 }
 
 // ToolArgPreview renders a tool_use input as a single safe line: the primary argument value

--- a/internal/subagent/activity.go
+++ b/internal/subagent/activity.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/ethanhq/cc-fleet/internal/config"
 	"github.com/ethanhq/cc-fleet/internal/redact"
 )
 
@@ -52,6 +53,21 @@ func newActivityWriter(path string) *activityWriter {
 		return nil
 	}
 	return &activityWriter{path: path}
+}
+
+// freshActivitySidecar empties a prior attempt's .activity that survived the best-effort restart cleanup
+// (a failed remove — e.g. a Windows open-handle race), so the new attempt's writer appends to a clean
+// file. The board synthesizes a snapshot's attempt from the live meta, so a surviving stale/mixed sidecar
+// would be read as the current attempt; truncating before the running meta is published makes the
+// sidecar's content provably this attempt's. Truncate-only (no O_CREATE): an absent file is a no-op, so
+// it never leaves an orphan when the cleanup already removed the file. Best-effort, nil-path-safe.
+func freshActivitySidecar(path string) {
+	if path == "" {
+		return
+	}
+	if f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); err == nil {
+		_ = f.Close()
+	}
 }
 
 // estimatePromptTokens roughly estimates a prompt's input-token count from its rune count (≈3 runes
@@ -157,7 +173,7 @@ func (s *activitySink) consume(w *activityWriter) {
 // never the assistant line. The terminal type:"result" line is handled by classify/extractResultLine.
 type streamLine struct {
 	Type    string         `json:"type"`
-	Message *streamMessage `json:"message"` // type:"assistant" (assembled message); message_start nests one
+	Message *streamMessage `json:"message"` // type:"assistant" (assembled message)
 	Event   *streamEvent   `json:"event"`   // type:"stream_event": the wrapped SSE event
 }
 
@@ -321,9 +337,10 @@ func parseStreamLine(line []byte, w *activityWriter, a *streamAccum) {
 // scanState is a detached job's persisted scan checkpoint (<jobID>.scan): the byte offset consumed so
 // far plus the running accumulator. Each StatusFor poll parses ONLY the .out bytes appended since the
 // last one, so the per-poll cost is bounded to the new bytes and the running total is kept for the
-// whole capture no matter how large it grows. Best-effort: a missing/torn checkpoint just restarts the
-// scan from offset 0 — the figure is always re-derivable from (off, accumulator) + the bytes after off,
-// so concurrent pollers need no lock (a raced stale write only makes the next poll re-parse a little).
+// whole capture no matter how large it grows. The accounting (off + accumulator) is re-derivable, so a
+// torn/missing checkpoint just restarts the scan from offset 0; but LastOut (the display floor) is NOT
+// re-derivable, so scanLiveUsage serializes the whole read-modify-write per job (a flock on a dedicated
+// <jobID>.scan.lock file) — concurrent board polls can't clobber the floor with a stale, lower value.
 type scanState struct {
 	Off       int64 `json:"off"`
 	DoneOut   int   `json:"done_out"`
@@ -358,8 +375,24 @@ func (st scanState) usage() *Usage {
 // appended since the last poll (tracked by the <jobID>.scan checkpoint) and persisting the advanced
 // checkpoint. The background lane has no live writer (its child is detached), so StatusFor calls this
 // each poll to make the job's board token count climb without a sidecar. Returns nil when nothing has
-// been reported yet.
+// been reported yet. The checkpoint read-modify-write is serialized per job (a blocking flock keyed by
+// the .scan path) so two concurrent board polls — the 500ms and 3s chains scan the same job — can't
+// interleave: a slower poll can never write back a stale, lower display floor and tick the board down.
 func scanLiveUsage(outPath, statePath string) *Usage {
+	var u *Usage
+	// Serialize on a DEDICATED lock file (a separate inode from the .scan data file the body reads and
+	// rewrites): locking the data file itself and then re-opening it to write would collide on Windows,
+	// where a byte-range lock plus a second write handle to the same file fails.
+	if err := config.WithFlock(statePath+".lock", func() error {
+		u = scanLiveUsageLocked(outPath, statePath)
+		return nil
+	}); err != nil {
+		return nil // lock unobtainable (e.g. dir vanished) → no figure this poll, never a wrong one
+	}
+	return u
+}
+
+func scanLiveUsageLocked(outPath, statePath string) *Usage {
 	st := loadScanState(statePath)
 	f, err := os.Open(outPath)
 	if err != nil {

--- a/internal/subagent/activity.go
+++ b/internal/subagent/activity.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -125,16 +126,14 @@ func (s *activitySink) close() {
 	<-s.done
 }
 
-// consume reassembles complete NDJSON lines across chunk boundaries and parses each. outRunes and
-// outTokens accumulate, across the whole run, the model's streamed output text (for the pre-usage
-// estimate) and the summed real per-message output tokens (the leaf's running output total).
+// consume reassembles complete NDJSON lines across chunk boundaries and feeds each to
+// parseStreamLine, which accumulates the leaf's running token usage in a streamAccum.
 func (s *activitySink) consume(w *activityWriter) {
 	defer close(s.done)
 	var buf []byte
-	var outRunes, outTokens int
-	inTokens := 0
+	a := &streamAccum{}
 	if w != nil {
-		inTokens = w.inputSeed // start input at the prompt estimate; a real usage.input_tokens supersedes it
+		a.inTok = w.inputSeed // start input at the prompt estimate; a real usage.input_tokens supersedes it
 	}
 	for chunk := range s.lines {
 		buf = append(buf, chunk...)
@@ -143,17 +142,35 @@ func (s *activitySink) consume(w *activityWriter) {
 			if i < 0 {
 				break
 			}
-			parseStreamLine(buf[:i], w, &outRunes, &outTokens, &inTokens)
+			parseStreamLine(buf[:i], w, a)
 			buf = buf[i+1:]
 		}
 	}
 }
 
-// streamLine / streamMessage / streamContent are the LENIENT view of a `--output-format stream-json`
-// NDJSON line — only the fields activity capture needs; everything else is ignored.
+// streamLine is the LENIENT view of a stream-json NDJSON line — only the fields activity capture
+// needs. With --include-partial-messages claude wraps the raw Anthropic SSE in type:"stream_event":
+// message_start carries the input/cache usage, content_block_delta streams text_delta chunks (the
+// live estimate), and message_delta carries the message's real cumulative output_tokens (the
+// authoritative per-message figure). The assembled type:"assistant" line still arrives, but under
+// partials its usage.output_tokens is an early placeholder, so output is taken from message_delta —
+// never the assistant line. The terminal type:"result" line is handled by classify/extractResultLine.
 type streamLine struct {
 	Type    string         `json:"type"`
-	Message *streamMessage `json:"message"`
+	Message *streamMessage `json:"message"` // type:"assistant" (assembled message); message_start nests one
+	Event   *streamEvent   `json:"event"`   // type:"stream_event": the wrapped SSE event
+}
+
+type streamEvent struct {
+	Type    string         `json:"type"`    // message_start | content_block_delta | message_delta | …
+	Message *streamMessage `json:"message"` // message_start: the opening message (input/cache usage)
+	Delta   *streamDelta   `json:"delta"`   // content_block_delta: the text chunk
+	Usage   *innerUsage    `json:"usage"`   // message_delta: the message's cumulative usage
+}
+
+type streamDelta struct {
+	Type string `json:"type"` // "text_delta" for streamed output text
+	Text string `json:"text"`
 }
 
 type streamMessage struct {
@@ -162,57 +179,172 @@ type streamMessage struct {
 }
 
 type streamContent struct {
-	Type  string          `json:"type"` // "text" | "tool_use" | "tool_result" | …
+	Type  string          `json:"type"` // "tool_use" | "text" | … (only tool_use is read; live text streams via streamDelta)
 	Name  string          `json:"name"` // tool_use: the tool name
 	Input json.RawMessage `json:"input"`
-	Text  string          `json:"text"` // text block: the streamed model output (for the live token estimate)
 }
 
-// parseStreamLine decodes one stream-json line: it emits a tool record per tool_use block and one
-// usage snapshot per assistant message. Output is a MONOTONIC cumulative for the leaf: the summed real
-// output_tokens of MEASURED messages (those whose usage the provider reported) PLUS a runes/3 estimate
-// for the text of UNMEASURED messages (≈3 runes/token). A measured message's own text does NOT feed
-// the estimate — its real count already covers it — so confirmed usage is never overridden by the
-// estimate, and the two non-decreasing terms keep the count from ever stepping backward. cc-fleet
-// parses CLAUDE's normalized stream (`--output-format stream-json --verbose`, no partial messages →
-// exactly one usage per assistant message), so summing the measured messages is the cumulative without
-// double-counting; the estimate covers providers that stream no per-message usage until the result line.
-// Input is seeded from the prompt estimate (so the live count is never 0 even for a no-usage,
-// tool-heavy leaf) and superseded by a real, larger usage.input_tokens; cache is the latest reported.
-// The accurate final still arrives from Result.Usage on completion. A non-assistant line / decode
-// error is skipped; the result line is handled by classify.
-func parseStreamLine(line []byte, w *activityWriter, outRunes, outTokens, inTokens *int) {
+// streamAccum carries the running token figure across a leaf's stream-json lines. Output is APPROXIMATE
+// while a message streams and reconciles to the EXACT provider count as each message completes:
+// doneOut is the summed real output of finalized prior messages, curOut is the current message's real
+// cumulative output (set from its message_delta — cumulative, so the latest value wins; multiple deltas
+// in one message never double-count), and turnRunes is a conservative runes estimate used only until
+// curOut is known, so the figure climbs during a long turn instead of jumping only at the end. It is
+// NOT strictly monotonic: an over-running estimate yields DOWN to the authoritative count when
+// message_delta lands. Input is seeded from the prompt estimate and superseded by a real, larger
+// usage.input_tokens; cache is the latest non-zero reported. The exact final arrives from Result.Usage.
+type streamAccum struct {
+	inTok     int // latest input tokens (prompt seed, then real)
+	cache     int // latest cache-read input tokens
+	doneOut   int // summed real output of finalized prior messages
+	curOut    int // current message's real cumulative output (0 until its message_delta)
+	turnRunes int // streamed text runes of the current message (estimate source until curOut is known)
+	lastEmit  int // last emitted output (throttle baseline only — not a floor)
+}
+
+// runesPerTokenEstimate converts streamed output runes into a CONSERVATIVE token estimate for the
+// in-flight message. It biases low (real output runs ≈4 chars/token, sometimes more) so the live
+// figure tends to settle UP to the exact provider count when message_delta lands rather than snapping
+// down — a clean "finishing" motion instead of a backward step.
+const runesPerTokenEstimate = 5
+
+// estOut is the running output figure: finalized prior messages' real output, plus the current
+// message's real cumulative once message_delta reports it, else the conservative runes estimate.
+func (a *streamAccum) estOut() int {
+	if a.curOut > 0 {
+		return a.doneOut + a.curOut
+	}
+	return a.doneOut + a.turnRunes/runesPerTokenEstimate
+}
+
+// foldInputCache lifts input/cache from a usage object (message_start, message_delta, or the
+// assembled assistant line): input is the peak (it only grows with context), cache the latest
+// non-zero. Output is never taken here — it comes only from message_delta.
+func (a *streamAccum) foldInputCache(u *innerUsage) {
+	if u == nil {
+		return
+	}
+	if u.InputTokens > a.inTok {
+		a.inTok = u.InputTokens
+	}
+	if u.CacheReadInputTokens > 0 {
+		a.cache = u.CacheReadInputTokens
+	}
+}
+
+// activityUsageStep throttles the climbing estimate: a content_block_delta emits a new usage row only
+// once output has grown by at least this many tokens — bounding sidecar writes while still updating
+// well within the board's 0.1k display resolution. A message_start / message_delta force-emits.
+const activityUsageStep = 24
+
+// maybeEmitUsage writes a usage snapshot on a forced event (message boundary / reconcile) or once the
+// climbing estimate grew past the throttle. Nil-safe for the writer (scanLiveUsage accumulates only).
+func maybeEmitUsage(w *activityWriter, a *streamAccum, force bool) {
+	out := a.estOut()
+	if a.inTok == 0 && out == 0 && a.cache == 0 {
+		return
+	}
+	if !force && out-a.lastEmit < activityUsageStep {
+		return
+	}
+	a.lastEmit = out
+	w.emit(activityRecord{Kind: "usage", In: a.inTok, Out: out, Cache: a.cache})
+}
+
+// parseStreamLine decodes one stream-json line and updates the accumulator, emitting a tool record per
+// tool_use block and throttled/reconciled usage snapshots. With --include-partial-messages the real
+// per-message output arrives on message_delta as a cumulative count (the assistant line's usage is an
+// early placeholder, so output is never taken from it); content_block_delta text feeds the in-flight
+// estimate until then. A non-matching line / decode error is skipped; the terminal result line is
+// handled by classify.
+func parseStreamLine(line []byte, w *activityWriter, a *streamAccum) {
 	if len(bytes.TrimSpace(line)) == 0 {
 		return
 	}
 	var sl streamLine
-	if json.Unmarshal(line, &sl) != nil || sl.Type != "assistant" || sl.Message == nil {
+	if json.Unmarshal(line, &sl) != nil {
 		return
 	}
-	msgRunes := 0
-	for _, c := range sl.Message.Content {
-		if c.Type == "tool_use" && c.Name != "" {
-			w.emit(activityRecord{Kind: "tool", Tool: c.Name, Arg: ToolArgPreview(c.Input)})
+	switch sl.Type {
+	case "assistant":
+		if sl.Message == nil {
+			return
 		}
-		if c.Type == "text" && c.Text != "" {
-			msgRunes += utf8.RuneCountInString(c.Text)
+		for _, c := range sl.Message.Content {
+			if c.Type == "tool_use" && c.Name != "" {
+				w.emit(activityRecord{Kind: "tool", Tool: c.Name, Arg: ToolArgPreview(c.Input)})
+			}
+		}
+		a.foldInputCache(sl.Message.Usage) // input/cache only; output comes from message_delta
+		maybeEmitUsage(w, a, false)
+	case "stream_event":
+		if sl.Event == nil {
+			return
+		}
+		switch sl.Event.Type {
+		case "message_start":
+			a.doneOut += a.curOut // finalize the prior message's real output
+			a.curOut = 0
+			a.turnRunes = 0
+			if sl.Event.Message != nil {
+				a.foldInputCache(sl.Event.Message.Usage)
+			}
+			maybeEmitUsage(w, a, true) // establish the input/context figure right away (even before output)
+		case "content_block_delta":
+			if d := sl.Event.Delta; d != nil && d.Type == "text_delta" {
+				a.turnRunes += utf8.RuneCountInString(d.Text)
+				maybeEmitUsage(w, a, false)
+			}
+		case "message_delta":
+			a.foldInputCache(sl.Event.Usage)
+			if sl.Event.Usage != nil {
+				a.curOut = sl.Event.Usage.OutputTokens // this message's cumulative output — latest wins, never summed
+			}
+			maybeEmitUsage(w, a, true)
 		}
 	}
-	cache := 0
-	if u := sl.Message.Usage; u != nil {
-		cache = u.CacheReadInputTokens
-		if u.InputTokens > *inTokens {
-			*inTokens = u.InputTokens // real per-turn input (the growing context) supersedes the seed
+}
+
+// maxLiveScan bounds the per-poll running-status scan of a detached job's .out (StatusFor runs every
+// board tick). A normal output is far smaller; only a multi-MiB output is tail-truncated, where the
+// live figure is best-effort anyway and the terminal classify still reads the whole file.
+const maxLiveScan = 4 << 20 // 4 MiB
+
+// readTailCapped returns up to the last max bytes of the file (the whole file when smaller). The read
+// is HARD-capped via io.LimitReader, so a child appending to the same .out between the stat and the
+// read can never make this poll read more than max — the extra bytes are picked up on the next poll.
+// A tail cut may split the first line; scanLiveUsage skips an unparseable line, so it loses that one.
+func readTailCapped(path string, max int64) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > max {
+		if _, seekErr := f.Seek(fi.Size()-max, io.SeekStart); seekErr != nil {
+			return nil
 		}
-		*outTokens += u.OutputTokens // measured message: its real output joins the running total
-	} else {
-		*outRunes += msgRunes // unmeasured message: its text feeds the estimate
 	}
-	in := *inTokens
-	out := *outTokens + *outRunes/3 // real (measured) + estimate (unmeasured) — both non-decreasing
-	if in > 0 || out > 0 || cache > 0 {
-		w.emit(activityRecord{Kind: "usage", In: in, Out: out, Cache: cache})
+	data, _ := io.ReadAll(io.LimitReader(f, max))
+	return data
+}
+
+// scanLiveUsage runs the same accumulation as the live sink over a (possibly partial) stream-json
+// capture and returns the running usage, or nil when nothing has been reported yet. The background
+// lane has no live writer (its child is detached), so StatusFor calls this each poll to fill a running
+// job's Usage from its growing .out — making its board token count climb without a sidecar.
+func scanLiveUsage(stdout []byte) *Usage {
+	a := &streamAccum{}
+	sc := bufio.NewScanner(bytes.NewReader(stdout))
+	sc.Buffer(make([]byte, 0, 64*1024), maxChildOutput)
+	for sc.Scan() {
+		parseStreamLine(sc.Bytes(), nil, a) // nil writer: accumulate only, never emit
 	}
+	out := a.estOut()
+	if a.inTok == 0 && out == 0 && a.cache == 0 {
+		return nil
+	}
+	return &Usage{InputTokens: a.inTok, OutputTokens: out, CacheReadInputTokens: a.cache}
 }
 
 // ToolArgPreview renders a tool_use input as a single safe line: the primary argument value

--- a/internal/subagent/activity_test.go
+++ b/internal/subagent/activity_test.go
@@ -68,13 +68,16 @@ func TestToolArgPreview(t *testing.T) {
 }
 
 // TestActivitySink_CapFirstAndParses: the sink tees to the byte-cap FIRST (overflow still fires) and
-// writes tool/usage rows parsed from the stream to the activity sidecar.
+// writes tool/usage rows parsed from the partial-message stream to the activity sidecar — input/cache
+// from message_start, the tool from the assistant line, output reconciled from message_delta.
 func TestActivitySink_CapFirstAndParses(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "x.activity")
 	out := &cappedWriter{limit: 1 << 20}
 	w := newActivityWriter(path)
 	sink := newActivitySink(out, w)
-	sink.Write([]byte(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"echo hi"}}],"usage":{"input_tokens":10,"output_tokens":2,"cache_read_input_tokens":3}}}` + "\n"))
+	sink.Write([]byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":3}}}}` + "\n"))
+	sink.Write([]byte(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"echo hi"}}]}}` + "\n"))
+	sink.Write([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":42}}}` + "\n"))
 	sink.Write([]byte(`{"type":"result","subtype":"success","result":"ok"}` + "\n"))
 	sink.close()
 
@@ -82,17 +85,23 @@ func TestActivitySink_CapFirstAndParses(t *testing.T) {
 		t.Fatal("sink must tee bytes into the cap")
 	}
 	recs := readActivity(t, path)
-	if len(recs) != 2 {
-		t.Fatalf("got %d activity records, want 2 (tool + usage); %+v", len(recs), recs)
+	var tool, usage *activityRecord
+	for i := range recs {
+		switch recs[i].Kind {
+		case "tool":
+			tool = &recs[i]
+		case "usage":
+			usage = &recs[i] // keep the latest usage row (what the board reads)
+		}
 	}
-	if recs[0].Kind != "tool" || recs[0].Tool != "Bash" || recs[0].Arg != "echo hi" {
-		t.Errorf("tool record = %+v", recs[0])
+	if tool == nil || tool.Tool != "Bash" || tool.Arg != "echo hi" {
+		t.Errorf("tool record = %+v", tool)
 	}
-	if recs[1].Kind != "usage" || recs[1].In != 10 || recs[1].Out != 2 || recs[1].Cache != 3 {
-		t.Errorf("usage record = %+v", recs[1])
+	if usage == nil || usage.In != 10 || usage.Out != 42 || usage.Cache != 3 {
+		t.Errorf("usage record = %+v", usage)
 	}
-	if recs[0].Seq != 1 || recs[1].Seq != 2 {
-		t.Errorf("seqs not monotonic: %d, %d", recs[0].Seq, recs[1].Seq)
+	if len(recs) == 0 || recs[0].Seq != 1 {
+		t.Errorf("seq must start at 1, got %+v", recs)
 	}
 }
 
@@ -137,6 +146,26 @@ func TestFinalizeSyncJob_KeepsSafeMetricsStripsAnswer(t *testing.T) {
 	}
 }
 
+// TestReadTailCapped_BoundsRead: the running-status scan must never read more than the cap, even when
+// the file is far larger (the bound is what keeps the per-poll cost flat on a big background output).
+func TestReadTailCapped_BoundsRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.out")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 500)), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := readTailCapped(path, 100); len(got) != 100 {
+		t.Fatalf("read %d bytes, want exactly the 100-byte cap", len(got))
+	}
+	// A file under the cap is returned whole.
+	small := filepath.Join(t.TempDir(), "small.out")
+	if err := os.WriteFile(small, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := readTailCapped(small, 100); string(got) != "hello" {
+		t.Fatalf("small file should return whole, got %q", got)
+	}
+}
+
 func readActivity(t *testing.T, path string) []activityRecord {
 	t.Helper()
 	f, err := os.Open(path)
@@ -155,79 +184,107 @@ func readActivity(t *testing.T, path string) []activityRecord {
 	return out
 }
 
-// TestParseStreamLine_EstimatesOutput: when an assistant message streams text but NO usage (the
-// provider case), parseStreamLine emits a live OUTPUT estimate (~runes/3) so the board count climbs.
-func TestParseStreamLine_EstimatesOutput(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "x.activity")
+// TestParseStreamLine_EstimatesThenReconciles: a content_block_delta streams text → a live runes-based
+// estimate climbs (so the board moves mid-turn); message_delta then reconciles output to the message's
+// real figure (replacing the estimate, not adding to it).
+func TestParseStreamLine_EstimatesThenReconciles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.activity")
 	w := newActivityWriter(path)
-	outRunes, outTokens, inTokens := 0, 0, 0
-	line := []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"` + strings.Repeat("字", 30) + `"}]}}`)
-	parseStreamLine(line, w, &outRunes, &outTokens, &inTokens)
-	data, _ := os.ReadFile(path)
-	if !strings.Contains(string(data), `"out":10`) { // 30 runes / 3, no real usage yet
-		t.Fatalf("expected an estimated output usage row (~10), got:\n%s", data)
+	a := &streamAccum{}
+	// 150 runes / 5 → 30 estimate (past the throttle), emitted live.
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"`+strings.Repeat("字", 150)+`"}}}`), w, a)
+	if data, _ := os.ReadFile(path); !strings.Contains(string(data), `"out":30`) {
+		t.Fatalf("expected a live output estimate (~30) from streamed text, got:\n%s", data)
 	}
-	// A measured message adds its real output (99) on top of the carried estimate of the earlier
-	// unmeasured message (10) → 109; the measured message's own text is not double-counted as estimate.
-	line2 := []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"x"}],"usage":{"input_tokens":5,"output_tokens":99}}}`)
-	parseStreamLine(line2, w, &outRunes, &outTokens, &inTokens)
-	if data, _ := os.ReadFile(path); !strings.Contains(string(data), `"out":109`) {
-		t.Fatalf("the measured output (99) should add to the carried estimate (10) → 109, got:\n%s", data)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":99}}}`), w, a)
+	if data, _ := os.ReadFile(path); !strings.Contains(string(data), `"out":99`) {
+		t.Fatalf("message_delta should reconcile output to the real 99, got:\n%s", data)
 	}
 }
 
-// TestParseStreamLine_CumulativeOutput: successive real per-message output_tokens accumulate into a
-// monotonic leaf total (50 then 120) — never the later single message's 70 — so the count climbs and
-// never steps backward.
-func TestParseStreamLine_CumulativeOutput(t *testing.T) {
+// TestParseStreamLine_CrossMessageOutput: per-message real outputs accumulate ACROSS messages (a new
+// message_start finalizes the prior message's count), so a multi-turn leaf's total climbs 50 → 120.
+func TestParseStreamLine_CrossMessageOutput(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "c.activity")
 	w := newActivityWriter(path)
-	outRunes, outTokens, inTokens := 0, 0, 0
-	parseStreamLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"a"}],"usage":{"output_tokens":50}}}`), w, &outRunes, &outTokens, &inTokens)
-	parseStreamLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"b"}],"usage":{"output_tokens":70}}}`), w, &outRunes, &outTokens, &inTokens)
+	a := &streamAccum{}
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":50}}}`), w, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{}}}}`), w, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":70}}}`), w, a)
 	data, _ := os.ReadFile(path)
 	if !strings.Contains(string(data), `"out":50`) || !strings.Contains(string(data), `"out":120`) {
-		t.Fatalf("expected cumulative output rows 50 then 120, got:\n%s", data)
-	}
-	if strings.Contains(string(data), `"out":70`) {
-		t.Fatalf("the later message's raw 70 must not be emitted (it should sum to 120), got:\n%s", data)
+		t.Fatalf("expected cross-message rows 50 then 120 (50 + the second message's 70), got:\n%s", data)
 	}
 }
 
-// TestParseStreamLine_NoBackwardWhenRealFollowsEstimate: an unmeasured message's estimate (300 runes →
-// 100) is CARRIED, not undercut, when a later measured message lands — its real output (10) ADDS to the
-// carried estimate (→ 110), so the count climbs and never steps backward across the estimate→real edge.
-func TestParseStreamLine_NoBackwardWhenRealFollowsEstimate(t *testing.T) {
+// TestParseStreamLine_CumulativeDeltaNotSummed: multiple message_delta events WITHIN one message carry
+// a growing CUMULATIVE output; the latest wins (30 then 40 → 40), never summed (would be 70).
+func TestParseStreamLine_CumulativeDeltaNotSummed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "d.activity")
+	w := newActivityWriter(path)
+	a := &streamAccum{}
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":30}}}`), w, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":40}}}`), w, a)
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), `"out":40`) {
+		t.Fatalf("the latest cumulative output (40) must win, got:\n%s", data)
+	}
+	if strings.Contains(string(data), `"out":70`) {
+		t.Fatalf("two cumulative deltas in one message must NOT be summed to 70, got:\n%s", data)
+	}
+}
+
+// TestParseStreamLine_EstimateReconcilesToReal: the live figure is APPROXIMATE — an over-running
+// estimate (400 runes / 5 → 80) yields to the authoritative per-message count (10) when message_delta
+// lands. It tracks the truth rather than holding an inflated estimate; the exact final is Result.Usage.
+func TestParseStreamLine_EstimateReconcilesToReal(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "m.activity")
 	w := newActivityWriter(path)
-	outRunes, outTokens, inTokens := 0, 0, 0
-	parseStreamLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"`+strings.Repeat("x", 300)+`"}]}}`), w, &outRunes, &outTokens, &inTokens)
-	parseStreamLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"y"}],"usage":{"output_tokens":10}}}`), w, &outRunes, &outTokens, &inTokens)
+	a := &streamAccum{}
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"`+strings.Repeat("x", 400)+`"}}}`), w, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":10}}}`), w, a)
 	var outs []int
 	for _, r := range readActivity(t, path) {
 		if r.Kind == "usage" {
 			outs = append(outs, r.Out)
 		}
 	}
-	if len(outs) != 2 || outs[0] != 100 || outs[1] != 110 {
-		t.Fatalf("expected the estimate (100) then real-added-to-carried-estimate (110), got %v", outs)
+	if len(outs) != 2 || outs[0] != 80 || outs[1] != 10 {
+		t.Fatalf("expected the estimate (80) then a reconcile to the real count (10), got %v", outs)
 	}
 }
 
-// TestParseStreamLine_InputSeedCarry: input is seeded (the prompt estimate) and carried, so a tool-only
-// assistant message (no usage, no text) still emits a usage row with the seeded input — the board's
-// live token count is never a literal 0; a real, larger usage.input_tokens then supersedes the seed.
+// TestParseStreamLine_InputSeedCarry: input is seeded (the prompt estimate); message_start force-emits
+// it right away so the board's context figure shows before any output, and a real, larger
+// usage.input_tokens then supersedes the seed.
 func TestParseStreamLine_InputSeedCarry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "i.activity")
 	w := newActivityWriter(path)
-	outRunes, outTokens, inTokens := 0, 0, 1200 // input seeded from the prompt estimate
-	parseStreamLine([]byte(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`), w, &outRunes, &outTokens, &inTokens)
+	a := &streamAccum{inTok: 1200} // input seeded from the prompt estimate
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{}}}}`), w, a)
 	if data, _ := os.ReadFile(path); !strings.Contains(string(data), `"in":1200`) {
-		t.Fatalf("a tool-only message must still emit the seeded input (1200), got:\n%s", data)
+		t.Fatalf("message_start must emit the seeded input (1200), got:\n%s", data)
 	}
-	parseStreamLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"x"}],"usage":{"input_tokens":5000,"output_tokens":10}}}`), w, &outRunes, &outTokens, &inTokens)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"input_tokens":5000,"output_tokens":10}}}`), w, a)
 	if data, _ := os.ReadFile(path); !strings.Contains(string(data), `"in":5000`) {
 		t.Fatalf("a real input_tokens (5000) must supersede the seed, got:\n%s", data)
+	}
+}
+
+// TestScanLiveUsage_PartialAndReconciled: the background poll scan returns a climbing estimate from a
+// partial capture (text deltas, no message_delta yet) and the reconciled real output once message_delta
+// lands; a capture with no usage at all returns nil.
+func TestScanLiveUsage_PartialAndReconciled(t *testing.T) {
+	partial := []byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":2000}}}}` + "\n" +
+		`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"` + strings.Repeat("x", 80) + `"}}}` + "\n")
+	if u := scanLiveUsage(partial); u == nil || u.InputTokens != 2000 || u.OutputTokens != 16 {
+		t.Fatalf("partial scan: want in=2000 out=16 (80 runes/5), got %+v", u)
+	}
+	full := append(append([]byte{}, partial...), []byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":42}}}`+"\n")...)
+	if u := scanLiveUsage(full); u == nil || u.OutputTokens != 42 {
+		t.Fatalf("full scan: want out=42 (reconciled), got %+v", u)
+	}
+	if scanLiveUsage([]byte(`{"type":"system"}`+"\n")) != nil {
+		t.Fatalf("a capture with no usage should return nil")
 	}
 }

--- a/internal/subagent/activity_test.go
+++ b/internal/subagent/activity_test.go
@@ -6,8 +6,35 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
+
+// TestFreshActivitySidecar_TruncatesStale: a restart reuses the job id, and the best-effort cleanup can
+// leave a prior attempt's .activity (a failed remove). The new attempt must start from an EMPTY sidecar
+// so the board, which stamps a snapshot's attempt from the live meta, never reads stale rows as the
+// current attempt.
+func TestFreshActivitySidecar_TruncatesStale(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "job.activity")
+	if err := os.WriteFile(path, []byte(`{"kind":"usage","in":5000,"out":800}`+"\n"), 0o600); err != nil {
+		t.Fatalf("seed stale sidecar: %v", err)
+	}
+	freshActivitySidecar(path)
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after fresh: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a new attempt must start from an empty sidecar, got %q", got)
+	}
+	// Truncate-only: an absent sidecar (the cleanup already removed it) is a no-op — never recreated as
+	// an orphan empty file.
+	absent := filepath.Join(t.TempDir(), "gone.activity")
+	freshActivitySidecar(absent)
+	if _, err := os.Stat(absent); !os.IsNotExist(err) {
+		t.Fatalf("freshActivitySidecar must not create an absent sidecar, got %v", err)
+	}
+}
 
 // TestExtractResultLine: the type:"result" line is found by SCANNING (not last-line) — a trailing
 // SessionStart hook_response after the result must not shadow it.
@@ -342,5 +369,62 @@ func TestScanLiveUsage_IncrementalCheckpoint(t *testing.T) {
 	// An absent capture (nothing reported yet) returns nil.
 	if scanLiveUsage(filepath.Join(dir, "absent.out"), filepath.Join(dir, "absent.scan")) != nil {
 		t.Fatal("an absent capture should return nil")
+	}
+}
+
+// TestScanLiveUsage_FloorHeldWhenRealLower: a later poll whose accounting drops (a real per-message
+// count landing under an earlier estimate) must not lower the persisted display floor — the board
+// figure holds, while the accounting underneath stays exact.
+func TestScanLiveUsage_FloorHeldWhenRealLower(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "j.out")
+	statePath := filepath.Join(dir, "j.scan")
+	write := func(s string) {
+		f, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		_, _ = f.WriteString(s)
+		_ = f.Close()
+	}
+	// Poll 1: 500 runes, no message_delta → estimate 100 → floor 100.
+	write(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"` + strings.Repeat("x", 500) + `"}}}` + "\n")
+	if u := scanLiveUsage(outPath, statePath); u == nil || u.OutputTokens != 100 {
+		t.Fatalf("poll 1: want out=100, got %+v", u)
+	}
+	// Poll 2: the real per-message count lands low (10); the display floor holds 100.
+	write(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":10}}}` + "\n")
+	if u := scanLiveUsage(outPath, statePath); u == nil || u.OutputTokens != 100 {
+		t.Fatalf("poll 2: the floor must hold at 100, got %+v", u)
+	}
+	if got := loadScanState(statePath).LastOut; got != 100 {
+		t.Fatalf("persisted floor must stay 100, got %d", got)
+	}
+}
+
+// TestScanLiveUsage_ConcurrentPollsHoldFloor: the 500ms and 3s board chains scan the same job
+// concurrently; the per-job flock serializes the checkpoint read-modify-write, so no poll sees the
+// floor dip and the file never races (run under -race).
+func TestScanLiveUsage_ConcurrentPollsHoldFloor(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "j.out")
+	statePath := filepath.Join(dir, "j.scan")
+	if err := os.WriteFile(outPath, []byte(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"`+strings.Repeat("x", 500)+`"}}}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	scanLiveUsage(outPath, statePath) // establish the floor at 100
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if u := scanLiveUsage(outPath, statePath); u == nil || u.OutputTokens < 100 {
+				t.Errorf("a concurrent poll saw the floor dip: %+v", u)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := loadScanState(statePath).LastOut; got != 100 {
+		t.Fatalf("persisted floor changed under concurrent polls: %d", got)
 	}
 }

--- a/internal/subagent/activity_test.go
+++ b/internal/subagent/activity_test.go
@@ -146,26 +146,6 @@ func TestFinalizeSyncJob_KeepsSafeMetricsStripsAnswer(t *testing.T) {
 	}
 }
 
-// TestReadTailCapped_BoundsRead: the running-status scan must never read more than the cap, even when
-// the file is far larger (the bound is what keeps the per-poll cost flat on a big background output).
-func TestReadTailCapped_BoundsRead(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "big.out")
-	if err := os.WriteFile(path, []byte(strings.Repeat("x", 500)), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if got := readTailCapped(path, 100); len(got) != 100 {
-		t.Fatalf("read %d bytes, want exactly the 100-byte cap", len(got))
-	}
-	// A file under the cap is returned whole.
-	small := filepath.Join(t.TempDir(), "small.out")
-	if err := os.WriteFile(small, []byte("hello"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if got := readTailCapped(small, 100); string(got) != "hello" {
-		t.Fatalf("small file should return whole, got %q", got)
-	}
-}
-
 func readActivity(t *testing.T, path string) []activityRecord {
 	t.Helper()
 	f, err := os.Open(path)
@@ -234,10 +214,10 @@ func TestParseStreamLine_CumulativeDeltaNotSummed(t *testing.T) {
 	}
 }
 
-// TestParseStreamLine_EstimateReconcilesToReal: the live figure is APPROXIMATE — an over-running
-// estimate (400 runes / 5 → 80) yields to the authoritative per-message count (10) when message_delta
-// lands. It tracks the truth rather than holding an inflated estimate; the exact final is Result.Usage.
-func TestParseStreamLine_EstimateReconcilesToReal(t *testing.T) {
+// TestParseStreamLine_MonotonicHoldsEstimate: the live figure never dips — an over-running estimate
+// (400 runes / 5 → 80) is HELD when a lower real count (10) lands, because the current message
+// contributes max(real, estimate). The exact final still arrives from Result.Usage at completion.
+func TestParseStreamLine_MonotonicHoldsEstimate(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "m.activity")
 	w := newActivityWriter(path)
 	a := &streamAccum{}
@@ -249,8 +229,53 @@ func TestParseStreamLine_EstimateReconcilesToReal(t *testing.T) {
 			outs = append(outs, r.Out)
 		}
 	}
-	if len(outs) != 2 || outs[0] != 80 || outs[1] != 10 {
-		t.Fatalf("expected the estimate (80) then a reconcile to the real count (10), got %v", outs)
+	if len(outs) == 0 {
+		t.Fatal("expected at least one usage row")
+	}
+	for i, o := range outs {
+		if o < 80 {
+			t.Fatalf("the figure must not dip below the estimate (80); outs=%v (row %d = %d)", outs, i, o)
+		}
+	}
+}
+
+// TestParseStreamLine_MeasuredCarriesReal: when an over-running estimate (400 runes → 80) is followed by
+// a LOWER real count (message_delta 10), the ACCOUNTING carries the real 10 into doneOut at the next
+// message_start — never the inflated estimate — while the DISPLAY floor holds the figure (≥80) so the
+// board doesn't dip. This keeps a measured message from being permanently overcounted.
+func TestParseStreamLine_MeasuredCarriesReal(t *testing.T) {
+	a := &streamAccum{}
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"`+strings.Repeat("x", 400)+`"}}}`), nil, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":10}}}`), nil, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{}}}}`), nil, a)
+	if a.doneOut != 10 {
+		t.Fatalf("a measured message must carry its REAL count (10) into doneOut, not the estimate (80); doneOut=%d", a.doneOut)
+	}
+	if a.lastEmit < 80 {
+		t.Fatalf("the display floor must hold the figure (≥80), got lastEmit=%d", a.lastEmit)
+	}
+}
+
+// TestParseStreamLine_NoDeltaCarriesEstimate: a message that streamed text but reported NO message_delta
+// (some third-party Anthropic-compatible providers) must not lose its output — at the next message_start
+// its estimate is carried into doneOut, and the running total stays ≥ the first message's estimate.
+func TestParseStreamLine_NoDeltaCarriesEstimate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nd.activity")
+	w := newActivityWriter(path)
+	a := &streamAccum{}
+	// msg1: 500 runes / 5 → 100 estimate, NO message_delta.
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"`+strings.Repeat("x", 500)+`"}}}`), w, a)
+	// msg2 begins: msg1's 100 estimate must carry into doneOut, not vanish.
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{}}}}`), w, a)
+	parseStreamLine([]byte(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"`+strings.Repeat("y", 150)+`"}}}`), w, a)
+	var last int
+	for _, r := range readActivity(t, path) {
+		if r.Kind == "usage" {
+			last = r.Out
+		}
+	}
+	if last < 130 { // carried 100 + the 30 of msg2's in-flight estimate
+		t.Fatalf("a no-message_delta message's estimate must carry across the boundary, got last out=%d", last)
 	}
 }
 
@@ -271,20 +296,51 @@ func TestParseStreamLine_InputSeedCarry(t *testing.T) {
 	}
 }
 
-// TestScanLiveUsage_PartialAndReconciled: the background poll scan returns a climbing estimate from a
-// partial capture (text deltas, no message_delta yet) and the reconciled real output once message_delta
-// lands; a capture with no usage at all returns nil.
-func TestScanLiveUsage_PartialAndReconciled(t *testing.T) {
-	partial := []byte(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":2000}}}}` + "\n" +
-		`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"` + strings.Repeat("x", 80) + `"}}}` + "\n")
-	if u := scanLiveUsage(partial); u == nil || u.InputTokens != 2000 || u.OutputTokens != 16 {
-		t.Fatalf("partial scan: want in=2000 out=16 (80 runes/5), got %+v", u)
+// TestScanLiveUsage_IncrementalCheckpoint: the background scan parses only the bytes appended since the
+// last poll (tracked by the .scan checkpoint) and keeps the running total across the whole capture, so
+// the count climbs across polls and never drops regardless of file size.
+func TestScanLiveUsage_IncrementalCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "j.out")
+	statePath := filepath.Join(dir, "j.scan")
+	write := func(s string) {
+		f, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		_, _ = f.WriteString(s)
+		_ = f.Close()
 	}
-	full := append(append([]byte{}, partial...), []byte(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":42}}}`+"\n")...)
-	if u := scanLiveUsage(full); u == nil || u.OutputTokens != 42 {
-		t.Fatalf("full scan: want out=42 (reconciled), got %+v", u)
+
+	// Poll 1: message_start + a text delta → the live estimate (80 runes / 5 = 16).
+	write(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":2000}}}}` + "\n")
+	write(`{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"` + strings.Repeat("x", 80) + `"}}}` + "\n")
+	u1 := scanLiveUsage(outPath, statePath)
+	if u1 == nil || u1.InputTokens != 2000 || u1.OutputTokens != 16 {
+		t.Fatalf("poll 1: want in=2000 out=16, got %+v", u1)
 	}
-	if scanLiveUsage([]byte(`{"type":"system"}`+"\n")) != nil {
-		t.Fatalf("a capture with no usage should return nil")
+	off1 := loadScanState(statePath).Off
+	if off1 == 0 {
+		t.Fatal("checkpoint offset should advance after poll 1")
+	}
+
+	// Poll 2: append msg1's real count and a whole second message → totals accumulate across polls.
+	write(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":50}}}` + "\n")
+	write(`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{}}}}` + "\n")
+	write(`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":70}}}` + "\n")
+	u2 := scanLiveUsage(outPath, statePath)
+	if u2 == nil || u2.OutputTokens != 120 { // 50 (msg1) carried + 70 (msg2)
+		t.Fatalf("poll 2: want out=120 (50+70 accumulated across the capture), got %+v", u2)
+	}
+	if u2.OutputTokens < u1.OutputTokens {
+		t.Fatalf("the running figure dropped across polls: %d -> %d", u1.OutputTokens, u2.OutputTokens)
+	}
+	if loadScanState(statePath).Off <= off1 {
+		t.Fatal("checkpoint offset should advance again on poll 2")
+	}
+
+	// An absent capture (nothing reported yet) returns nil.
+	if scanLiveUsage(filepath.Join(dir, "absent.out"), filepath.Join(dir, "absent.scan")) != nil {
+		t.Fatal("an absent capture should return nil")
 	}
 }

--- a/internal/subagent/helpers_test.go
+++ b/internal/subagent/helpers_test.go
@@ -12,13 +12,10 @@ import (
 // process/exec helpers (writeFakeBin, writeMinimalProviders, deadReapedPID,
 // readPID, waitGone) live in helpers_unix_test.go.
 
-// Real inner envelopes captured from a smoke run.
-const smokeSuccessJSON = `{"type":"result","subtype":"success","is_error":false,"api_error_status":null,
- "duration_ms":3654,"duration_api_ms":3385,"ttft_ms":3397,"num_turns":1,"stop_reason":"end_turn",
- "session_id":"84c5b474-aaaa","total_cost_usd":0.258409,
- "usage":{"input_tokens":50750,"cache_read_input_tokens":18,"output_tokens":186,"service_tier":"standard"},
- "modelUsage":{"mimo-v2-flash":{"inputTokens":50750,"outputTokens":186,"costUSD":0.258409}},
- "result":"SUBAGENT_SMOKE_OK=42","permission_denials":[],"terminal_reason":"completed"}`
+// Real inner envelope captured from a smoke run. ONE line: claude emits the terminal result as a
+// single NDJSON line (stream-json) / single json object, and the background scan distills it via
+// extractResultLine, which is line-oriented — a multi-line fixture would not be found.
+const smokeSuccessJSON = `{"type":"result","subtype":"success","is_error":false,"api_error_status":null,"duration_ms":3654,"duration_api_ms":3385,"ttft_ms":3397,"num_turns":1,"stop_reason":"end_turn","session_id":"84c5b474-aaaa","total_cost_usd":0.258409,"usage":{"input_tokens":50750,"cache_read_input_tokens":18,"output_tokens":186,"service_tier":"standard"},"modelUsage":{"mimo-v2-flash":{"inputTokens":50750,"outputTokens":186,"costUSD":0.258409}},"result":"SUBAGENT_SMOKE_OK=42","permission_denials":[],"terminal_reason":"completed"}`
 
 const smoke429BalanceJSON = `{"type":"result","subtype":"success","is_error":true,"api_error_status":429,
  "duration_ms":178257,"duration_api_ms":0,"num_turns":1,"stop_reason":"stop_sequence",

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -490,12 +490,13 @@ func StatusFor(jobID string) Result {
 			SlimDowngrade: meta.SlimDowngrade,
 			Attempt:       meta.Attempt,
 		}
-		// A detached job has no live activity writer, so scan its growing stream-json
-		// .out for the running token count — making its board figure climb mid-run.
-		// The read is tail-bounded so a poll stays cheap on a very large output (the
-		// terminal classify below still reads the whole file for the exact count).
+		// A detached job has no live activity writer, so each poll scans its growing stream-json .out
+		// for the running token count, parsing ONLY the bytes appended since the last poll (tracked by
+		// the <jobID>.scan checkpoint) so the cost stays flat and the total is kept for the whole
+		// capture regardless of size. The terminal classify below reads the whole file for the exact
+		// count.
 		if meta.Stream {
-			res.Usage = scanLiveUsage(readTailCapped(filepath.Join(dir, jobID+".out"), maxLiveScan))
+			res.Usage = scanLiveUsage(filepath.Join(dir, jobID+".out"), filepath.Join(dir, jobID+".scan"))
 		}
 		return res
 	}
@@ -504,7 +505,7 @@ func StatusFor(jobID string) Result {
 	// exit code; the terminal envelope is the only signal. This runs ONCE per job (the result is then
 	// cached), so it reads the whole .out: a stream-json transcript's type:"result" line carries the
 	// full answer and can sit anywhere, so the classify read must be complete — only the per-poll
-	// running scan above is tail-bounded (best-effort live; the terminal must be exact).
+	// running scan above is incremental (best-effort live; the terminal must be exact).
 	outPath := filepath.Join(dir, jobID+".out")
 	errPath := filepath.Join(dir, jobID+".err")
 	stdout, _ := os.ReadFile(outPath)
@@ -562,6 +563,8 @@ func StatusFor(jobID string) Result {
 	if data, merr := json.Marshal(res); merr == nil {
 		_ = os.WriteFile(resultPath, data, 0o600)
 	}
+	// The live-scan checkpoint is moot once terminal (StatusFor serves the cache now); drop it.
+	_ = os.Remove(filepath.Join(dir, jobID+".scan"))
 	return res
 }
 
@@ -1069,7 +1072,7 @@ func readMeta(dir, jobID string) (jobMeta, error) {
 // removeJob deletes every file in a job's group (best-effort), including the opt-in
 // drill-in side files (.prompt / .answer) and a slim run's prompt sidecar (.slimprompt).
 func removeJob(dir, jobID string) {
-	for _, suffix := range []string{".json", ".out", ".err", ".prompt", ".answer", ".activity", ".slimprompt", ".result.json"} {
+	for _, suffix := range []string{".json", ".out", ".err", ".prompt", ".answer", ".activity", ".scan", ".slimprompt", ".result.json"} {
 		_ = os.Remove(filepath.Join(dir, jobID+suffix))
 	}
 }

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -43,16 +43,20 @@ var maxPromptBytes = 10 << 20 // 10 MiB
 // secret (prompt/answer are intentionally NOT persisted here) — just enough to
 // poll the process and re-classify its captured stdout later.
 type jobMeta struct {
-	JobID         string `json:"job_id"`
-	PID           int    `json:"pid"`
-	PGID          int    `json:"pgid"`
-	Provider      string `json:"provider"`
-	Model         string `json:"model"`
-	StartedAt     string `json:"started_at"`
-	Status        string `json:"status"`
-	Resume        string `json:"resume,omitempty"`
-	OutputFormat  string `json:"output_format,omitempty"`
-	JSON          bool   `json:"json"`
+	JobID        string `json:"job_id"`
+	PID          int    `json:"pid"`
+	PGID         int    `json:"pgid"`
+	Provider     string `json:"provider"`
+	Model        string `json:"model"`
+	StartedAt    string `json:"started_at"`
+	Status       string `json:"status"`
+	Resume       string `json:"resume,omitempty"`
+	OutputFormat string `json:"output_format,omitempty"`
+	JSON         bool   `json:"json"`
+	// Stream marks a background job whose .out is stream-json (not a single json
+	// envelope): StatusFor scans it for live usage while running and routes the
+	// dead-branch classify through extractResultLine. Absent on a legacy json meta.
+	Stream        bool   `json:"stream,omitempty"`
 	LeadSessionID string `json:"lead_session_id,omitempty"`
 	// SettingsPath is the claude `--settings <profile>` for a BACKGROUND job: the
 	// per-provider profile path, unique enough to bind meta.PID to its claude child
@@ -125,9 +129,11 @@ var materializePromptFn = materializePromptReader
 // child runs with its OWN process group and NO deadline so it survives the
 // parent cc-fleet exiting (poll it with StatusFor / subagent-status).
 //
-// Background runs always use claude's `--output-format json` so StatusFor can
-// rely on the envelope rather than a placeholder exit code, making text-mode
-// background failures classify correctly instead of false-reporting `done`.
+// Background runs always stream claude's `--output-format stream-json` (with
+// partial messages): StatusFor scans the growing .out for a live, climbing token
+// count while the job runs, and classifies the terminal type:"result" line via
+// extractResultLine. launchBackground OWNS this inner format — no caller field
+// decides it — so a text-mode background failure still classifies correctly.
 //
 // Any failure between cmd.Start and the final Release triggers a process-group
 // SIGTERM (200ms grace) → SIGKILL → Wait → file cleanup so we never leak a
@@ -141,11 +147,13 @@ func launchBackground(req Request, binaryPath, profilePath, model, effective, do
 		return fail(ErrCodeFailed, fmt.Sprintf("mkdir jobs dir: %v", err), req.Provider, "")
 	}
 
-	// Force inner JSON so StatusFor classifies via the envelope, not exitCode=0.
-	// Outer JSON/text formatting is unaffected (it only changes how
-	// reportSubagent prints the final Result).
+	// Stream the inner output as stream-json (+ partial messages) so StatusFor can
+	// scan the .out for a live token count and classify the terminal result line.
+	// buildArgv's switch checks StreamActivity FIRST, so setting it here is the sole
+	// authority on the inner format regardless of the caller's OutputFormat/JSON.
+	// Outer JSON/text formatting is unaffected (the persisted meta keeps req's).
 	innerReq := req
-	innerReq.OutputFormat = "json"
+	innerReq.StreamActivity = true
 
 	jobID := uuid.NewString()
 	outPath := filepath.Join(dir, jobID+".out")
@@ -247,15 +255,15 @@ func launchBackground(req Request, binaryPath, profilePath, model, effective, do
 		Resume:    req.Resume,
 		PersistIO: req.PersistIO, // finalize (via StatusFor) writes .answer only when carried here
 		// Persist the outer (user-facing) format flags so subagent-status can
-		// still render the operator's preferred shape (text vs JSON).
-		// OutputFormat stays as the caller asked; JSON is force-set true below
-		// regardless of the caller, because the inner argv is ALWAYS
-		// --output-format json for background launches, so StatusFor must
-		// classify stdout as an envelope. Without it, a text-mode background job
-		// whose child wrote a JSON error envelope would be blessed as
-		// status:"done" by the text-mode fallback.
+		// still render the operator's preferred shape (text vs JSON). OutputFormat
+		// stays as the caller asked; JSON is force-set true regardless of the
+		// caller so StatusFor treats the .out as an envelope (the inner stream-json
+		// carries a type:"result" line classify reads via extractResultLine).
+		// Without it, a text-mode background job whose child wrote a JSON error
+		// envelope would be blessed as status:"done" by the text-mode fallback.
 		OutputFormat:  req.OutputFormat,
 		JSON:          true,
+		Stream:        true, // the .out is stream-json: scan-for-live-usage + extract-result-line on classify
 		LeadSessionID: req.LeadSessionID,
 		SettingsPath:  profilePath, // binds this pid to its claude child (reuse guard)
 		RunID:         req.RunID,
@@ -464,7 +472,7 @@ func StatusFor(jobID string) Result {
 	}
 
 	if processAlive(meta.PID, meta.SettingsPath, meta.ProcStart) {
-		return Result{
+		res := Result{
 			OK:            true,
 			JobID:         jobID,
 			Status:        "running",
@@ -482,24 +490,44 @@ func StatusFor(jobID string) Result {
 			SlimDowngrade: meta.SlimDowngrade,
 			Attempt:       meta.Attempt,
 		}
+		// A detached job has no live activity writer, so scan its growing stream-json
+		// .out for the running token count — making its board figure climb mid-run.
+		// The read is tail-bounded so a poll stays cheap on a very large output (the
+		// terminal classify below still reads the whole file for the exact count).
+		if meta.Stream {
+			res.Usage = scanLiveUsage(readTailCapped(filepath.Join(dir, jobID+".out"), maxLiveScan))
+		}
+		return res
 	}
 
 	// Dead → classify the captured output. The detached child was Released, so we can't reap a real
-	// exit code; the (json) envelope or (text) answer is the only terminal signal.
+	// exit code; the terminal envelope is the only signal. This runs ONCE per job (the result is then
+	// cached), so it reads the whole .out: a stream-json transcript's type:"result" line carries the
+	// full answer and can sit anywhere, so the classify read must be complete — only the per-poll
+	// running scan above is tail-bounded (best-effort live; the terminal must be exact).
 	outPath := filepath.Join(dir, jobID+".out")
 	errPath := filepath.Join(dir, jobID+".err")
 	stdout, _ := os.ReadFile(outPath)
 	stderr, _ := os.ReadFile(errPath)
 	innerJSON := meta.JSON || meta.OutputFormat == "json"
-	// A detached json leaf can be seen dead a moment before its envelope write lands. When the
+	// A stream-json .out is multi-line NDJSON; classify wants the single type:"result" line, so
+	// distill it (the sync StreamActivity path does the same). A legacy json .out passes through.
+	if meta.Stream {
+		stdout = extractResultLine(stdout)
+	}
+	// A detached leaf can be seen dead a moment before its result write lands. When the result
 	// capture is empty, re-read once after a short delay before classifying, so a late write
 	// isn't cached as a failure. The capture file's EXISTENCE is the detached marker (only a
 	// detached launch creates it; sync metas never do) — not the profile path, which a native
-	// (reserved `claude`) job legitimately lacks. Non-empty output skips the wait.
+	// (reserved `claude`) job legitimately lacks. A non-empty result skips the wait.
 	if _, statErr := os.Stat(outPath); statErr == nil && innerJSON && strings.TrimSpace(string(stdout)) == "" {
 		time.Sleep(statusConfirmDelay)
-		stdout, _ = os.ReadFile(outPath)
 		stderr, _ = os.ReadFile(errPath)
+		raw, _ := os.ReadFile(outPath)
+		if meta.Stream {
+			raw = extractResultLine(raw)
+		}
+		stdout = raw
 	}
 	var res Result
 	if vanishedWithoutResult(stdout, innerJSON) {

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -563,8 +563,10 @@ func StatusFor(jobID string) Result {
 	if data, merr := json.Marshal(res); merr == nil {
 		_ = os.WriteFile(resultPath, data, 0o600)
 	}
-	// The live-scan checkpoint is moot once terminal (StatusFor serves the cache now); drop it.
-	_ = os.Remove(filepath.Join(dir, jobID+".scan"))
+	// The live-scan checkpoint is moot once terminal (StatusFor serves the cache now), but it is left for
+	// removeJob to GC: a poll that passed the alive check before this transition may still be mid-scan,
+	// and the .scan.lock flock is never unlinked at all — unlink+recreate would hand a concurrent scanner
+	// a different inode and break the serialization (the same rule the per-run .lock follows).
 	return res
 }
 
@@ -1071,6 +1073,9 @@ func readMeta(dir, jobID string) (jobMeta, error) {
 
 // removeJob deletes every file in a job's group (best-effort), including the opt-in
 // drill-in side files (.prompt / .answer) and a slim run's prompt sidecar (.slimprompt).
+// .scan.lock is deliberately absent: it is a flock file, never GC'd — unlinking one a board
+// poll might still hold would recreate a different inode and break the scan serialization
+// (the same rule the per-run .lock follows).
 func removeJob(dir, jobID string) {
 	for _, suffix := range []string{".json", ".out", ".err", ".prompt", ".answer", ".activity", ".scan", ".slimprompt", ".result.json"} {
 		_ = os.Remove(filepath.Join(dir, jobID+suffix))
@@ -1200,6 +1205,14 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 	// done/answer. No-op for a fresh id.
 	for _, ext := range []string{".result.json", ".answer", ".activity"} {
 		_ = os.Remove(filepath.Join(dir, jobID+ext))
+	}
+	// The remove above is best-effort; for a streamed leaf, GUARANTEE the activity sidecar is empty
+	// before the meta goes live — a survivor (a failed remove) would otherwise be read as this attempt's
+	// activity the instant the job becomes visible as running. Truncate-only, so it never creates an orphan.
+	if req.StreamActivity {
+		if p, perr := leafActivityPath(jobID); perr == nil {
+			freshActivitySidecar(p)
+		}
 	}
 	if err := writeMetaFn(dir, meta); err != nil {
 		return registerFailed

--- a/internal/subagent/job_cleanup_test.go
+++ b/internal/subagent/job_cleanup_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -98,13 +99,13 @@ func TestLaunchBackground_CleanupOnWriteMetaFailure(t *testing.T) {
 	}
 }
 
-// TestLaunchBackground_ForcesInnerJSON: even when the caller asks for text-mode
+// TestLaunchBackground_ForcesStreamJSON: even when the caller asks for text-mode
 // output (req.OutputFormat = "text"), background launches MUST run claude with
-// --output-format json so StatusFor can classify via the envelope rather than a
-// placeholder exit code. We detect this by snooping the meta's OutputFormat
-// (which stays "text" — the outer print format), then asserting the actual argv
-// contained "--output-format json".
-func TestLaunchBackground_ForcesInnerJSON(t *testing.T) {
+// --output-format stream-json (+ partial messages) so StatusFor can scan live
+// usage and classify the terminal result line. We detect this by asserting the
+// actual argv emitted the coupled --output-format stream-json plus the partial
+// flag, while the meta's OutputFormat stays "text" (the outer print format).
+func TestLaunchBackground_ForcesStreamJSON(t *testing.T) {
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	t.Setenv("HOME", t.TempDir())
@@ -164,10 +165,13 @@ exit 0
 	}
 	// The flag and its value must be ADJACENT (the script writes one arg per
 	// line): two loose tokens anywhere in the argv would not prove
-	// `--output-format json` was actually emitted as a coupled pair.
+	// `--output-format stream-json` was actually emitted as a coupled pair.
 	argv := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if !argvHasAdjacent(argv, "--output-format", "json") {
-		t.Errorf("background argv missing adjacent --output-format json:\n%s", string(data))
+	if !argvHasAdjacent(argv, "--output-format", "stream-json") {
+		t.Errorf("background argv missing adjacent --output-format stream-json:\n%s", string(data))
+	}
+	if !slices.Contains(argv, "--include-partial-messages") {
+		t.Errorf("background argv missing --include-partial-messages:\n%s", string(data))
 	}
 
 	// Reap detached child.
@@ -175,12 +179,12 @@ exit 0
 }
 
 // TestLaunchBackground_OuterTextStatusEnvelopeAware: with outer text-mode but
-// Background=true, the inner argv is forced to --output-format json AND StatusFor
-// MUST classify stdout as an envelope. meta.JSON is forced true for background
-// launches so the `innerJSON := meta.JSON || meta.OutputFormat == "json"`
-// decision doesn't fall to the text-mode classifier, which would bless a JSON
-// error envelope as status:"done". This pokes that path end-to-end (fake-claude
-// exits with an error envelope, then we poll StatusFor and assert status:"failed").
+// Background=true, the inner argv is forced to stream-json AND StatusFor MUST
+// classify the terminal result line as an envelope. meta.JSON is forced true for
+// background launches so the `innerJSON := meta.JSON || meta.OutputFormat == "json"`
+// decision doesn't fall to the text-mode classifier, which would bless an error
+// envelope as status:"done". This pokes that path end-to-end (fake-claude emits a
+// stream-json result line with an error, then we poll StatusFor for status:"failed").
 func TestLaunchBackground_OuterTextStatusEnvelopeAware(t *testing.T) {
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
@@ -191,9 +195,9 @@ func TestLaunchBackground_OuterTextStatusEnvelopeAware(t *testing.T) {
 	// ErrCodeRateLimited under the envelope-aware branch. In the text-mode
 	// fallback, this same stdout would be treated as a successful plain-text
 	// result and reported as status:"done".
-	const errorEnvelope = `{"type":"result","subtype":"error","is_error":true,"api_error_status":429,
- "result":"rate limit exceeded","num_turns":1,"total_cost_usd":0,
- "modelUsage":{},"permission_denials":[]}`
+	// A single-line stream-json result line (the inner format is now stream-json, so the
+	// terminal envelope arrives as one NDJSON line that extractResultLine distills).
+	const errorEnvelope = `{"type":"result","subtype":"error","is_error":true,"api_error_status":429,"result":"rate limit exceeded","num_turns":1,"total_cost_usd":0,"modelUsage":{},"permission_denials":[]}`
 
 	script := `#!/bin/sh
 printf '%s' '` + errorEnvelope + `'

--- a/internal/subagent/job_test.go
+++ b/internal/subagent/job_test.go
@@ -10,6 +10,28 @@ import (
 // Cross-platform background-job board tests. The exec/reap-driven cases (fake
 // claude via /bin/sh, syscall.Wait4) live in job_unix_test.go.
 
+// TestRemoveJob_PreservesScanLock: removeJob GCs a job's data sidecars but must never unlink the
+// .scan.lock flock — a concurrent board poll may still hold it, and unlink+recreate would hand a new
+// scanner a different inode and break the live-scan serialization (mirrors the per-run .lock rule).
+func TestRemoveJob_PreservesScanLock(t *testing.T) {
+	dir := t.TempDir()
+	id := "11111111-1111-1111-1111-111111111111"
+	for _, suffix := range []string{".json", ".out", ".scan", ".scan.lock"} {
+		if err := os.WriteFile(filepath.Join(dir, id+suffix), nil, 0o600); err != nil {
+			t.Fatalf("seed %s: %v", suffix, err)
+		}
+	}
+	removeJob(dir, id)
+	if _, err := os.Stat(filepath.Join(dir, id+".scan.lock")); err != nil {
+		t.Fatalf(".scan.lock must survive removeJob, got %v", err)
+	}
+	for _, suffix := range []string{".json", ".out", ".scan"} {
+		if _, err := os.Stat(filepath.Join(dir, id+suffix)); !os.IsNotExist(err) {
+			t.Fatalf("%s must be removed, got %v", suffix, err)
+		}
+	}
+}
+
 func TestStatusFor_RunningJobStaysRunning(t *testing.T) {
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -478,8 +478,10 @@ func buildArgv(binaryPath, profilePath, model string, req Request, slim slimArgv
 	switch {
 	case req.StreamActivity:
 		// stream-json (requires --verbose) so per-message tool_use + usage can be tailed live;
-		// the terminal type:"result" line is byte-identical to --output-format json for classify.
-		argv = append(argv, "--output-format", "stream-json", "--verbose")
+		// --include-partial-messages streams text_delta + a per-message message_delta usage so the
+		// token count climbs WITHIN a turn, not only at its end. The terminal type:"result" line is
+		// byte-identical to --output-format json for classify.
+		argv = append(argv, "--output-format", "stream-json", "--verbose", "--include-partial-messages")
 	case req.JSON || req.OutputFormat == "json":
 		argv = append(argv, "--output-format", "json")
 	}

--- a/internal/subagent/syncjob_test.go
+++ b/internal/subagent/syncjob_test.go
@@ -13,6 +13,40 @@ import (
 // Cross-platform sync-job board + processAlive guard tests. The fake-claude
 // exec cases live in syncjob_unix_test.go.
 
+// TestRegisterSyncJob_NoStaleActivityAtPublish: a restart reuses the job id, so registerSyncJob must
+// leave no prior-attempt .activity readable the instant it publishes the running meta — a board poll that
+// then observes the job as running would otherwise read the stale sidecar and (since the board stamps the
+// snapshot with the live attempt) paint it as the current attempt. Guards the cleanup-before-writeMetaFn
+// ordering: the meta is captured at publish time and the sidecar must already be empty.
+func TestRegisterSyncJob_NoStaleActivityAtPublish(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	jobID := "11111111-1111-1111-1111-111111111111"
+	p, err := leafActivityPath(jobID)
+	if err != nil {
+		t.Fatalf("leafActivityPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(`{"kind":"usage","in":5000,"out":800}`+"\n"), 0o600); err != nil {
+		t.Fatalf("seed stale sidecar: %v", err)
+	}
+	origWrite := writeMetaFn
+	t.Cleanup(func() { writeMetaFn = origWrite })
+	var atPublish []byte
+	writeMetaFn = func(dir string, m jobMeta) error {
+		atPublish, _ = os.ReadFile(p) // the sidecar as the running meta is published
+		return origWrite(dir, m)
+	}
+	req := Request{Provider: "v", Model: "m", RunID: "r1", Phase: "map", Label: "leaf-a", StreamActivity: true, Attempt: 2}
+	if registerSyncJob(jobID, req, "m", "", "", 0) != registerOK {
+		t.Fatal("registerSyncJob failed")
+	}
+	if len(atPublish) != 0 {
+		t.Fatalf("no stale activity may be readable when the running meta is published, got %q", atPublish)
+	}
+}
+
 // ----- a sync run is visible on the board, without leaking its answer -----
 
 func TestRegisterAndFinalizeSyncJob(t *testing.T) {

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -77,12 +77,13 @@ type Request struct {
 	// workflow engine; the CLI's --prompt) pass it here separately for the side file.
 	// Empty → no prompt side file.
 	IOPrompt string
-	// StreamActivity opts a SYNC run into `--output-format stream-json --verbose` so its
-	// per-job tool calls + running token usage stream to <jobID>.activity for the boards'
-	// Activity feed WHILE it runs. Content-privacy, gated like PersistIO; set only where
-	// the caller consumes a distilled envelope rather than passing claude's output through
-	// (workflow sync leaves; the CLI's --json path), so every passthrough run — plain text
-	// AND --output-format json — stays byte-identical.
+	// StreamActivity opts a run into `--output-format stream-json --verbose --include-partial-messages`.
+	// On a SYNC run its per-job tool calls + running token usage also stream to <jobID>.activity for the
+	// boards' Activity feed WHILE it runs (content-privacy, gated like PersistIO; set where the caller
+	// consumes a distilled envelope rather than passing claude's output through — workflow sync leaves,
+	// the CLI's --json path — so every passthrough run, plain text AND --output-format json, stays
+	// byte-identical). launchBackground also sets it, only to select that inner format: the detached child
+	// writes no sidecar, so StatusFor scans its .out for live usage instead.
 	StreamActivity bool
 	// JournalKey is the leaf's content-hash key (workflow-engine-only). Persisted on the job
 	// record so the board can target THIS leaf for restart — drop its journal entry and resume,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -167,6 +168,14 @@ type Model struct {
 	confirm    *confirmModal
 	pins       pinned.Set
 	boardEpoch int
+	// lastRefreshSeq is the highest boardRefreshSeq whose JOB/workflow rows were applied this epoch (from
+	// EITHER chain); a refresh that read disk earlier but arrived later (the 3s/500ms chains race) is
+	// dropped so it can't resurrect a terminal row. lastBoardFullSeq is the same for the full-refresh-only
+	// state (teammates/meta/pins), bumped only by boardMsg — so a boardMsg whose jobs lost to a faster
+	// wfRefreshMsg still updates teammates, while a stale boardMsg can't roll that state back over a newer
+	// boardMsg. Both reset on board entry so the visit's first refresh always applies.
+	lastRefreshSeq   int64
+	lastBoardFullSeq int64
 	// boardSeen marks that a boardMsg has ever been accepted; a revisit then skips the
 	// "discovering…" loading frame and keeps the previous frame until the fresh load
 	// lands. boardEntryRoute defers the entry reset (cursors + focus park) to that
@@ -361,6 +370,7 @@ type boardMsg struct {
 	jobsErr     error
 	runs        []subagent.WorkflowRun
 	activity    map[string]activitySnapshot
+	seq         int64
 	sessionMeta map[string]sessiontitle.Meta
 	// endedSeen maps an ended team's name to its record LastSeen, so the card can
 	// render "ended · last seen <ts>" without threading a time into the synthetic
@@ -368,6 +378,9 @@ type boardMsg struct {
 	endedSeen map[string]time.Time
 	pins      pinned.Set
 	epoch     int
+	// fullSeq orders the full-refresh-only state (stamped at the teammate read); seq orders the job rows
+	// (stamped at ListJobs). Two stamps because boardMsg reads those at different times.
+	fullSeq int64
 }
 
 func (boardMsg) owningScreen() screen { return screenSpawn }
@@ -401,6 +414,13 @@ func loadProviders() tea.Msg {
 	return providersMsg{providers: res.Providers, defaultProvider: res.DefaultProvider}
 }
 
+// boardRefreshSeq is a process-wide monotonic counter stamped on each board/wf refresh as it finishes
+// reading from disk. Within one board epoch the 3s and 500ms chains race and their tea.Cmds can deliver
+// out of order; the handlers apply a refresh only when its seq is the newest seen, so a later-delivered
+// EARLIER read can't overwrite a fresh one (which would resurrect a just-terminal row, with its stale
+// live snapshot). Higher seq == read disk later == fresher.
+var boardRefreshSeq atomic.Int64
+
 // loadBoard returns a tea.Cmd that assembles a board refresh tagged with the
 // caller's epoch: discover teammates, annotate them with pane-scan health + the
 // hidden flag from team config, and list subagent jobs. A discovery error
@@ -410,6 +430,10 @@ func loadProviders() tea.Msg {
 // Update can drop a stale refresh from a prior visit.
 func loadBoard(epoch int) tea.Cmd {
 	return func() tea.Msg {
+		// Stamp the full-state freshness BEFORE the teammate read below — the full-refresh-only state
+		// (teammates/meta/pins) is gated on its own track, so its seq must order by when that read began,
+		// not by the later ListJobs stamp (the job rows carry the latter).
+		fullSeq := boardRefreshSeq.Add(1)
 		items, err := teardown.DiscoverTeammates()
 		// tmux absent from PATH isn't a board failure: the live-teammate lane is
 		// simply unavailable (it's the only tmux-dependent source), so drop the
@@ -425,6 +449,11 @@ func loadBoard(epoch int) tea.Cmd {
 			items = teardown.AnnotateLeadSession(items)
 		}
 		jobs, jobsErr := subagent.ListJobs()
+		// Stamp the freshness seq the instant job STATUS is read — before loadWfData's activity/run reads
+		// and the meta/team-history/pins work below, any of which can stall. The resurrection concern is a
+		// done row flashing back to running, so seq must order by when a row's status was observed; a slow
+		// older read then can't out-rank a fast newer one in the handler.
+		seq := boardRefreshSeq.Add(1)
 		runs, activity, wfErr := loadWfData(jobs)
 		if jobsErr == nil {
 			jobsErr = wfErr
@@ -456,6 +485,8 @@ func loadBoard(epoch int) tea.Cmd {
 			endedSeen:   endedSeen,
 			pins:        pins,
 			epoch:       epoch,
+			seq:         seq,
+			fullSeq:     fullSeq,
 		}
 	}
 }
@@ -521,18 +552,68 @@ func loadWfData(jobs []subagent.Result) ([]subagent.WorkflowRun, map[string]acti
 		if j.JobID == "" {
 			continue
 		}
-		if snap, ok := readLeafActivity(j.JobID); ok {
-			activity[j.JobID] = snap
-			continue
+		// Only a RUNNING job's sidecar/Usage describes live activity. A queued/held job — notably a leaf
+		// requeued for its next attempt, whose old .activity can survive a best-effort remove — gets a bare
+		// attempt-stamped tombstone, never a sidecar read: reading a stale sidecar here would seed the
+		// current attempt's floor (snap.attempt is stamped from j) while queued, and floorActivity would
+		// carry that into the running phase as the same attempt.
+		if j.Status == "running" {
+			if snap, ok := readLeafActivity(j.JobID); ok {
+				snap.attempt = j.Attempt
+				activity[j.JobID] = snap
+				continue
+			}
+			// No sidecar (a detached background job): surface its running Usage — filled live by
+			// StatusFor's stream-json scan — so its row climbs like a sync leaf's.
+			if j.Usage != nil && (j.Usage.InputTokens > 0 || j.Usage.OutputTokens > 0) {
+				activity[j.JobID] = activitySnapshot{inTok: j.Usage.InputTokens, outTok: j.Usage.OutputTokens, hasUsage: true, attempt: j.Attempt}
+				continue
+			}
 		}
-		// No sidecar (a detached background job): surface its running Usage — filled live by
-		// StatusFor's stream-json scan — so its row climbs like a sync leaf's.
-		if j.Status == "running" && j.Usage != nil && (j.Usage.InputTokens > 0 || j.Usage.OutputTokens > 0) {
-			activity[j.JobID] = activitySnapshot{inTok: j.Usage.InputTokens, outTok: j.Usage.OutputTokens, hasUsage: true}
+		// A live job with no usage to show yet — the restart gap, or a queued/held leaf. A zero,
+		// hasUsage:false tombstone keeps the job present so floorActivity retains its per-attempt floor
+		// across out-of-order refreshes; liveTokens is gated on hasUsage, so a tombstone never changes the
+		// rendered tokens — it only preserves attempt order.
+		if j.Status == "running" || j.Status == "queued" || j.Status == "held" {
+			activity[j.JobID] = activitySnapshot{attempt: j.Attempt}
 		}
 	}
 	runs, err := subagent.ListRuns()
 	return runs, activity, err
+}
+
+// floorActivity keeps each job's live token snapshot monotonic across refreshes. The 3s full chain and
+// the 500ms light chain both scan the same jobs and their tea.Cmds can complete out of order, so a
+// later-delivered OLDER snapshot must not lower a job's already-shown input/output — the board would
+// tick down for a frame. The floor respects attempt order: a HIGHER attempt (a restart reusing the job
+// id with a fresh low count) resets the floor to the new attempt; an EQUAL attempt holds the monotonic
+// max; a LOWER attempt is a stale pre-restart refresh that finished late and is discarded for the newer
+// attempt already shown. A finished job leaves the live map (rendering from its terminal Result).
+// Mutates and returns next.
+func floorActivity(prev, next map[string]activitySnapshot) map[string]activitySnapshot {
+	for id, ns := range next {
+		ps, ok := prev[id]
+		if !ok {
+			continue
+		}
+		switch {
+		case ns.attempt > ps.attempt:
+			// A restart: take the fresh low count as-is so the floor resets to the new attempt.
+		case ns.attempt < ps.attempt:
+			// A pre-restart refresh landing late: keep the newer attempt, never the stale total.
+			next[id] = ps
+		default:
+			if ps.inTok > ns.inTok {
+				ns.inTok = ps.inTok
+			}
+			if ps.outTok > ns.outTok {
+				ns.outTok = ps.outTok
+			}
+			ns.hasUsage = ns.hasUsage || ps.hasUsage
+			next[id] = ns
+		}
+	}
+	return next
 }
 
 // wfTagged filters a job list down to the RunID-tagged workflow leaves.
@@ -555,6 +636,7 @@ type wfRefreshMsg struct {
 	runs     []subagent.WorkflowRun
 	activity map[string]activitySnapshot
 	epoch    int
+	seq      int64
 }
 
 func (wfRefreshMsg) owningScreen() screen { return screenSpawn }
@@ -566,8 +648,9 @@ type wfLiveTickMsg struct{ epoch int }
 func loadWfLight(epoch int) tea.Cmd {
 	return func() tea.Msg {
 		all, _ := subagent.ListJobs()
+		seq := boardRefreshSeq.Add(1) // stamp at the job-status read, before loadWfData (see loadBoard)
 		runs, activity, _ := loadWfData(all)
-		return wfRefreshMsg{jobs: wfTagged(all), runs: runs, activity: activity, epoch: epoch}
+		return wfRefreshMsg{jobs: wfTagged(all), runs: runs, activity: activity, epoch: epoch, seq: seq}
 	}
 }
 
@@ -1422,19 +1505,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		prevBox, hadBox := m.boxRowRef()
 		m.loading = false
 		m.boardSeen = true
-		// Pre-group session → team so the session tree (recomputed per render off these
-		// slices, mirror wfGroups) renders contiguously on every update path, tests included.
-		m.teammates = groupByTeam(msg.teammates)
-		m.spawnErr = msg.teamErr
-		m.tmuxMissing = msg.tmuxMissing
-		m.jobs = msg.jobs
-		m.boardJobsErr = msg.jobsErr
-		m.workflowJobs = wfTagged(msg.jobs)
-		m.workflowRuns = msg.runs
-		m.wfActivity = msg.activity
-		m.sessionMeta = msg.sessionMeta
-		m.endedSeen = msg.endedSeen
-		m.pins = msg.pins
+		// Teammate / session-meta / pin state is full-refresh-only (the 500ms light chain never carries it),
+		// gated on fullSeq — stamped at the teammate read, on a boardMsg-only track. So a boardMsg whose JOB
+		// rows lost the shared-seq race to a faster wfRefreshMsg still updates it (the light chain never
+		// bumps lastBoardFullSeq), but a stale boardMsg can't roll it back over a newer boardMsg. Pre-group
+		// session → team so the session tree (recomputed per render off these slices, mirror wfGroups)
+		// renders contiguously on every update path.
+		if msg.fullSeq >= m.lastBoardFullSeq {
+			m.lastBoardFullSeq = msg.fullSeq
+			m.teammates = groupByTeam(msg.teammates)
+			m.spawnErr = msg.teamErr
+			m.tmuxMissing = msg.tmuxMissing
+			m.sessionMeta = msg.sessionMeta
+			m.endedSeen = msg.endedSeen
+			m.pins = msg.pins
+		}
+		// The job/workflow rows are seq-gated against BOTH chains: a refresh that read disk earlier but
+		// arrived after a newer one (the 3s/500ms chains race within an epoch) would otherwise resurrect a
+		// just-terminal job as running, with its stale live snapshot.
+		if msg.seq >= m.lastRefreshSeq {
+			m.lastRefreshSeq = msg.seq
+			m.jobs = msg.jobs
+			m.boardJobsErr = msg.jobsErr
+			m.workflowJobs = wfTagged(msg.jobs)
+			m.workflowRuns = msg.runs
+			m.wfActivity = floorActivity(m.wfActivity, msg.activity)
+		}
 		// Preserve the drill state: re-route if the focus chain broke, re-find the L2 row
 		// by identity, index-clamp the entity cursor, re-clamp the card scroll.
 		m.rerootSpawn()
@@ -1504,10 +1600,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.epoch != m.boardEpoch {
 			return m, nil
 		}
+		// Same out-of-order drop as boardMsg: an earlier-read refresh arriving late must not roll the
+		// workflow rows + live snapshots back over a fresher one.
+		if msg.seq < m.lastRefreshSeq {
+			return m, nil
+		}
+		m.lastRefreshSeq = msg.seq
 		prevBox, hadBox := m.boxRowRef()
 		m.workflowJobs = msg.jobs
 		m.workflowRuns = msg.runs
-		m.wfActivity = msg.activity
+		m.wfActivity = floorActivity(m.wfActivity, msg.activity)
 		m.rerootSpawn()
 		if hadBox {
 			m.reanchorBox(prevBox)
@@ -1844,6 +1946,7 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// bump can't overwrite the new visit's state (its msg.epoch fails the
 		// gate in the boardMsg handler).
 		m.boardEpoch++
+		m.lastRefreshSeq, m.lastBoardFullSeq = 0, 0 // a new visit's first refresh always applies (its seq beats the reset)
 		return m, tea.Batch(loadBoard(m.boardEpoch), boardTick(m.boardEpoch))
 	case "up", "k":
 		if m.providerCursor > 0 {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -609,6 +609,12 @@ func floorActivity(prev, next map[string]activitySnapshot) map[string]activitySn
 			if ps.outTok > ns.outTok {
 				ns.outTok = ps.outTok
 			}
+			// Tool sigs accumulate within an attempt, so the longer list is the newer read; keep it rather
+			// than a shorter one carried by an out-of-order refresh (seq orders by ListJobs, not the sidecar
+			// read), so the tool count + Activity feed never tick backward while in/out are floored.
+			if len(ps.sigs) > len(ns.sigs) {
+				ns.sigs = ps.sigs
+			}
 			ns.hasUsage = ns.hasUsage || ps.hasUsage
 			next[id] = ns
 		}
@@ -627,12 +633,14 @@ func wfTagged(jobs []subagent.Result) []subagent.Result {
 	return out
 }
 
-// wfRefreshMsg carries a LIGHT workflow-only refresh (run manifests + leaf jobs + activity
-// sidecars — never teammate discovery or pane capture), driven by the 500ms live chain so a
-// running run's counters climb smoothly between the 3s full refreshes. Owned by screenSpawn,
-// boardEpoch-gated like boardMsg.
+// wfRefreshMsg carries a LIGHT refresh (the full subagent job list + run manifests + activity sidecars —
+// never teammate discovery or pane capture), driven by the 500ms live chain so a running run's counters
+// AND a standalone background subagent's row climb smoothly between the 3s full refreshes. jobs is the
+// full ListJobs result (mirror boardMsg) so a standalone row's status/usage refresh at 500ms too, not
+// only on the 3s tick. Owned by screenSpawn, boardEpoch-gated like boardMsg.
 type wfRefreshMsg struct {
 	jobs     []subagent.Result
+	jobsErr  error
 	runs     []subagent.WorkflowRun
 	activity map[string]activitySnapshot
 	epoch    int
@@ -647,10 +655,13 @@ type wfLiveTickMsg struct{ epoch int }
 // loadWfLight reads only the workflow data (no teammate discovery, no pane capture).
 func loadWfLight(epoch int) tea.Cmd {
 	return func() tea.Msg {
-		all, _ := subagent.ListJobs()
+		all, jobsErr := subagent.ListJobs()
 		seq := boardRefreshSeq.Add(1) // stamp at the job-status read, before loadWfData (see loadBoard)
-		runs, activity, _ := loadWfData(all)
-		return wfRefreshMsg{jobs: wfTagged(all), runs: runs, activity: activity, epoch: epoch, seq: seq}
+		runs, activity, wfErr := loadWfData(all)
+		if jobsErr == nil {
+			jobsErr = wfErr
+		}
+		return wfRefreshMsg{jobs: all, jobsErr: jobsErr, runs: runs, activity: activity, epoch: epoch, seq: seq}
 	}
 }
 
@@ -1086,8 +1097,8 @@ func (m Model) anyLeafRunning() bool {
 
 // anyJobRunning reports whether any STANDALONE subagent job is live — so the 500ms light chain also
 // ticks for a background subagent's climbing token count, not just for workflow runs. Workflow leaves
-// (RunID set) are covered by anyLeafRunning via the 500ms-fresh m.workflowJobs; m.jobs only refreshes
-// on the 3s full tick, so scanning it for leaves too would keep the chain alive on a stale row.
+// (RunID set) are covered by anyLeafRunning via m.workflowJobs; this scans only RunID=="" rows so a
+// finished leaf can't keep the chain alive through a standalone scan.
 func (m Model) anyJobRunning() bool {
 	for _, j := range m.jobs {
 		if j.RunID == "" && j.Status == "running" {
@@ -1607,7 +1618,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.lastRefreshSeq = msg.seq
 		prevBox, hadBox := m.boxRowRef()
-		m.workflowJobs = msg.jobs
+		// The light chain carries the full job list too, so a standalone subagent row's status/usage
+		// refresh at 500ms — otherwise it lags 3s behind its own live snapshot and falls back to a stale,
+		// lower usage (a visible down-jump) and a stuck "running" when the job finishes between full ticks.
+		m.jobs = msg.jobs
+		m.boardJobsErr = msg.jobsErr
+		m.workflowJobs = wfTagged(msg.jobs)
 		m.workflowRuns = msg.runs
 		m.wfActivity = floorActivity(m.wfActivity, msg.activity)
 		m.rerootSpawn()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -510,16 +510,25 @@ func synthesizeEnded(live []teardown.Teammate, meta map[string]sessiontitle.Meta
 // excluded from the live "ok" / teammate-count rollups.
 const endedStatus = "ended"
 
-// loadWfData assembles the workflow half of a refresh from an already-listed job set: the
-// run manifests plus each RunID-tagged leaf's activity sidecar (live tokens + tool calls).
+// loadWfData assembles the live-token half of a refresh from an already-listed job set: the run
+// manifests plus each job's activity snapshot keyed by JobID — a workflow leaf or a sync subagent
+// from its <jobID>.activity sidecar, a detached background job synthesized from its poll-time Usage
+// (it writes no sidecar). This feeds both the workflow run headers and the standalone subagent rows,
+// so every running agent's token count climbs on the 500ms light tick.
 func loadWfData(jobs []subagent.Result) ([]subagent.WorkflowRun, map[string]activitySnapshot, error) {
 	activity := map[string]activitySnapshot{}
 	for _, j := range jobs {
-		if j.RunID == "" || j.JobID == "" {
+		if j.JobID == "" {
 			continue
 		}
 		if snap, ok := readLeafActivity(j.JobID); ok {
 			activity[j.JobID] = snap
+			continue
+		}
+		// No sidecar (a detached background job): surface its running Usage — filled live by
+		// StatusFor's stream-json scan — so its row climbs like a sync leaf's.
+		if j.Status == "running" && j.Usage != nil && (j.Usage.InputTokens > 0 || j.Usage.OutputTokens > 0) {
+			activity[j.JobID] = activitySnapshot{inTok: j.Usage.InputTokens, outTok: j.Usage.OutputTokens, hasUsage: true}
 		}
 	}
 	runs, err := subagent.ListRuns()
@@ -572,7 +581,7 @@ func wfLiveTick(epoch int) tea.Cmd {
 // startWfLive starts the 500ms light chain when a refresh sees a running leaf and no chain
 // is already live; the chain stops itself (clearing the flag) once nothing runs.
 func (m *Model) startWfLive() tea.Cmd {
-	if m.wfLiveOn || !m.anyLeafRunning() {
+	if m.wfLiveOn || !m.anyAgentRunning() {
 		return nil
 	}
 	m.wfLiveOn = true
@@ -991,6 +1000,23 @@ func (m Model) anyLeafRunning() bool {
 	}
 	return false
 }
+
+// anyJobRunning reports whether any STANDALONE subagent job is live — so the 500ms light chain also
+// ticks for a background subagent's climbing token count, not just for workflow runs. Workflow leaves
+// (RunID set) are covered by anyLeafRunning via the 500ms-fresh m.workflowJobs; m.jobs only refreshes
+// on the 3s full tick, so scanning it for leaves too would keep the chain alive on a stale row.
+func (m Model) anyJobRunning() bool {
+	for _, j := range m.jobs {
+		if j.RunID == "" && j.Status == "running" {
+			return true
+		}
+	}
+	return false
+}
+
+// anyAgentRunning is the live-tick predicate: a workflow leaf/run OR a standalone job is running.
+// Both the start gate and the keep-alive gate use it, so the chain can't start then die after a tick.
+func (m Model) anyAgentRunning() bool { return m.anyLeafRunning() || m.anyJobRunning() }
 
 // paneVisMsg carries the outcome of an inline hide/show so the board can surface
 // a failure (its code/reason/suggestion) instead of silently relying on the next
@@ -1492,7 +1518,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case wfLiveTickMsg:
 		if m.screen == screenSpawn && msg.epoch == m.boardEpoch {
-			if m.anyLeafRunning() {
+			if m.anyAgentRunning() {
 				return m, tea.Batch(loadWfLight(msg.epoch), wfLiveTick(msg.epoch))
 			}
 			m.wfLiveOn = false // nothing runs — the chain ends; a later refresh restarts it

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1543,6 +1543,13 @@ func TestFloorActivity_KeepsTokensMonotonic(t *testing.T) {
 	if _, ok := fresh["j1"]; ok {
 		t.Fatal("a job absent from the new map must not be carried")
 	}
+	// A same-attempt out-of-order refresh carrying FEWER tool sigs must not shrink the count: sigs
+	// accumulate within an attempt, so the longer list is the newer read.
+	prevSigs := map[string]activitySnapshot{"j1": {inTok: 100, outTok: 50, hasUsage: true, attempt: 1, sigs: []string{"A", "B", "C"}}}
+	short := floorActivity(prevSigs, map[string]activitySnapshot{"j1": {inTok: 120, outTok: 60, hasUsage: true, attempt: 1, sigs: []string{"A"}}})
+	if len(short["j1"].sigs) != 3 {
+		t.Fatalf("a same-attempt refresh with fewer sigs must not shrink the tool list, got %d", len(short["j1"].sigs))
+	}
 	// A restart reuses the job id with a higher Attempt and a fresh low count — the floor must NOT pin it
 	// to the prior attempt's total; the new low snapshot wins.
 	prevA1 := map[string]activitySnapshot{"j1": {inTok: 5000, outTok: 800, hasUsage: true, attempt: 1}}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1475,6 +1475,24 @@ func TestLoadBoardTmuxMissingSkipsEndedSynthesis(t *testing.T) {
 	}
 }
 
+// TestLoadWfData_SynthesizesBackgroundLiveSnapshot: a detached background job writes no .activity
+// sidecar, so loadWfData synthesizes a live snapshot from its poll-time Usage — making its standalone
+// row climb. A terminal job gets none (only a running row overrides with the live figure).
+func TestLoadWfData_SynthesizesBackgroundLiveSnapshot(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	running := subagent.Result{JobID: "bg11111111111111", Status: "running",
+		Usage: &subagent.Usage{InputTokens: 5000, OutputTokens: 320}}
+	_, activity, _ := loadWfData([]subagent.Result{running})
+	if snap := activity["bg11111111111111"]; !snap.hasUsage || snap.inTok != 5000 || snap.outTok != 320 {
+		t.Fatalf("a running background job must get a synthesized live snapshot, got %+v", snap)
+	}
+	done := subagent.Result{JobID: "bg22222222222222", Status: "done",
+		Usage: &subagent.Usage{InputTokens: 5000, OutputTokens: 320}}
+	if _, activity, _ := loadWfData([]subagent.Result{done}); len(activity) != 0 {
+		t.Fatalf("a terminal job must not get a synthesized live snapshot: %+v", activity)
+	}
+}
+
 // TestBoardJobsErrOwnLine: a jobs-scan failure renders on its own line and does NOT clobber
 // a surfaced hide/show outcome.
 func TestBoardJobsErrOwnLine(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1475,6 +1475,34 @@ func TestLoadBoardTmuxMissingSkipsEndedSynthesis(t *testing.T) {
 	}
 }
 
+// TestLoadWfData_QueuedJobIgnoresStaleSidecar: a restart reuses the job id, and the best-effort cleanup
+// can leave the prior attempt's .activity. While the requeued job is QUEUED, loadWfData must NOT read that
+// sidecar (which it would stamp with the new attempt) — it must emit a bare tombstone — so floorActivity
+// never carries the stale snapshot into the running phase as the current attempt.
+func TestLoadWfData_QueuedJobIgnoresStaleSidecar(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	jobID := "11111111-1111-1111-1111-111111111111"
+	dir, err := config.ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	p := filepath.Join(dir, "subagent-jobs", jobID+".activity")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(`{"kind":"usage","in":5000,"out":800}`+"\n"), 0o600); err != nil {
+		t.Fatalf("seed stale sidecar: %v", err)
+	}
+	queued := subagent.Result{JobID: jobID, RunID: "r1", Status: "queued", Attempt: 2}
+	_, activity, _ := loadWfData([]subagent.Result{queued})
+	if snap := activity[jobID]; snap.hasUsage || snap.inTok != 0 || snap.outTok != 0 {
+		t.Fatalf("a queued job must not read its stale sidecar; want a bare tombstone, got %+v", snap)
+	}
+	if activity[jobID].attempt != 2 {
+		t.Fatalf("the queued tombstone must carry the current attempt, got %+v", activity[jobID])
+	}
+}
+
 // TestLoadWfData_SynthesizesBackgroundLiveSnapshot: a detached background job writes no .activity
 // sidecar, so loadWfData synthesizes a live snapshot from its poll-time Usage — making its standalone
 // row climb. A terminal job gets none (only a running row overrides with the live figure).
@@ -1490,6 +1518,54 @@ func TestLoadWfData_SynthesizesBackgroundLiveSnapshot(t *testing.T) {
 		Usage: &subagent.Usage{InputTokens: 5000, OutputTokens: 320}}
 	if _, activity, _ := loadWfData([]subagent.Result{done}); len(activity) != 0 {
 		t.Fatalf("a terminal job must not get a synthesized live snapshot: %+v", activity)
+	}
+}
+
+// TestFloorActivity_KeepsTokensMonotonic: the 3s and 500ms board chains can deliver refreshes out of
+// order, so a later, lower snapshot for a running job must not lower its already-shown tokens; a higher
+// one raises them; a new job passes through; a job absent from the new map is dropped.
+func TestFloorActivity_KeepsTokensMonotonic(t *testing.T) {
+	prev := map[string]activitySnapshot{"j1": {inTok: 5000, outTok: 800, hasUsage: true}}
+	// A stale, lower snapshot lands later — the floor holds the higher tokens.
+	got := floorActivity(prev, map[string]activitySnapshot{"j1": {inTok: 4000, outTok: 300, hasUsage: true}})
+	if got["j1"].inTok != 5000 || got["j1"].outTok != 800 {
+		t.Fatalf("floor must hold the higher tokens, got %+v", got["j1"])
+	}
+	// A genuinely higher snapshot raises the figure.
+	if up := floorActivity(prev, map[string]activitySnapshot{"j1": {inTok: 5000, outTok: 950, hasUsage: true}}); up["j1"].outTok != 950 {
+		t.Fatalf("a higher snapshot must raise the figure, got %+v", up["j1"])
+	}
+	// A new job passes through; a job absent from the new map is not carried.
+	fresh := floorActivity(prev, map[string]activitySnapshot{"j2": {outTok: 10, hasUsage: true}})
+	if fresh["j2"].outTok != 10 {
+		t.Fatalf("a new job must pass through, got %+v", fresh)
+	}
+	if _, ok := fresh["j1"]; ok {
+		t.Fatal("a job absent from the new map must not be carried")
+	}
+	// A restart reuses the job id with a higher Attempt and a fresh low count — the floor must NOT pin it
+	// to the prior attempt's total; the new low snapshot wins.
+	prevA1 := map[string]activitySnapshot{"j1": {inTok: 5000, outTok: 800, hasUsage: true, attempt: 1}}
+	restart := floorActivity(prevA1, map[string]activitySnapshot{"j1": {inTok: 200, outTok: 5, hasUsage: true, attempt: 2}})
+	if restart["j1"].inTok != 200 || restart["j1"].outTok != 5 {
+		t.Fatalf("a bumped attempt must reset the floor, got %+v", restart["j1"])
+	}
+	// A stale pre-restart refresh (attempt 1) can land AFTER the restart's attempt-2 snapshot; it must be
+	// discarded, never put the board back on attempt 1's high total.
+	prevA2 := map[string]activitySnapshot{"j1": {inTok: 200, outTok: 5, hasUsage: true, attempt: 2}}
+	stale := floorActivity(prevA2, map[string]activitySnapshot{"j1": {inTok: 5000, outTok: 800, hasUsage: true, attempt: 1}})
+	if stale["j1"].inTok != 200 || stale["j1"].outTok != 5 {
+		t.Fatalf("a stale lower-attempt snapshot must be discarded, got %+v", stale["j1"])
+	}
+	// The attempt-2 leaf may briefly emit no activity (the restart gap): loadWfData carries it as a zero
+	// attempt-2 tombstone. That refresh must KEEP the attempt-2 floor (not drop the job), so a later stale
+	// attempt-1 refresh still loses to it instead of being accepted as a brand-new entry.
+	held := floorActivity(prevA2, map[string]activitySnapshot{"j1": {attempt: 2}})
+	if held["j1"].inTok != 200 || held["j1"].outTok != 5 || held["j1"].attempt != 2 {
+		t.Fatalf("an empty same-attempt tombstone must hold the floor, got %+v", held["j1"])
+	}
+	if after := floorActivity(held, map[string]activitySnapshot{"j1": {inTok: 5000, outTok: 800, hasUsage: true, attempt: 1}}); after["j1"].inTok != 200 {
+		t.Fatalf("a stale attempt-1 refresh after a tombstone must still be discarded, got %+v", after["j1"])
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1085,14 +1085,21 @@ func leafDuration(j subagent.Result) string {
 // Live from the activity snapshot while running, the accurate final from the Result once done; the
 // tool count always comes from the snapshot (the final Result doesn't carry it).
 func (m Model) leafCounts(j subagent.Result) (in, out, tools int) {
+	in, out = m.liveTokens(j)
+	return in, out, m.wfActivity[j.JobID].toolCount()
+}
+
+// liveTokens resolves a job's (peak-input, cumulative-output) token pair: the final Result usage,
+// overridden by the live activity snapshot while the job runs. Shared by leafCounts and jobTokens so
+// every surface (run header, workflow rows, subagent rows) reads the same 500ms-refreshed source.
+func (m Model) liveTokens(j subagent.Result) (in, out int) {
 	if j.Usage != nil {
 		in, out = j.Usage.InputTokens, j.Usage.OutputTokens
 	}
-	snap := m.wfActivity[j.JobID]
-	if j.Status == "running" && snap.hasUsage {
+	if snap := m.wfActivity[j.JobID]; j.Status == "running" && snap.hasUsage {
 		in, out = snap.inTok, snap.outTok
 	}
-	return in, out, snap.toolCount()
+	return in, out
 }
 
 // agentDetailLines is the focused agent's inline detail (the run drill's agent right pane, scrollable): status/model
@@ -1798,17 +1805,9 @@ func (m Model) leafStatsLine(j subagent.Result) string {
 	return line
 }
 
-// jobTokens is the job's (peak-context, cumulative-output) token pair: the final Result
-// usage, overridden by the live activity snapshot while the focused job still runs.
-func (m Model) jobTokens(j subagent.Result) (in, out int) {
-	if j.Usage != nil {
-		in, out = j.Usage.InputTokens, j.Usage.OutputTokens
-	}
-	if j.Status == "running" && m.asDetailJobID == j.JobID && m.asDetailSnap.hasUsage {
-		in, out = m.asDetailSnap.inTok, m.asDetailSnap.outTok
-	}
-	return in, out
-}
+// jobTokens is the subagent row/card token pair — the shared live resolution, so any row (not just
+// the focused one) climbs live.
+func (m Model) jobTokens(j subagent.Result) (in, out int) { return m.liveTokens(j) }
 
 // viewAsBoxes is L2: the session header above the stacked boxes — Dynamic Workflows
 // (master-detail: run rail | the previewed run's phase rows), Agent Teams (master-detail:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1079,14 +1079,28 @@ func leafDuration(j subagent.Result) string {
 	return fmt.Sprintf("%dm %ds", int(d/time.Minute), int(d.Seconds())%60)
 }
 
+// snapForJob returns the live activity snapshot that may drive j's board display, or the zero snapshot
+// when none applies. The snapshot describes j only while j is RUNNING at the SAME attempt it was scanned
+// at: floorActivity smooths m.wfActivity across out-of-order refreshes, so the map can momentarily hold a
+// snapshot carried from a different attempt (a restart reuses the job id), which must never paint j's
+// tokens or tool count. A non-running job renders from its Result, never the snapshot. Single render-side
+// gate — every wfActivity consumer reads through it.
+func (m Model) snapForJob(j subagent.Result) activitySnapshot {
+	if snap := m.wfActivity[j.JobID]; j.Status == "running" && snap.attempt == j.Attempt {
+		return snap
+	}
+	return activitySnapshot{}
+}
+
 // leafCounts returns the leaf's (input, output) tokens + tool-call count. input is the PEAK context
-// window (max over turns, non-cumulative — so it is shown per-leaf, never summed across leaves);
-// output is CUMULATIVE generated tokens (additive, what the run header sums); cache-read is excluded.
-// Live from the activity snapshot while running, the accurate final from the Result once done; the
-// tool count always comes from the snapshot (the final Result doesn't carry it).
+// window (max over turns, non-cumulative — so it is shown per-leaf, never summed across leaves); output
+// is CUMULATIVE generated tokens (additive, what the run header sums); cache-read is excluded. Live from
+// the activity snapshot while running, the accurate final from the Result once done; the tool count comes
+// from the snapshot (the final Result doesn't carry it), so it shows only while j is the running current
+// attempt.
 func (m Model) leafCounts(j subagent.Result) (in, out, tools int) {
 	in, out = m.liveTokens(j)
-	return in, out, m.wfActivity[j.JobID].toolCount()
+	return in, out, m.snapForJob(j).toolCount()
 }
 
 // liveTokens resolves a job's (peak-input, cumulative-output) token pair: the final Result usage,
@@ -1096,7 +1110,7 @@ func (m Model) liveTokens(j subagent.Result) (in, out int) {
 	if j.Usage != nil {
 		in, out = j.Usage.InputTokens, j.Usage.OutputTokens
 	}
-	if snap := m.wfActivity[j.JobID]; j.Status == "running" && snap.hasUsage {
+	if snap := m.snapForJob(j); snap.hasUsage {
 		in, out = snap.inTok, snap.outTok
 	}
 	return in, out
@@ -1114,7 +1128,7 @@ func (m Model) agentDetailLines(rightW int) []string {
 		return []string{faintStyle.Render("(no agent)")}
 	}
 	in, out, tools := m.leafCounts(j)
-	snap := m.wfActivity[j.JobID]
+	snap := m.snapForJob(j)
 	status := statusLabel(j.Status) + faintStyle.Render(" · "+trunc(sessiontitle.CleanTitle(j.Model), 28))
 	if j.Attempt > 1 {
 		// >1 occurs only in records from engines that retried schema mismatches; surface it.

--- a/internal/tui/workflow_board_test.go
+++ b/internal/tui/workflow_board_test.go
@@ -500,6 +500,30 @@ func TestWfPromptFold_TogglesOnEnter(t *testing.T) {
 	}
 }
 
+// TestWfRefresh_UpdatesStandaloneJobs: the 500ms light chain carries the full job list, so a standalone
+// background subagent's row (sourced from m.jobs) refreshes at 500ms — its status flips to done and its
+// usage tracks the final the moment it finishes, with no down-jump or stuck "running" between 3s ticks.
+func TestWfRefresh_UpdatesStandaloneJobs(t *testing.T) {
+	m := runsModel(t, nil, nil, map[string]activitySnapshot{})
+	ep := m.boardEpoch
+	bg := "bg11111111111111"
+	// A light refresh shows the standalone job running (RunID empty = standalone, sourced from m.jobs).
+	running := subagent.Result{JobID: bg, Status: "running", Usage: &subagent.Usage{InputTokens: 5000, OutputTokens: 40}}
+	m, _ = step(t, m, wfRefreshMsg{jobs: []subagent.Result{running}, epoch: ep, seq: 1})
+	if len(m.jobs) != 1 || m.jobs[0].Status != "running" {
+		t.Fatalf("the light chain must populate the standalone row in m.jobs, got %+v", m.jobs)
+	}
+	// The job finishes: the next light refresh flips it to done + final usage, no waiting for the 3s tick.
+	done := subagent.Result{JobID: bg, Status: "done", Usage: &subagent.Usage{InputTokens: 5000, OutputTokens: 72}}
+	m, _ = step(t, m, wfRefreshMsg{jobs: []subagent.Result{done}, epoch: ep, seq: 2})
+	if len(m.jobs) != 1 || m.jobs[0].Status != "done" {
+		t.Fatalf("the light chain must flip the standalone row to done, got %+v", m.jobs)
+	}
+	if in, out := m.liveTokens(m.jobs[0]); in != 5000 || out != 72 {
+		t.Fatalf("a finished standalone row must show its final usage, not a stale or dropped figure, got %d/%d", in, out)
+	}
+}
+
 // TestBoardMsg_FullStateAppliesWhenJobsLoseToLightChain: a boardMsg whose JOB rows lost the shared-seq
 // race to a faster wfRefreshMsg must still apply its full-refresh-only state (teammates/tmux/pins) — that
 // state rides its own boardMsg-only seq, which the light chain never bumps — while its stale job rows are

--- a/internal/tui/workflow_board_test.go
+++ b/internal/tui/workflow_board_test.go
@@ -500,6 +500,114 @@ func TestWfPromptFold_TogglesOnEnter(t *testing.T) {
 	}
 }
 
+// TestBoardMsg_FullStateAppliesWhenJobsLoseToLightChain: a boardMsg whose JOB rows lost the shared-seq
+// race to a faster wfRefreshMsg must still apply its full-refresh-only state (teammates/tmux/pins) — that
+// state rides its own boardMsg-only seq, which the light chain never bumps — while its stale job rows are
+// dropped.
+func TestBoardMsg_FullStateAppliesWhenJobsLoseToLightChain(t *testing.T) {
+	jobID := "j1"
+	done := subagent.Result{JobID: jobID, RunID: "r1", Status: "done", Attempt: 1, Usage: &subagent.Usage{InputTokens: 300, OutputTokens: 42}}
+	running := subagent.Result{JobID: jobID, RunID: "r1", Status: "running", Attempt: 1, Usage: &subagent.Usage{InputTokens: 200, OutputTokens: 5}}
+	m := runsModel(t, nil, nil, map[string]activitySnapshot{})
+	ep := m.boardEpoch
+	// A faster light refresh (seq 2) lands first: leaf done, bumps the shared job seq only.
+	m, _ = step(t, m, wfRefreshMsg{jobs: []subagent.Result{done}, epoch: ep, seq: 2})
+	// A boardMsg whose jobs read earlier (seq 1): its tmux/teammate state still applies (own fullSeq
+	// track), its job rows are dropped (shared track, 1 < 2).
+	m, _ = step(t, m, boardMsg{jobs: []subagent.Result{running}, tmuxMissing: true, epoch: ep, seq: 1, fullSeq: 1})
+	if !m.tmuxMissing {
+		t.Fatal("a boardMsg whose jobs lost to the light chain must still apply its full-refresh-only state")
+	}
+	if len(m.workflowJobs) != 1 || m.workflowJobs[0].Status != "done" {
+		t.Fatalf("its stale job rows must be seq-dropped (stay done), got %+v", m.workflowJobs)
+	}
+}
+
+// TestBoardMsg_StaleFullStateDropped: a stale boardMsg arriving after a newer boardMsg must NOT roll back
+// the newer one's full-refresh-only state (a wrong discovery error / tmux notice / teammate rows would
+// otherwise flash). The fullSeq track drops it just like the job track.
+func TestBoardMsg_StaleFullStateDropped(t *testing.T) {
+	m := runsModel(t, nil, nil, map[string]activitySnapshot{})
+	ep := m.boardEpoch
+	// Newer full board (fullSeq 2): tmux missing.
+	m, _ = step(t, m, boardMsg{tmuxMissing: true, epoch: ep, seq: 2, fullSeq: 2})
+	// A stale boardMsg (fullSeq 1) carrying the opposite state must be dropped, not roll tmuxMissing back.
+	m, _ = step(t, m, boardMsg{tmuxMissing: false, epoch: ep, seq: 1, fullSeq: 1})
+	if !m.tmuxMissing {
+		t.Fatal("a stale boardMsg must not roll back newer full-refresh-only state")
+	}
+}
+
+// TestBoardMsg_StaleFullStateDroppedDespiteHigherJobSeq: full state is gated on fullSeq (stamped at the
+// teammate read), NOT on the job seq (stamped later at ListJobs). So a boardMsg that read teammates STALE
+// but stalled and stamped a HIGHER job seq must still have its stale full state dropped — while its fresher
+// job rows are accepted on the job track.
+func TestBoardMsg_StaleFullStateDroppedDespiteHigherJobSeq(t *testing.T) {
+	m := runsModel(t, nil, nil, map[string]activitySnapshot{})
+	ep := m.boardEpoch
+	jobID := "j1"
+	running := subagent.Result{JobID: jobID, RunID: "r1", Status: "running", Attempt: 1, Usage: &subagent.Usage{InputTokens: 200, OutputTokens: 5}}
+	// Newer full payload B: fresh teammates (fullSeq 6, tmux present), jobs at seq 7.
+	m, _ = step(t, m, boardMsg{tmuxMissing: false, epoch: ep, seq: 7, fullSeq: 6})
+	// Older full payload A: read teammates STALE (fullSeq 1, tmux missing) but stamped a higher job seq 10
+	// after a stall. Its stale full state must be dropped (1 < 6); its later-read jobs are accepted (10 > 7).
+	m, _ = step(t, m, boardMsg{jobs: []subagent.Result{running}, tmuxMissing: true, epoch: ep, seq: 10, fullSeq: 1})
+	if m.tmuxMissing {
+		t.Fatal("a stale full payload must be dropped on fullSeq even when its job seq is higher")
+	}
+	if len(m.workflowJobs) != 1 || m.workflowJobs[0].Status != "running" {
+		t.Fatalf("its later-read job rows should still apply on the job seq track, got %+v", m.workflowJobs)
+	}
+}
+
+// TestWfRefresh_OutOfOrderSeqDropped: within one board epoch the 3s and 500ms chains race, so a refresh
+// that read disk earlier can arrive AFTER a newer one. A newer refresh showing a leaf DONE must not be
+// rolled back by a late earlier-seq refresh that still saw it running with a live snapshot — that would
+// flash the stale running row and its stale tokens for a frame.
+func TestWfRefresh_OutOfOrderSeqDropped(t *testing.T) {
+	m := runsModel(t, nil, nil, map[string]activitySnapshot{})
+	ep := m.boardEpoch
+	jobID := "j1"
+	running := subagent.Result{JobID: jobID, RunID: "r1", Status: "running", Attempt: 1, Usage: &subagent.Usage{InputTokens: 200, OutputTokens: 5}}
+	done := subagent.Result{JobID: jobID, RunID: "r1", Status: "done", Attempt: 1, Usage: &subagent.Usage{InputTokens: 300, OutputTokens: 42}}
+	stale := map[string]activitySnapshot{jobID: {inTok: 5000, outTok: 800, hasUsage: true, attempt: 1}}
+	// The newer refresh (higher seq) lands first: leaf done, no live snapshot.
+	m, _ = step(t, m, wfRefreshMsg{jobs: []subagent.Result{done}, epoch: ep, seq: 2})
+	// The earlier-read refresh (lower seq) arrives late — it must be dropped, not resurrect the run row.
+	m, _ = step(t, m, wfRefreshMsg{jobs: []subagent.Result{running}, activity: stale, epoch: ep, seq: 1})
+	if len(m.workflowJobs) != 1 || m.workflowJobs[0].Status != "done" {
+		t.Fatalf("a late earlier-seq refresh must not resurrect the running row, got %+v", m.workflowJobs)
+	}
+	if in, out := m.liveTokens(m.workflowJobs[0]); in != 300 || out != 42 {
+		t.Fatalf("the done leaf must render Result.Usage, not the stale snapshot, got %d/%d", in, out)
+	}
+}
+
+// TestLeafCounts_AttemptGate: floorActivity smooths m.wfActivity across out-of-order refreshes and can
+// momentarily hold a snapshot carried from a DIFFERENT attempt (a restart reuses the job id). leafCounts/
+// liveTokens must paint such a carried snapshot only when it matches the rendered job's current attempt —
+// never a cross-attempt snapshot on a running row, never a stale snapshot on a terminal row.
+func TestLeafCounts_AttemptGate(t *testing.T) {
+	runningA1 := subagent.Result{JobID: "j1", RunID: "r1", Status: "running", Attempt: 1, Usage: &subagent.Usage{InputTokens: 200, OutputTokens: 5}}
+	doneA2 := subagent.Result{JobID: "j2", RunID: "r1", Status: "done", Attempt: 2, Usage: &subagent.Usage{InputTokens: 300, OutputTokens: 42}}
+	runningA2 := subagent.Result{JobID: "j3", RunID: "r1", Status: "running", Attempt: 2, Usage: &subagent.Usage{InputTokens: 100, OutputTokens: 2}}
+	snap := map[string]activitySnapshot{
+		"j1": {inTok: 5000, outTok: 800, hasUsage: true, attempt: 2, sigs: []string{"A", "B", "C"}}, // attempt-2 snapshot carried onto an attempt-1 running row
+		"j2": {inTok: 5000, outTok: 800, hasUsage: true, attempt: 1, sigs: []string{"A"}},           // stale snapshot on a terminal row
+		"j3": {inTok: 1000, outTok: 200, hasUsage: true, attempt: 2, sigs: []string{"A", "B"}},      // matching attempt-2 snapshot — legit smoothing
+	}
+	m := runsModel(t, nil, nil, snap)
+	if in, out, tools := m.leafCounts(runningA1); in != 200 || out != 5 || tools != 0 {
+		t.Fatalf("a cross-attempt snapshot must not paint a running row; want 200/5/0, got %d/%d/%d", in, out, tools)
+	}
+	if in, out, tools := m.leafCounts(doneA2); in != 300 || out != 42 || tools != 0 {
+		t.Fatalf("a terminal row must use Result.Usage and no stale tool count; want 300/42/0, got %d/%d/%d", in, out, tools)
+	}
+	if in, out, tools := m.leafCounts(runningA2); in != 1000 || out != 200 || tools != 2 {
+		t.Fatalf("a matching-attempt snapshot must drive the running row; want 1000/200/2, got %d/%d/%d", in, out, tools)
+	}
+}
+
 // TestWfLeafCounts_DoneUsesFinalResult: a done leaf shows its accurate final Result.Usage (not the
 // live activity snapshot), while a running leaf shows the live snapshot.
 func TestWfLeafCounts_DoneUsesFinalResult(t *testing.T) {

--- a/internal/tui/workflow_events.go
+++ b/internal/tui/workflow_events.go
@@ -22,6 +22,7 @@ type activitySnapshot struct {
 	sigs          []string // tool-call signatures in arrival order
 	inTok, outTok int
 	hasUsage      bool
+	attempt       int // the leaf's exec ordinal this snapshot belongs to; a restart bumps it and resets the floor
 }
 
 // toolCount is the number of tool calls the leaf has made so far.


### PR DESCRIPTION
Following up on #58 — the token usage on the board never moved while a task was working. It stayed blank and only filled in the final number once the task finished, which made a long run feel stuck.

This wires the live count end to end. Provider-backed subagent and workflow leaves now stream with `--include-partial-messages`, and the activity parser turns the per-message deltas into a running estimate that snaps to the exact provider count as each message completes — so a single long turn climbs smoothly rather than jumping at the very end. Detached background jobs don't keep an activity sidecar, so their status poll scans the growing capture instead (tail-bounded, so a large output doesn't make the poll expensive) and reports the running usage the same way. On the board, every running row now reads that live snapshot, not only the one you've expanded.

The live figure is intentionally a slight under-estimate that settles up to the precise count at completion, so it never ticks backwards. Verified with the race suite, the cross-platform vet gate, and a live run where a background subagent's output tokens climb in real time and reconcile to the final total.

Closes #58
