### PR TITLE
feat(selfupdate): verify a signed checksums.txt before swapping the binary

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) — even your Codex subscription — as real Claude Code workflows, agent-team teammates, or one-shot subagents, driven exactly like native ones. Your main session's own auth is untouched (OAuth subscription or API key, either works); API-key providers bill the provider key via apiKeyHelper, while a Codex subscription bills through a local OAuth daemon — each worker receives its credential on demand, never through its env or argv. Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     tags:
       - "v*"
 
+# Read-only by default; only the signing-gated goreleaser job gets contents: write,
+# so a tag-triggered run cannot create or mutate releases before the human approval.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Runs before any artifact is built: a stale plugin.json or npm version fails
@@ -20,6 +22,14 @@ jobs:
   goreleaser:
     needs: version-guard
     runs-on: ubuntu-latest
+    # Gate the signing job behind a protected environment: CCF_RELEASE_SIGNING_KEY is an
+    # environment secret with required reviewers, so a pushed tag cannot run release code
+    # with the long-lived signing key until a human approves the deployment.
+    environment: release-signing
+    # Release write capability lives only on this gated job (publishing the release,
+    # uploading assets, undrafting).
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -27,6 +37,12 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      # Fail the release if the public key embedded in the binary does not match the
+      # signing secret — a mismatch would publish a checksums.txt.sig every updated
+      # client rejects.
+      - run: bash scripts/signing-preflight.sh
+        env:
+          CCF_RELEASE_SIGNING_KEY: ${{ secrets.CCF_RELEASE_SIGNING_KEY }}
       - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
@@ -34,6 +50,17 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CCF_RELEASE_SIGNING_KEY: ${{ secrets.CCF_RELEASE_SIGNING_KEY }}
+      # GoReleaser publishes a DRAFT; confirm the signature asset is attached, then
+      # undraft — so an unsigned release is never public, and a failed signature upload
+      # leaves only a draft to clean up.
+      - run: |
+          gh release view "${GITHUB_REF_NAME}" --json assets --jq '.assets[].name' \
+            | grep -qx 'checksums.txt.sig' \
+            || { echo "release asset checksums.txt.sig missing"; exit 1; }
+          gh release edit "${GITHUB_REF_NAME}" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   npm-publish:
     needs: [version-guard, goreleaser]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,11 +60,24 @@ archives:
 checksum:
   name_template: checksums.txt
 
+# Sign checksums.txt with the project's Ed25519 release key (CCF_RELEASE_SIGNING_KEY,
+# a base64 seed). The detached base64 signature is published as checksums.txt.sig and
+# verified by `cc-fleet update` against the public key embedded in the binary. The
+# signer is the repo's own tools/sign-checksums (stdlib Ed25519 — no gpg/cosign).
+signs:
+  - id: checksums
+    artifacts: checksum
+    cmd: go
+    args: ["run", "./tools/sign-checksums", "${artifact}", "${signature}"]
+    signature: "${artifact}.sig"
+
 release:
   github:
     owner: ethanhq
     name: cc-fleet
-  draft: false
+  # Publish as a draft; the release workflow undrafts it only after confirming
+  # checksums.txt.sig is attached, so no unsigned release is ever public.
+  draft: true
   prerelease: auto
 
 changelog:

