### PR TITLE
fix(selfupdate): enforce https on update downloads and the CCF_BASE_URL override

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) — even your Codex subscription — as real Claude Code workflows, agent-team teammates, or one-shot subagents, driven exactly like native ones. Your main session's own auth is untouched (OAuth subscription or API key, either works); API-key providers bill the provider key via apiKeyHelper, while a Codex subscription bills through a local OAuth daemon — each worker receives its credential on demand, never through its env or argv. Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/internal/selfupdate/binary.go
+++ b/internal/selfupdate/binary.go
@@ -33,7 +33,10 @@ func prepareTarballBinary(ctx context.Context, exe, tag string, out io.Writer) (
 
 	osArch := runtime.GOOS + "-" + runtime.GOARCH
 	tarName := fmt.Sprintf("cc-fleet-%s.tar.gz", osArch)
-	base := assetBase(tag)
+	base, err := assetBase(tag)
+	if err != nil {
+		return "", err
+	}
 
 	fmt.Fprintf(out, "  ↓ %s\n", tarName)
 	tarBytes, err := download(ctx, base+"/"+tarName)

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -290,37 +291,57 @@ func runLocked(ctx context.Context, opts Options, out io.Writer) error {
 	return nil
 }
 
-// download GETs url (following redirects to the asset CDN) and returns the body,
-// failing explicitly if it exceeds maxAsset rather than silently truncating.
-func download(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// assetHTTPClient follows redirects to the asset CDN under checkAssetRedirect.
+var assetHTTPClient = &http.Client{CheckRedirect: checkAssetRedirect}
+
+// checkAssetRedirect allows an asset redirect only while it stays https and the chain
+// stays within Go's default 10-hop bound — a non-nil CheckRedirect disables that default,
+// so a hostile https mirror can neither downgrade the fetch to http nor loop unboundedly.
+func checkAssetRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after %d redirects", len(via))
+	}
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing insecure redirect to %s://%s", req.URL.Scheme, req.URL.Host)
+	}
+	return nil
+}
+
+// download GETs url (following https-only redirects to the asset CDN) and returns the
+// body, failing explicitly if it exceeds maxAsset rather than silently truncating.
+func download(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "cc-fleet")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := assetHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+		return nil, fmt.Errorf("GET %s: HTTP %d", rawURL, resp.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAsset+1))
 	if err != nil {
 		return nil, err
 	}
 	if len(data) > maxAsset {
-		return nil, fmt.Errorf("GET %s: response exceeds %d bytes", url, maxAsset)
+		return nil, fmt.Errorf("GET %s: response exceeds %d bytes", rawURL, maxAsset)
 	}
 	return data, nil
 }
 
-// assetBase is the release-download base for a tag (CCF_BASE_URL overrides it
-// for a mirror or a local test, matching install.sh / npm).
-func assetBase(tag string) string {
+// assetBase is the release-download base for a tag. CCF_BASE_URL overrides it for an
+// https mirror or a local https test; a non-https override is rejected so the update
+// source cannot be silently re-pointed at a plaintext host.
+func assetBase(tag string) (string, error) {
 	if b := os.Getenv("CCF_BASE_URL"); b != "" {
-		return b
+		if u, err := url.Parse(b); err != nil || u.Scheme != "https" {
+			return "", fmt.Errorf("CCF_BASE_URL must be an https:// URL, got %q", b)
+		}
+		return b, nil
 	}
-	return fmt.Sprintf("%s/%s/releases/download/%s", githubBase, repo, tag)
+	return fmt.Sprintf("%s/%s/releases/download/%s", githubBase, repo, tag), nil
 }

--- a/internal/selfupdate/transport_test.go
+++ b/internal/selfupdate/transport_test.go
@@ -1,0 +1,75 @@
+package selfupdate
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestCheckAssetRedirect: the redirect policy allows https within the hop cap, refuses an
+// http downgrade, and stops a loop past the cap (a non-nil CheckRedirect drops Go's default).
+func TestCheckAssetRedirect(t *testing.T) {
+	httpsReq := &http.Request{URL: mustURL(t, "https://cdn.example/x")}
+	if err := checkAssetRedirect(httpsReq, make([]*http.Request, 3)); err != nil {
+		t.Errorf("https within the cap should be allowed: %v", err)
+	}
+	if err := checkAssetRedirect(&http.Request{URL: mustURL(t, "http://evil.example/x")}, nil); err == nil {
+		t.Error("an http downgrade redirect should be refused")
+	}
+	if err := checkAssetRedirect(httpsReq, make([]*http.Request, 10)); err == nil {
+		t.Error("a redirect past the 10-hop cap should be stopped")
+	}
+}
+
+func mustURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+// TestAssetBase_RequiresHTTPS: the CCF_BASE_URL override must be https — #68.
+func TestAssetBase_RequiresHTTPS(t *testing.T) {
+	t.Setenv("CCF_BASE_URL", "")
+	got, err := assetBase("v1.2.3")
+	if err != nil || !strings.HasPrefix(got, githubBase+"/") {
+		t.Fatalf("default base: got %q err %v", got, err)
+	}
+
+	t.Setenv("CCF_BASE_URL", "https://mirror.example/dl")
+	if got, err := assetBase("v1.2.3"); err != nil || got != "https://mirror.example/dl" {
+		t.Fatalf("https override: got %q err %v", got, err)
+	}
+
+	for _, bad := range []string{"http://evil.example", "ftp://x", "evil.example", "HtTp://x"} {
+		t.Setenv("CCF_BASE_URL", bad)
+		if _, err := assetBase("v1.2.3"); err == nil {
+			t.Errorf("CCF_BASE_URL=%q should be rejected", bad)
+		}
+	}
+}
+
+// TestDownload_RejectsInsecureRedirect: the asset download follows https-only redirects;
+// an https→http downgrade fails closed, while a direct (un-redirected) fetch still works — #67.
+func TestDownload_RejectsInsecureRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redir" {
+			http.Redirect(w, r, "http://downgrade.example/x", http.StatusFound)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	if body, err := download(context.Background(), srv.URL+"/ok"); err != nil || string(body) != "ok" {
+		t.Fatalf("direct GET: body %q err %v", body, err)
+	}
+	if _, err := download(context.Background(), srv.URL+"/redir"); err == nil {
+		t.Error("a redirect to http should be refused")
+	}
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
The signed-checksum trust anchor blocks artifact substitution, but the update transport itself was not HTTPS-enforced: `download` used the default client and followed redirects of any scheme, so an https→http downgrade on the CDN chain was followed silently, and `assetBase` honored a `CCF_BASE_URL` override verbatim — even an `http://` one — on every in-place update.

The asset download now uses a client whose redirect policy refuses any non-https hop (and keeps Go's default ten-hop cap, which a custom policy otherwise drops), and `CCF_BASE_URL` is rejected unless it is an `https://` URL. Together with the existing signature check, the update source stays https end to end and cannot be silently re-pointed at a plaintext host. Scope is the in-process tarball update path; the one-line installers and the npm postinstall are a separate follow-up.

Closes #67. Closes #68.
