### PR TITLE
fix(tui): keep the Agents Board title inset in every state

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-fleet",
-  "description": "Spawn any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) as real Claude Code agent-team teammates or one-shot subagents — driven exactly like native teammates. Your main session's own auth is untouched (OAuth subscription or API key, either works); provider workers bill the provider API key via apiKeyHelper (the key never enters env/argv/history). Requires the `cc-fleet` binary on PATH, installed separately.",
+  "description": "Run any model with an Anthropic- or OpenAI-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) — even your Codex subscription — as real Claude Code workflows, agent-team teammates, or one-shot subagents, driven exactly like native ones. Your main session's own auth is untouched (OAuth subscription or API key, either works); API-key providers bill the provider key via apiKeyHelper, while a Codex subscription bills through a local OAuth daemon — each worker receives its credential on demand, never through its env or argv. Requires the `cc-fleet` binary on PATH, installed separately.",
   "version": "0.2.7",
   "author": {
     "name": "Ethan Guo",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Spawn any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) as real Claude Code agent-team teammates or one-shot subagents — driven exactly like native teammates. Your main session's own auth is untouched (OAuth subscription or API key, either works); provider workers bill the provider API key via apiKeyHelper (the key never enters env/argv/history). Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/internal/tui/board_align_test.go
+++ b/internal/tui/board_align_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/teardown"
+	"github.com/ethanhq/cc-fleet/internal/userops"
+)
+
+// titleIndent is the leading-space count of the first rendered line carrying needle.
+func titleIndent(t *testing.T, out, needle string) int {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return len(line) - len(strings.TrimLeft(line, " "))
+		}
+	}
+	t.Fatalf("no line containing %q in:\n%s", needle, out)
+	return -1
+}
+
+// TestBoardTitleInsetMatchesProviders: the Agents Board title keeps a constant boardMargin
+// inset across loading / error / empty / populated, matching the Model Providers title — so
+// the two screens align and the title never jumps horizontally on tab-in.
+func TestBoardTitleInsetMatchesProviders(t *testing.T) {
+	const board = "cc-fleet · Agents Board"
+
+	// Baseline: the inset the board must match.
+	hub := withProviders(t, userops.ProviderView{Name: "glm"})
+	hub.width, hub.height = 100, 40
+	want := titleIndent(t, hub.View(), "cc-fleet · Model Providers")
+	if want != boardMargin {
+		t.Fatalf("Model Providers title indent = %d, want boardMargin=%d", want, boardMargin)
+	}
+
+	// Loading — the first frame after tab, the flicker's origin.
+	loading := withProviders(t, userops.ProviderView{Name: "glm"})
+	loading, _ = press(t, loading, "tab")
+	loading.width, loading.height = 100, 40
+	if !loading.loading {
+		t.Fatal("board should be loading right after tab")
+	}
+
+	// Error.
+	errM := boardModel(t, nil, nil)
+	errM.loading, errM.spawnErr = false, errors.New("boom")
+	errM.width, errM.height = 100, 40
+
+	// Empty — no teammates, no jobs.
+	empty := boardModel(t, nil, nil)
+	empty.width, empty.height = 100, 40
+
+	// Populated — the frame the loading state used to jump to.
+	full := boardModel(t,
+		[]teardown.Teammate{{Name: "alice", Team: "t1", PaneID: "%1", LeadSessionID: "sess-aaaaaaaa"}}, nil)
+	full.width, full.height = 100, 40
+
+	for _, c := range []struct {
+		name string
+		m    Model
+	}{{"loading", loading}, {"error", errM}, {"empty", empty}, {"populated", full}} {
+		if got := titleIndent(t, c.m.View(), board); got != want {
+			t.Errorf("%s board title indent = %d, want %d (boardMargin)", c.name, got, want)
+		}
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -468,9 +468,9 @@ func (m Model) viewSpawn() string {
 	var b strings.Builder
 	switch {
 	case m.loading:
-		b.WriteString(m.spawnTitle() + "\n\ndiscovering…")
+		b.WriteString(m.boardFallback("discovering…"))
 	case m.spawnErr != nil:
-		b.WriteString(m.spawnTitle() + "\n\n" + errStyle.Render("error: "+m.spawnErr.Error()))
+		b.WriteString(m.boardFallback(errStyle.Render("error: " + m.spawnErr.Error())))
 	case m.asMode == asModeProjects:
 		b.WriteString(m.viewAsProjects())
 	case m.asMode == asModeSessions:
@@ -483,8 +483,8 @@ func (m Model) viewSpawn() string {
 		b.WriteString(m.viewWfAgent())
 	default:
 		if _, ok := m.focusedSession(); !ok {
-			b.WriteString(m.spawnTitle() + "\n\n" +
-				faintStyle.Render("(no live agents — none spawned, and no subagent jobs)"))
+			b.WriteString(m.boardFallback(
+				faintStyle.Render("(no live agents — none spawned, and no subagent jobs)")))
 		} else {
 			b.WriteString(m.viewAsBoxes())
 		}
@@ -519,6 +519,13 @@ func tmuxMissingNotice() string {
 // fallbacks and as the first chrome line every board level renders above its header.
 func (m Model) spawnTitle() string {
 	return titleStyle.Render("cc-fleet · Agents Board") + faintStyle.Render("    tab → Model Providers")
+}
+
+// boardFallback renders a bare board level (loading / error / empty) as the app title over a
+// single message, inset by boardMargin so the title lines up with every populated level and the
+// Model Providers hub — and never shifts horizontally when records arrive.
+func (m Model) boardFallback(body string) string {
+	return indentBox(m.spawnTitle()+"\n\n"+body, boardMargin)
 }
 
 // renderAsFooter is the contextual footer per asMode; the boxes level swaps in the card
@@ -1524,7 +1531,7 @@ func (m Model) renderProjectHeader(p asProject) string {
 func (m Model) viewAsSessions() string {
 	p, ok := m.focusedProjectGroup()
 	if !ok {
-		return m.spawnTitle() + "\n\n" + faintStyle.Render("(no live agents)")
+		return m.boardFallback(faintStyle.Render("(no live agents)"))
 	}
 	var leftLines []string
 	for i, s := range p.sessions {
@@ -1833,8 +1840,8 @@ func (m Model) jobTokens(j subagent.Result) (in, out int) { return m.liveTokens(
 func (m Model) viewAsBoxes() string {
 	s, ok := m.focusedSession()
 	if !ok {
-		return m.spawnTitle() + "\n\n" +
-			faintStyle.Render("(no live agents — none spawned, and no subagent jobs)")
+		return m.boardFallback(
+			faintStyle.Render("(no live agents — none spawned, and no subagent jobs)"))
 	}
 	header := indentBox(m.renderSessionHeader(s), boardMargin) + "\n" + m.headerRule() + "\n"
 	runsBody, teamsBody, jobsBody := m.splitBoxHeights(s)
@@ -2310,7 +2317,7 @@ func (m Model) asEntityRightWidth() int {
 func (m Model) viewAsEntity() string {
 	s, ok := m.focusedSession()
 	if !ok {
-		return m.spawnTitle() + "\n\n" + faintStyle.Render("(no live agents)")
+		return m.boardFallback(faintStyle.Render("(no live agents)"))
 	}
 	listTitle, leftLines := m.asEntityLeftLines()
 	leftW, rightW := m.paneWidths(leftWidth(listTitle, leftLines, m.boardInner()))

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,10 +1,13 @@
 # cc-fleet
 
-Run any third-party LLM provider with an Anthropic-compatible API (e.g. DeepSeek,
-GLM, Kimi, Qwen, MiniMax) as scripted multi-agent **workflows**, real Claude Code
-**agent-team teammates**, or one-shot **subagents** — driven just like native ones.
-Your main session's own auth (OAuth subscription or API key) is untouched; provider
-workers bill the provider key.
+Run any model with an Anthropic- or OpenAI-compatible API — DeepSeek, GLM, Kimi,
+Qwen, MiniMax, even your Codex subscription — as scripted multi-agent **workflows**,
+real Claude Code **agent-team teammates**, or one-shot **subagents**, driven just
+like native ones. Your main session's own auth (OAuth subscription or API key) is
+untouched; provider workers bill the provider key.
+
+No Claude subscription? `ccf run <provider>` starts an interactive session on that
+provider — the same `claude` you know, just on the provider's model.
 
 ## Install
 
@@ -14,25 +17,47 @@ npm install -g @ethanhq/cc-fleet
 npx @ethanhq/cc-fleet --help
 ```
 
-`postinstall` downloads the prebuilt binary for your platform (linux/darwin/windows ×
-x64/arm64) from the matching GitHub Release, verifies its sha256, and installs
-`cc-fleet` plus the `ccf` alias.
+`postinstall` downloads the prebuilt release archive for your platform (linux/darwin/windows
+× x64/arm64) from the matching GitHub Release, verifies its sha256 against `checksums.txt`,
+then unpacks the binary — giving you `cc-fleet` and the `ccf` alias.
 
 ## The skill
 
-The npm package installs only the CLI binary. To teach Claude Code *when* to use
-the fleet, install the cc-fleet skill via the plugin:
+The npm package installs only the CLI binary. To teach Claude Code *when* to reach for
+the fleet — scheduling Workflows, Agent Teams, and Subagents on the right lane — install
+the cc-fleet plugin. Either way:
 
-```bash
-claude plugin marketplace add ethanhq/cc-fleet
-claude plugin install cc-fleet@ethanhq
-```
+- **Inside Claude Code (recommended)** — launch `claude` and run the two slash commands
+  (or `/plugin` for the interactive panel):
+
+  ```
+  /plugin marketplace add ethanhq/cc-fleet
+  /plugin install cc-fleet@ethanhq
+  ```
+
+- **From the shell:**
+
+  ```bash
+  claude plugin marketplace add ethanhq/cc-fleet
+  claude plugin install cc-fleet@ethanhq
+  ```
 
 ## First run
 
 ```bash
 cc-fleet             # open the TUI and register a provider (config created on first save)
-cc-fleet doctor      # health-check
+```
+
+## Common commands
+
+`cc-fleet` and `ccf` are the same binary — use whichever you prefer.
+
+```bash
+ccf doctor               # health-check (core vs optional)
+ccf list                 # list configured providers
+ccf run <provider>       # interactive claude session on that provider
+ccf update               # update the binary + plugin (--check to only check)
+ccf uninstall            # reset cc-fleet state (--all to fully remove)
 ```
 
 Full documentation: https://github.com/ethanhq/cc-fleet

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,7 +4,7 @@ Run any model with an Anthropic- or OpenAI-compatible API — DeepSeek, GLM, Kim
 Qwen, MiniMax, even your Codex subscription — as scripted multi-agent **workflows**,
 real Claude Code **agent-team teammates**, or one-shot **subagents**, driven just
 like native ones. Your main session's own auth (OAuth subscription or API key) is
-untouched; provider workers bill the provider key.
+untouched; each worker bills its own provider — an API key, or your Codex subscription.
 
 No Claude subscription? `ccf run <provider>` starts an interactive session on that
 provider — the same `claude` you know, just on the provider's model.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ethanhq/cc-fleet",
   "version": "0.2.6",
-  "description": "Spawn any third-party LLM provider with an Anthropic-compatible API as real Claude Code agent-team teammates or one-shot subagents. The main session's own auth (OAuth or API key) is untouched.",
+  "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",
     "ccf": "bin/launcher.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
The Agents Board title sat flush-left whenever the board had no records to show — the loading, error, and empty states emitted the title without the two-column inset that Model Providers and the populated board apply via `indentBox(…, boardMargin)`. That misaligned the two screens and produced a one-frame horizontal jump when tabbing in to a board that does have records: the first frame renders the loading state at indent 0, the next at indent 2.

This routes every bare board level through a single `boardFallback` helper that insets the title like every populated level, so the inset is constant across loading, error, empty, and populated — no misalignment, no flicker. The header builders that their callers already wrap in `indentBox` are left alone, to avoid double-indenting. A regression test asserts the board title inset matches the Model Providers inset in all four states.

The branch also refreshes the npm package's README and description: it now names the OpenAI-compatible and Codex-subscription path and `ccf run`, documents both plugin-install methods, lists the common commands, and corrects the postinstall wording to match the release archive it actually verifies.

Closes #69.