--- a/internal/selfupdate/binary.go
+++ b/internal/selfupdate/binary.go
@@ -44,6 +44,18 @@ func prepareTarballBinary(ctx context.Context, exe, tag string, out io.Writer) (
 	if err != nil {
 		return "", fmt.Errorf("download checksums.txt: %w", err)
 	}
+	// Verify the release signature over checksums.txt against the embedded public key
+	// BEFORE trusting any sha256: the checksum is same-channel and only proves the archive
+	// matches a hash fetched from the same place — the signature is the trust anchor a
+	// mirror / redirect / arbitrary CCF_BASE_URL cannot forge. Fail closed.
+	sigBytes, err := download(ctx, base+"/checksums.txt.sig")
+	if err != nil {
+		return "", fmt.Errorf("download checksums.txt.sig: %w", err)
+	}
+	if err := verifyChecksumsSig(sumsBytes, sigBytes); err != nil {
+		return "", fmt.Errorf("verify release signature: %w", err)
+	}
+	fmt.Fprintln(out, "  ✔ signature verified")
 	expected := checksumFor(string(sumsBytes), tarName)
 	if expected == "" {
 		return "", fmt.Errorf("no checksum for %s in checksums.txt", tarName)

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/ed25519"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -248,6 +250,17 @@ func TestRun_TarballEndToEnd(t *testing.T) {
 	tarName := fmt.Sprintf("cc-fleet-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
 	tarGz := buildReleaseTarGz(t, "#!/bin/sh\necho \"cc-fleet version v9.9.9\"\n")
 	sums := fmt.Sprintf("%s  %s\n", sha256Hex(tarGz), tarName)
+	// Sign checksums.txt with a test key and point the embedded verifier at its public
+	// half, so the update verifies the signature before swapping (the real release uses
+	// the production key).
+	tpub, tpriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldKey := releaseVerifyKey
+	releaseVerifyKey = tpub
+	t.Cleanup(func() { releaseVerifyKey = oldKey })
+	sumsSig := base64.StdEncoding.EncodeToString(ed25519.Sign(tpriv, []byte(sums))) + "\n"
 	mux := http.NewServeMux()
 	mux.HandleFunc("/"+repo+"/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Location", "/"+repo+"/releases/tag/v9.9.9")
@@ -258,6 +271,9 @@ func TestRun_TarballEndToEnd(t *testing.T) {
 	})
 	mux.HandleFunc("/"+repo+"/releases/download/v9.9.9/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(sums))
+	})
+	mux.HandleFunc("/"+repo+"/releases/download/v9.9.9/checksums.txt.sig", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(sumsSig))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/internal/selfupdate/signing.go
+++ b/internal/selfupdate/signing.go
@@ -1,0 +1,52 @@
+package selfupdate
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// releaseSigningKeyB64 is the base64 Ed25519 PUBLIC key the release pipeline signs
+// checksums.txt with (see tools/sign-checksums). The matching private seed is the
+// CCF_RELEASE_SIGNING_KEY release secret; signing-preflight.sh fails the release unless
+// this constant equals the key derived from that secret.
+const releaseSigningKeyB64 = "dAbMy8Omb0En+n0xZNGTjKsNHDdwBipwqy+jHXGpZjw="
+
+// releaseVerifyKey is the decoded public key, or nil if releaseSigningKeyB64 is
+// malformed — verifyChecksumsSig then fails closed rather than letting ed25519.Verify
+// panic on a wrong-size key.
+var releaseVerifyKey = decodeVerifyKey(releaseSigningKeyB64)
+
+// decodeVerifyKey returns the Ed25519 public key for a base64 string, or nil if it is
+// not exactly ed25519.PublicKeySize bytes.
+func decodeVerifyKey(b64 string) ed25519.PublicKey {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil || len(raw) != ed25519.PublicKeySize {
+		return nil
+	}
+	return ed25519.PublicKey(raw)
+}
+
+// verifyChecksumsSig verifies a base64 Ed25519 detached signature (sigB64) over the
+// EXACT bytes of checksums.txt (sums) against the embedded release public key. It is
+// the trust anchor the self-update path checks before trusting any sha256: it fails
+// closed on a malformed embedded key, a malformed/wrong-length signature, or a
+// verification mismatch, and never panics.
+func verifyChecksumsSig(sums, sigB64 []byte) error {
+	if len(releaseVerifyKey) != ed25519.PublicKeySize {
+		return errors.New("release signing key unavailable (malformed embedded public key)")
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(sigB64)))
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("signature is %d bytes, want %d", len(sig), ed25519.SignatureSize)
+	}
+	if !ed25519.Verify(releaseVerifyKey, sums, sig) {
+		return errors.New("checksums.txt signature does not match the release key")
+	}
+	return nil
+}

