### PR TITLE
fix(profile): set CLAUDE_CODE_SUBAGENT_MODEL to inherit so subagents keep their own model

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) as real Claude Code agent-team teammates or one-shot subagents — driven exactly like native teammates. Your main session's own auth is untouched (OAuth subscription or API key, either works); provider workers bill the provider API key via apiKeyHelper (the key never enters env/argv/history). Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/internal/profile/generate.go
+++ b/internal/profile/generate.go
@@ -67,20 +67,22 @@ func GenerateForProvider(v *config.Provider, helperBinary string) ([]byte, error
 	// emitted verbatim so the profile stays byte-stable), windows double-quotes for
 	// cmd/PowerShell. The provider KEY never enters this string (keyget resolves it
 	// at runtime), so quoting protects only the path + provider name.
-	// Pin every Claude Code model slot to a provider model so a teammate/subagent
-	// never falls back to a built-in claude-* id the provider can't serve — the
-	// haiku slot drives background work (titles, context compaction, quick
-	// classification), so leaving it unset breaks long sessions against a provider
-	// base_url. The main model is the --model flag; these cover the opus/sonnet/
-	// haiku aliases and the Task-subagent model. The [1m] context marker is
-	// stripped here: only the main model (via --model) carries it, where Claude
-	// Code's strip-before-request is the documented behavior.
+	// Pin the opus/sonnet/haiku alias slots to provider models so a teammate or
+	// subagent resolving one of those aliases never falls back to a built-in
+	// claude-* id the provider can't serve — the haiku slot drives background work
+	// (titles, context compaction, quick classification), so leaving it unset breaks
+	// long sessions against a provider base_url. The main model is the --model flag.
+	// CLAUDE_CODE_SUBAGENT_MODEL is "inherit" so a subagent keeps its own model:
+	// frontmatter (resolved through those alias slots) instead of being forced onto
+	// one fixed model. The [1m] context marker is stripped from the alias slots: only
+	// the main model (via --model) carries it, where Claude Code's strip-before-request
+	// is the documented behavior.
 	env := map[string]string{
 		"ANTHROPIC_BASE_URL":             v.BaseURL,
 		"ANTHROPIC_DEFAULT_OPUS_MODEL":   config.Strip1M(v.StrongModelOrDefault()),
 		"ANTHROPIC_DEFAULT_SONNET_MODEL": config.Strip1M(v.DefaultModel),
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  config.Strip1M(v.FastModelOrDefault()),
-		"CLAUDE_CODE_SUBAGENT_MODEL":     config.Strip1M(v.DefaultModel),
+		"CLAUDE_CODE_SUBAGENT_MODEL":     "inherit",
 	}
 	pf := profileFile{
 		APIKeyHelper: quoteArg(helperBinary) + " keyget " + quoteArg(v.Name),

--- a/internal/profile/generate_test.go
+++ b/internal/profile/generate_test.go
@@ -43,8 +43,9 @@ func TestGenerateForProvider_Snapshot(t *testing.T) {
 	}
 	v := sampleProvider()
 	const helper = "/usr/local/bin/cc-fleet"
-	// A single-model provider (no strong/fast/effort): every Claude Code model tier
-	// is pinned to the default so no built-in claude-* id can escape to the provider.
+	// A single-model provider (no strong/fast/effort): the opus/sonnet/haiku alias
+	// slots are pinned to the default so no built-in claude-* id can escape to the
+	// provider, and the subagent slot is "inherit" (subagents keep their own model:).
 	const want = `{
   "apiKeyHelper": "/usr/local/bin/cc-fleet keyget deepseek",
   "env": {
@@ -52,7 +53,7 @@ func TestGenerateForProvider_Snapshot(t *testing.T) {
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-flash",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-flash",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-flash"
+    "CLAUDE_CODE_SUBAGENT_MODEL": "inherit"
   }
 }`
 
@@ -114,7 +115,7 @@ func TestGenerateForProvider_TiersEffortAndStrip1M(t *testing.T) {
 		"ANTHROPIC_DEFAULT_OPUS_MODEL":   "deepseek-v4-max", // strong, [1m] stripped
 		"ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro", // default, [1m] stripped
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "deepseek-v4-flash",
-		"CLAUDE_CODE_SUBAGENT_MODEL":     "deepseek-v4-pro", // default
+		"CLAUDE_CODE_SUBAGENT_MODEL":     "inherit", // subagents keep their own model:
 	}
 	for k, w := range want {
 		if back.Env[k] != w {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API as real Claude Code agent-team teammates or one-shot subagents. The main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
The provider profile pins `CLAUDE_CODE_SUBAGENT_MODEL` to the provider's default model. That env var overrides each subagent's own `model:` frontmatter (and the Task tool's per-invocation model), so every subagent a teammate or `cc-fleet run` session spawns is forced onto the default tier — losing the native per-agent model choice you get when running `claude` directly.

Setting the slot to `inherit` restores normal resolution: a subagent follows its own `model:` frontmatter, which still resolves through the `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` alias slots the profile already pins to provider models, and a subagent with no `model:` inherits the main `--model`. The three alias slots stay pinned, and the var stays in the env scrub set so an ambient shell value can't override the profile.
