### PR TITLE
fix(profile): leave CLAUDE_CODE_SUBAGENT_MODEL unset so subagents keep their own model

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) as real Claude Code agent-team teammates or one-shot subagents — driven exactly like native teammates. Your main session's own auth is untouched (OAuth subscription or API key, either works); provider workers bill the provider API key via apiKeyHelper (the key never enters env/argv/history). Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/internal/profile/generate.go
+++ b/internal/profile/generate.go
@@ -72,17 +72,19 @@ func GenerateForProvider(v *config.Provider, helperBinary string) ([]byte, error
 	// claude-* id the provider can't serve — the haiku slot drives background work
 	// (titles, context compaction, quick classification), so leaving it unset breaks
 	// long sessions against a provider base_url. The main model is the --model flag.
-	// CLAUDE_CODE_SUBAGENT_MODEL is "inherit" so a subagent keeps its own model:
-	// frontmatter (resolved through those alias slots) instead of being forced onto
-	// one fixed model. The [1m] context marker is stripped from the alias slots: only
-	// the main model (via --model) carries it, where Claude Code's strip-before-request
-	// is the documented behavior.
+	// CLAUDE_CODE_SUBAGENT_MODEL is deliberately NOT set: setting it (even to
+	// "inherit") makes every Task subagent take that one model, overriding its own
+	// model: frontmatter; leaving it unset lets each subagent pick its model the
+	// native way, resolved through the alias slots above. childenv / spawn's env -u
+	// still scrub it from the ambient env so an operator's shell value can't pin it.
+	// The [1m] context marker is stripped from the alias slots: only the main model
+	// (via --model) carries it, where Claude Code's strip-before-request is the
+	// documented behavior.
 	env := map[string]string{
 		"ANTHROPIC_BASE_URL":             v.BaseURL,
 		"ANTHROPIC_DEFAULT_OPUS_MODEL":   config.Strip1M(v.StrongModelOrDefault()),
 		"ANTHROPIC_DEFAULT_SONNET_MODEL": config.Strip1M(v.DefaultModel),
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  config.Strip1M(v.FastModelOrDefault()),
-		"CLAUDE_CODE_SUBAGENT_MODEL":     "inherit",
 	}
 	pf := profileFile{
 		APIKeyHelper: quoteArg(helperBinary) + " keyget " + quoteArg(v.Name),

--- a/internal/profile/generate_test.go
+++ b/internal/profile/generate_test.go
@@ -45,15 +45,14 @@ func TestGenerateForProvider_Snapshot(t *testing.T) {
 	const helper = "/usr/local/bin/cc-fleet"
 	// A single-model provider (no strong/fast/effort): the opus/sonnet/haiku alias
 	// slots are pinned to the default so no built-in claude-* id can escape to the
-	// provider, and the subagent slot is "inherit" (subagents keep their own model:).
+	// provider. CLAUDE_CODE_SUBAGENT_MODEL is not set, so subagents keep their own model:.
 	const want = `{
   "apiKeyHelper": "/usr/local/bin/cc-fleet keyget deepseek",
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-flash",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-flash",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "inherit"
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-flash"
   }
 }`
 
@@ -115,12 +114,14 @@ func TestGenerateForProvider_TiersEffortAndStrip1M(t *testing.T) {
 		"ANTHROPIC_DEFAULT_OPUS_MODEL":   "deepseek-v4-max", // strong, [1m] stripped
 		"ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro", // default, [1m] stripped
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "deepseek-v4-flash",
-		"CLAUDE_CODE_SUBAGENT_MODEL":     "inherit", // subagents keep their own model:
 	}
 	for k, w := range want {
 		if back.Env[k] != w {
 			t.Errorf("env[%s] = %q, want %q", k, back.Env[k], w)
 		}
+	}
+	if _, ok := back.Env["CLAUDE_CODE_SUBAGENT_MODEL"]; ok {
+		t.Errorf("CLAUDE_CODE_SUBAGENT_MODEL must NOT be set (subagents keep their own model:), got %q", back.Env["CLAUDE_CODE_SUBAGENT_MODEL"])
 	}
 	if _, ok := back.Env["CLAUDE_CODE_EFFORT_LEVEL"]; ok {
 		t.Errorf("a non-max effort must NOT set CLAUDE_CODE_EFFORT_LEVEL env, got %q", back.Env["CLAUDE_CODE_EFFORT_LEVEL"])

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API as real Claude Code agent-team teammates or one-shot subagents. The main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
The provider profile set `CLAUDE_CODE_SUBAGENT_MODEL` — first to the default model, then to `inherit`. Either way cc-fleet is dictating subagent model selection through that env var, and a subagent that asks for a specific tier via its own `model:` frontmatter (e.g. the fast/haiku slot) did not reliably get it.

Leaving the slot unset is the native default: each Task subagent follows its own `model:` frontmatter, resolved through the `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` alias slots the profile still pins to provider models, and falls back to the main `--model` only when it specifies none. The var stays in the env scrub set so an operator's shell value can't pin it either.