--- a/internal/selfupdate/signing_test.go
+++ b/internal/selfupdate/signing_test.go
@@ -1,0 +1,85 @@
+package selfupdate
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+)
+
+func b64(b []byte) []byte { return []byte(base64.StdEncoding.EncodeToString(b)) }
+
+// TestEmbeddedReleaseKeyValid guards that the shipped releaseSigningKeyB64 constant is a
+// well-formed Ed25519 public key — a placeholder/zero/malformed value would make every
+// signed update fail closed, so it must never ship.
+func TestEmbeddedReleaseKeyValid(t *testing.T) {
+	if len(releaseVerifyKey) != ed25519.PublicKeySize {
+		t.Fatalf("embedded release public key is malformed (len=%d) — set a valid base64 Ed25519 key in signing.go", len(releaseVerifyKey))
+	}
+}
+
+func TestVerifyChecksumsSig(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := releaseVerifyKey
+	releaseVerifyKey = pub
+	t.Cleanup(func() { releaseVerifyKey = old })
+
+	sums := []byte("c0ffee  cc-fleet-linux-amd64.tar.gz\n")
+	sig := append(b64(ed25519.Sign(priv, sums)), '\n') // trailing newline as the signer writes it
+
+	if err := verifyChecksumsSig(sums, sig); err != nil {
+		t.Fatalf("AC1: a valid signature should verify: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		sums, sig []byte
+	}{
+		{"AC3 tampered checksums", []byte("tampered\n"), sig},
+		{"AC4 signature from a non-release key", sums, signWithFreshKey(t, sums)},
+		{"malformed base64 signature", sums, []byte("!!!not-base64")},
+		{"wrong-length signature", sums, b64([]byte("too short"))},
+		{"AC2 empty signature (missing .sig)", sums, []byte("")},
+	}
+	for _, c := range cases {
+		if err := verifyChecksumsSig(c.sums, c.sig); err == nil {
+			t.Errorf("%s: expected fail-closed, got nil", c.name)
+		}
+	}
+}
+
+// TestVerifyChecksumsSig_MalformedEmbeddedKey: a bad embedded key must fail closed, NOT
+// panic (ed25519.Verify panics on a wrong-size public key) — AC11.
+func TestVerifyChecksumsSig_MalformedEmbeddedKey(t *testing.T) {
+	old := releaseVerifyKey
+	releaseVerifyKey = ed25519.PublicKey([]byte("too-short"))
+	t.Cleanup(func() { releaseVerifyKey = old })
+
+	if err := verifyChecksumsSig([]byte("x"), b64(make([]byte, ed25519.SignatureSize))); err == nil {
+		t.Error("a malformed embedded key must fail closed")
+	}
+}
+
+func TestDecodeVerifyKey(t *testing.T) {
+	if decodeVerifyKey("not base64!!") != nil {
+		t.Error("malformed base64 → nil")
+	}
+	if decodeVerifyKey(base64.StdEncoding.EncodeToString(make([]byte, 5))) != nil {
+		t.Error("wrong length → nil")
+	}
+	pub, _, _ := ed25519.GenerateKey(nil)
+	if decodeVerifyKey(base64.StdEncoding.EncodeToString(pub)) == nil {
+		t.Error("a valid key → non-nil")
+	}
+}
+
+func signWithFreshKey(t *testing.T, msg []byte) []byte {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b64(ed25519.Sign(priv, msg))
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",

--- a/scripts/signing-preflight.sh
+++ b/scripts/signing-preflight.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Assert the Ed25519 public key embedded in the binary (releaseSigningKeyB64 in
+# internal/selfupdate/signing.go) matches the public key derived from the
+# CCF_RELEASE_SIGNING_KEY signing secret. Run as a release prerequisite BEFORE
+# GoReleaser signs checksums.txt: a mismatch (or an unprovisioned secret) would
+# publish a checksums.txt.sig that every updated client rejects, so it fails the
+# release loudly. The embedded key is replaced when the signing key is rotated.
+set -euo pipefail
+
+embedded="$(sed -n 's/.*releaseSigningKeyB64[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' internal/selfupdate/signing.go | head -1)"
+if [ -z "$embedded" ]; then
+  echo "signing-preflight: could not read releaseSigningKeyB64 from internal/selfupdate/signing.go" >&2
+  exit 1
+fi
+
+# Derives the public key from $CCF_RELEASE_SIGNING_KEY; fails if the secret is unset/malformed.
+derived="$(go run ./tools/sign-checksums -pubkey)"
+
+if [ "$embedded" != "$derived" ]; then
+  echo "signing-preflight: embedded public key does not match CCF_RELEASE_SIGNING_KEY" >&2
+  echo "  embedded: $embedded" >&2
+  echo "  derived:  $derived" >&2
+  echo "signing-preflight: update releaseSigningKeyB64 in signing.go to the release key, or fix the secret." >&2
+  exit 1
+fi
+echo "signing-preflight: embedded public key matches the signing secret ($embedded)"

--- a/tools/sign-checksums/main.go
+++ b/tools/sign-checksums/main.go
@@ -1,0 +1,85 @@
+// Command sign-checksums is the release-side counterpart to the self-update signature
+// verifier: it signs a release artifact (checksums.txt) with the project's Ed25519 release
+// key, derives the public key for the release key-match preflight, or generates a fresh
+// keypair. It is invoked by goreleaser's signs: step and the release workflow; it is never
+// part of the shipped cc-fleet binary.
+//
+//	sign-checksums <artifact> <signature-out>   sign <artifact>, write base64 sig to <signature-out>
+//	sign-checksums -pubkey                       print the base64 public key for $CCF_RELEASE_SIGNING_KEY
+//	sign-checksums -genkey                        print a fresh SEED= / PUBKEY= pair
+//
+// The signing key is the base64 32-byte Ed25519 seed in $CCF_RELEASE_SIGNING_KEY.
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const seedEnv = "CCF_RELEASE_SIGNING_KEY"
+
+func main() {
+	pubkey := flag.Bool("pubkey", false, "print the base64 public key derived from $"+seedEnv)
+	genkey := flag.Bool("genkey", false, "generate a fresh keypair and print SEED= / PUBKEY=")
+	flag.Parse()
+
+	if *genkey {
+		pub, priv, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			fail(err)
+		}
+		fmt.Printf("SEED=%s\nPUBKEY=%s\n",
+			base64.StdEncoding.EncodeToString(priv.Seed()),
+			base64.StdEncoding.EncodeToString(pub))
+		return
+	}
+
+	seed, err := loadSeed()
+	if err != nil {
+		fail(err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	if *pubkey {
+		fmt.Println(base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey)))
+		return
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		fail(fmt.Errorf("usage: sign-checksums <artifact> <signature-out> (or -pubkey / -genkey)"))
+	}
+	data, err := os.ReadFile(args[0])
+	if err != nil {
+		fail(err)
+	}
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, data))
+	if err := os.WriteFile(args[1], []byte(sig+"\n"), 0o644); err != nil {
+		fail(err)
+	}
+}
+
+// loadSeed reads the base64 32-byte Ed25519 seed from $CCF_RELEASE_SIGNING_KEY.
+func loadSeed() ([]byte, error) {
+	raw := strings.TrimSpace(os.Getenv(seedEnv))
+	if raw == "" {
+		return nil, fmt.Errorf("%s is empty", seedEnv)
+	}
+	seed, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", seedEnv, err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("%s must decode to %d bytes, got %d", seedEnv, ed25519.SeedSize, len(seed))
+	}
+	return seed, nil
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "sign-checksums:", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
`cc-fleet update`'s tarball path downloaded the release archive and `checksums.txt` from the same base and verified only the sha256 — a same-channel integrity check, not a trust anchor. Anyone able to serve both files (a leaked release token, a malicious mirror, an active MITM, or an arbitrary `CCF_BASE_URL`) could publish an arbitrary binary with a matching checksum that passed every check and was then swapped over the running executable, i.e. code execution as the user.

`checksums.txt` is now signed with an Ed25519 key (the repo's own `tools/sign-checksums`, stdlib only) and published as `checksums.txt.sig`; the public half is embedded in the binary, and `prepareTarballBinary` verifies the signature against it — fail-closed, never panicking on a malformed key — before trusting any checksum, so a mirror or redirect that cannot produce a valid signature is rejected regardless of `CCF_BASE_URL`. The release pipeline gains a key-match preflight (the embedded public key must equal the key derived from the signing secret), publishes as a draft and undrafts only after confirming `checksums.txt.sig` is attached, runs the signing job behind a protected environment with required reviewers, and holds release-write capability only on that gated job.

Scope is the tarball / in-process update path; npm-method updates remain on the existing sha256 path until a follow-up, go-install relies on Go's module checksum database, and `update rollback`, signed-downgrade replay, and the marketplace plugin update are out of scope. A pre-signing binary uses the old verifier for its one hop to the first signed release; signature protection begins from that release onward.

Closes #66.
