### PR TITLE
fix(tui): scroll the add-provider picker to keep the selection visible

### DIFF
--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -600,3 +600,70 @@ func TestCodexSourceNote(t *testing.T) {
 		t.Fatalf("own note = %q", own)
 	}
 }
+
+// A picker taller than the pane windows on the cursored row so the selection and
+// its detail stay on screen, with ↑/↓ "more" markers; a pane tall enough to fit
+// the whole list is returned unwindowed.
+func TestAddPicker_WindowsTallListOnCursor(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter") // + Add -> grouped picker, cursor 0
+
+	// Tall pane: the whole list fits, so it is returned unwindowed (no markers).
+	m.height = 60
+	joined := strings.Join(m.addPickerLines(m.tmplCursor), "\n")
+	if !strings.Contains(joined, Templates[0].Label) || !strings.Contains(joined, "Codex") {
+		t.Fatalf("tall pane should list every row:\n%s", joined)
+	}
+	if strings.Contains(joined, "↑") || strings.Contains(joined, "↓") {
+		t.Fatalf("tall pane should not window (no markers):\n%s", joined)
+	}
+
+	// Short pane: the list overflows, so it windows on the cursor. At the top the
+	// cursored row shows with a ↓ marker; at the bottom it scrolls into view with
+	// a ↑ marker. The window never exceeds the pane height.
+	m.height = 24 // boardBodyHeight 14, far shorter than the ~28-line list
+	top := m.addPickerLines(m.tmplCursor)
+	joined = strings.Join(top, "\n")
+	if len(top) > m.boardBodyHeight() {
+		t.Fatalf("top window = %d lines, want <= %d:\n%s", len(top), m.boardBodyHeight(), joined)
+	}
+	if !strings.Contains(joined, Templates[0].Label) || !strings.Contains(joined, "↓") {
+		t.Fatalf("top window should show the cursored row and a ↓ marker:\n%s", joined)
+	}
+
+	// Mid-list: the cursor sits between hidden rows on both sides, so BOTH markers
+	// render — the only case that exercises windowBounds' centered start branch.
+	m = pressN(t, m, "down", 6) // to a middle Anthropic row
+	mid := m.addPickerLines(m.tmplCursor)
+	joined = strings.Join(mid, "\n")
+	if len(mid) > m.boardBodyHeight() {
+		t.Fatalf("mid window = %d lines, want <= %d:\n%s", len(mid), m.boardBodyHeight(), joined)
+	}
+	if !strings.Contains(joined, Templates[6].Label) ||
+		!strings.Contains(joined, "↑") || !strings.Contains(joined, "↓") {
+		t.Fatalf("mid window should show the cursored row and both ↑/↓ markers:\n%s", joined)
+	}
+
+	// Floor: at the minimum pane height the detail can't share the pane, so the
+	// window is clamped to bodyH — the bound still holds and the cursored row stays.
+	m.height = 12 // boardBodyHeight floors to 5
+	floor := m.addPickerLines(m.tmplCursor)
+	joined = strings.Join(floor, "\n")
+	if len(floor) > m.boardBodyHeight() {
+		t.Fatalf("floor window = %d lines, want <= %d:\n%s", len(floor), m.boardBodyHeight(), joined)
+	}
+	if !strings.Contains(joined, Templates[6].Label) {
+		t.Fatalf("floor window should still show the cursored row:\n%s", joined)
+	}
+	m.height = 24 // restore for the bottom-edge check
+
+	m = pressN(t, m, "down", codexIdx()-6) // continue to the last row (Codex)
+	bottom := m.addPickerLines(m.tmplCursor)
+	joined = strings.Join(bottom, "\n")
+	if len(bottom) > m.boardBodyHeight() {
+		t.Fatalf("bottom window = %d lines, want <= %d:\n%s", len(bottom), m.boardBodyHeight(), joined)
+	}
+	if !strings.Contains(joined, "Codex") || !strings.Contains(joined, "↑") {
+		t.Fatalf("bottom window should show Codex and a ↑ marker:\n%s", joined)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2882,9 +2882,12 @@ func (m Model) viewPickTemplate() string {
 
 // addPickerLines renders the grouped provider list. cursor >= 0 highlights that
 // flat item index and appends its seed preview; cursor < 0 is a read-only preview
-// (used as the home list's "+ Add provider…" hover detail).
+// (used as the home list's "+ Add provider…" hover detail). When the highlighted
+// list is taller than the pane it windows on the cursored row — keeping the
+// highlighted row visible — the way viewModelPick does.
 func (m Model) addPickerLines(cursor int) []string {
 	var lines []string
+	cursorLine := 0
 	idx := 0
 	for gi, g := range addGroups() {
 		if gi > 0 {
@@ -2897,16 +2900,45 @@ func (m Model) addPickerLines(cursor int) []string {
 			if idx == cursor {
 				marker = cursorStyle.Render("❯ ")
 				label = selectedStyle.Render(it.label)
+				cursorLine = len(lines)
 			}
 			lines = append(lines, "  "+marker+label)
 			idx++
 		}
 	}
+	detailStart := len(lines)
 	if cursor >= 0 {
 		lines = append(lines, "")
 		lines = append(lines, m.addItemDetail()...)
 	}
-	return lines
+	bodyH := m.boardBodyHeight()
+	if cursor < 0 || len(lines) <= bodyH {
+		return lines
+	}
+	// The list overflows the pane: window the rows on the cursored line so the
+	// highlight stays visible, keep its detail pinned below, and flag the hidden
+	// rows with ↑/↓ markers (two rows are reserved for them). On a tiny pane the
+	// detail alone can outrun the budget, so the result is clamped to bodyH — the
+	// cursored row sits near the top of the window and survives the clamp.
+	detail := lines[detailStart:]
+	avail := bodyH - len(detail) - 2
+	if avail < 1 {
+		avail = 1
+	}
+	start, end := windowBounds(cursorLine, detailStart, avail)
+	var out []string
+	if start > 0 {
+		out = append(out, faintStyle.Render(fmt.Sprintf("  ↑ %d more", start)))
+	}
+	out = append(out, lines[start:end]...)
+	if end < detailStart {
+		out = append(out, faintStyle.Render(fmt.Sprintf("  ↓ %d more", detailStart-end)))
+	}
+	out = append(out, detail...)
+	if len(out) > bodyH {
+		out = out[:bodyH]
+	}
+	return out
 }
 
 // addItemDetail is the seed/source preview for the highlighted picker row.


### PR DESCRIPTION
## What

The "+ Add provider…" picker didn't scroll. On a terminal too short to show the whole provider list, pressing ↓ moved the highlight past the bottom of the box and the selected row disappeared — you couldn't see what you were about to choose.

## Fix

The picker now windows its list on the highlighted row when the list is taller than the pane, keeping the selection and its detail on screen with ↑/↓ "more" markers — the same windowing the "select default model" list in this flow already uses. The shared board renderer and the flow wrapper are untouched; only the picker's own line builder changed.

## Testing

- `go build ./...`, `go test -race ./...`, `go vet ./...` (linux + windows), `gofmt -l` — all clean.
- New test `TestAddPicker_WindowsTallListOnCursor` covers both the overflow path (windowed, selection visible, markers) and the fits-in-pane path (unwindowed).

Closes #63
