### PR TITLE
feat(provider): export/import the provider roster as a keyless bundle

### DIFF
--- a/cmd/cc-fleet/export.go
+++ b/cmd/cc-fleet/export.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethanhq/cc-fleet/internal/userops"
+)
+
+// exportJSONEnvelope is the JSON shape `cc-fleet export --json` emits. With --out the
+// bundle is written to the file and Out names it; without --out the bundle TOML is
+// embedded as a string so stdout never mixes TOML and JSON.
+type exportJSONEnvelope struct {
+	OK           bool     `json:"ok"`
+	Written      []string `json:"written"`
+	OmittedCodex []string `json:"omitted_codex"`
+	Out          string   `json:"out,omitempty"`
+	Bundle       string   `json:"bundle,omitempty"`
+}
+
+func newExportCmd() *cobra.Command {
+	var out string
+	var providers []string
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Write a keyless TOML bundle of the provider roster for another machine",
+		Long: `Write a versioned, human-readable TOML bundle of the provider roster (config
++ the global default) for import on another machine. The bundle carries NO API key:
+file-backend keys stay on this machine; pass/1password/vault/keyring rows carry only
+their reference. codex providers are omitted (their login is machine-local).
+
+  cc-fleet export --out fleet-providers.toml
+  cc-fleet export --provider deepseek,glm > fleet-providers.toml
+
+Re-enter keys on the target with ` + "`cc-fleet edit --api-key-stdin/--api-key-file`" + ` and
+re-run ` + "`cc-fleet codex login`" + ` for any codex providers.`,
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			res, err := userops.Export(userops.ExportRequest{Providers: providers})
+			if err != nil {
+				reportUserOpErr(asJSON, err)
+				return err
+			}
+
+			if asJSON {
+				env := exportJSONEnvelope{OK: true, Written: res.Written, OmittedCodex: res.OmittedCodex}
+				if out != "" {
+					if err := os.WriteFile(out, res.Bundle, 0o600); err != nil {
+						reportUserOpErr(true, err)
+						return err
+					}
+					env.Out = out
+				} else {
+					env.Bundle = string(res.Bundle)
+				}
+				return json.NewEncoder(os.Stdout).Encode(env)
+			}
+
+			if out != "" {
+				if err := os.WriteFile(out, res.Bundle, 0o600); err != nil {
+					reportUserOpErr(false, err)
+					return err
+				}
+				fmt.Fprintf(os.Stderr, "wrote %d provider(s) to %s\n", len(res.Written), out)
+			} else {
+				_, _ = os.Stdout.Write(res.Bundle)
+			}
+			if len(res.OmittedCodex) > 0 {
+				fmt.Fprintf(os.Stderr, "omitted codex providers (re-add + `codex login` on the target): %v\n", res.OmittedCodex)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&out, "out", "", "write the bundle to this file (default: stdout)")
+	cmd.Flags().StringSliceVar(&providers, "provider", nil, "export only these providers (comma-separated)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit a JSON result envelope")
+	return cmd
+}

--- a/cmd/cc-fleet/import.go
+++ b/cmd/cc-fleet/import.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethanhq/cc-fleet/internal/userops"
+)
+
+// importJSONEnvelope is the JSON shape `cc-fleet import --json` emits. RepairFailed is
+// set only if the post-import profile rebuild failed (the roster is still committed —
+// re-run `cc-fleet repair`).
+type importJSONEnvelope struct {
+	OK               bool     `json:"ok"`
+	Added            []string `json:"added"`
+	Overwritten      []string `json:"overwritten"`
+	SkippedCollision []string `json:"skipped_collision"`
+	SkippedCodex     []string `json:"skipped_codex"`
+	DefaultSet       string   `json:"default_set,omitempty"`
+	DefaultDropped   string   `json:"default_dropped,omitempty"`
+	BackupPath       string   `json:"backup_path,omitempty"`
+	RepairFailed     string   `json:"repair_failed,omitempty"`
+}
+
+func newImportCmd() *cobra.Command {
+	var force, asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "import <bundle.toml>",
+		Short: "Apply a keyless provider bundle from another machine",
+		Long: `Apply a provider bundle written by ` + "`cc-fleet export`" + `. The whole bundle is
+validated before anything is written, so a bad bundle leaves the roster untouched. A
+provider that collides with an existing one is skipped unless --force; --force backs up
+providers.toml before replacing it in a single atomic write. codex providers in the
+bundle are skipped.
+
+Import writes config only and never contacts a provider; profiles are rebuilt afterward.
+Only import a bundle you trust — its base_url / models_endpoint / secret references drive
+later local secret reads and key-bearing requests.
+
+After import, re-enter keys for file-backend providers via
+` + "`cc-fleet edit --api-key-stdin/--api-key-file`" + `, re-run ` + "`cc-fleet codex login`" + ` for any
+codex providers, then ` + "`cc-fleet doctor`" + `.`,
+		Args:          cobra.ExactArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				reportUserOpErr(asJSON, err)
+				return err
+			}
+			res, err := userops.Import(userops.ImportRequest{Bundle: data, Force: force})
+			if err != nil {
+				reportUserOpErr(asJSON, err)
+				return err
+			}
+			// providers.toml is committed; rebuild profiles separately (a derived cache).
+			repairErr := ""
+			if _, e := userops.Repair(); e != nil {
+				repairErr = e.Error()
+			}
+
+			if asJSON {
+				return json.NewEncoder(os.Stdout).Encode(importJSONEnvelope{
+					OK: true, Added: res.Added, Overwritten: res.Overwritten,
+					SkippedCollision: res.SkippedCollision, SkippedCodex: res.SkippedCodex,
+					DefaultSet: res.DefaultSet, DefaultDropped: res.DefaultDropped,
+					BackupPath: res.BackupPath, RepairFailed: repairErr,
+				})
+			}
+
+			fmt.Printf("imported: %d added, %d overwritten, %d skipped (collision), %d skipped (codex)\n",
+				len(res.Added), len(res.Overwritten), len(res.SkippedCollision), len(res.SkippedCodex))
+			if res.BackupPath != "" {
+				fmt.Printf("backed up previous config to %s\n", res.BackupPath)
+			}
+			if res.DefaultSet != "" {
+				fmt.Printf("default provider: %s\n", res.DefaultSet)
+			}
+			if res.DefaultDropped != "" {
+				fmt.Printf("default %q not applied (target absent/reserved, or would change the existing default without --force)\n", res.DefaultDropped)
+			}
+			if len(res.SkippedCodex) > 0 {
+				fmt.Printf("codex skipped — run `cc-fleet codex add` + `cc-fleet codex login` here: %v\n", res.SkippedCodex)
+			}
+			fmt.Println("re-enter keys for file-backend providers (`cc-fleet edit --api-key-stdin/--api-key-file`), then `cc-fleet doctor`.")
+			if repairErr != "" {
+				fmt.Fprintf(os.Stderr, "warning: profile rebuild failed (re-run `cc-fleet repair`): %s\n", repairErr)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite colliding providers (backs up providers.toml first)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit a JSON result envelope")
+	return cmd
+}

--- a/cmd/cc-fleet/main.go
+++ b/cmd/cc-fleet/main.go
@@ -79,6 +79,8 @@ teammate Claude Code sessions inside tmux windows.`,
 	root.AddCommand(newRemoveCmd())
 	root.AddCommand(newListCmd())
 	root.AddCommand(newDefaultCmd())
+	root.AddCommand(newExportCmd())
+	root.AddCommand(newImportCmd())
 	root.AddCommand(newRepairCmd())
 	root.AddCommand(newUninstallCmd())
 	root.AddCommand(newUpdateCmd())

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,8 @@ The `cc-fleet` binary is the engine under the skills. Most of the time you let C
 | `remove <provider>` | Delete a provider and its profile (`--keep-secret` preserves the key). |
 | `list` | List configured providers with status and cache info (`--json` includes the default). |
 | `default [provider]` | Show / set / unset the fleet-wide default provider (`--unset`, `--force`). |
+| `export` | Write a keyless TOML bundle of the provider roster for another machine (`--out`, `--provider`, `--json`). |
+| `import <bundle>` | Apply a provider bundle — validates it whole, then merges (`--force` overwrites + backs up; `--json`). |
 | `models <provider>` | Show a provider's configured model roster (default / strong / fast slots). |
 | `refresh <provider>` | Re-query a provider's `/v1/models` and update the cache. |
 | `keyget <provider>` | Print a provider API key once — Claude's `apiKeyHelper` calls this. |
@@ -68,6 +70,32 @@ printf '%s' "$DEEPSEEK_API_KEY" | cc-fleet add deepseek \
 
 - `--model strong` / `--model fast` / `--model default` resolve through the roster.
 - Each slot can carry a 1M-context marker (`[1m]`) and the provider an effort level — both set in the TUI form or via `add`/`edit` flags.
+
+## Export / import the provider roster
+
+Carry your provider roster between machines as a keyless, versioned TOML bundle — review it, diff it, or check it into a private dotfiles repo. The bundle never contains a key.
+
+```bash
+cc-fleet export --out fleet-providers.toml          # all providers
+cc-fleet export --provider deepseek,glm > roster.toml
+cc-fleet import fleet-providers.toml                # apply on the new machine
+```
+
+What travels: each provider's config (protocol, base URL, for OpenAI-protocol providers the upstream URL, models endpoint, model roster, effort, default permission, key rotation, enabled, secret backend + reference) and the global default. What doesn't: the **key itself** (file-backend keys stay on the source; `pass`/`1password`/`vault`/`keyring` rows carry only their reference), and **codex** providers (their login is machine-local — omitted on export, skipped on import).
+
+`import` validates the whole bundle before writing anything, so a bad bundle leaves the roster untouched. A provider that collides with an existing one is skipped unless `--force`, which backs up `providers.toml` first and replaces it in a single atomic write. A daemon-backed (OpenAI-protocol) provider's loopback `base_url` is re-derived on the target — its `upstream_url` is what travels. Import writes config only and never contacts a provider; profiles are rebuilt afterward (a derived cache — re-run `repair` if that step reports a failure).
+
+> Only import a bundle you trust: its base URLs, models endpoints, and secret references drive later local secret-manager reads and key-bearing requests.
+
+After import, finish the setup:
+
+```bash
+printf '%s' "$KEY" | cc-fleet edit deepseek --api-key-stdin   # re-enter file-backend keys
+cc-fleet codex login                                          # for any codex providers
+cc-fleet doctor
+```
+
+The `bundle_version` in the file is the bundle format version — deliberately separate from the `version` (schema) of `providers.toml`.
 
 ## Subagent — one-shot headless calls
 

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -15,6 +15,8 @@
 | `remove <provider>` | 删除 provider 及其 profile(`--keep-secret` 保留 key)。 |
 | `list` | 列出已配置的 provider 及状态、缓存信息(`--json` 含默认 provider)。 |
 | `default [provider]` | 查看 / 设置 / 清除全局默认 provider(`--unset`、`--force`)。 |
+| `export` | 把 provider 名册导出成不含密钥的版本化 TOML 包(`--out`、`--provider`、`--json`)。 |
+| `import <bundle>` | 应用 provider 包 —— 整体校验后再合并(`--force` 覆盖并备份;`--json`)。 |
 | `models <provider>` | 查看 provider 的模型档位(default / strong / fast 槽)。 |
 | `refresh <provider>` | 重新查询 `/v1/models` 并更新缓存。 |
 | `keyget <provider>` | 输出一次 provider API key — 由 Claude 的 `apiKeyHelper` 调用。 |
@@ -68,6 +70,32 @@ printf '%s' "$DEEPSEEK_API_KEY" | cc-fleet add deepseek \
 
 - `--model strong` / `--model fast` / `--model default` 按档位表解析。
 - 每个槽位可标 1M 上下文(`[1m]`),provider 可设 effort 档 — TUI 表单或 `add`/`edit` flag 均可配置。
+
+## 导出 / 导入 provider 名册
+
+把 provider 名册作为不含密钥的版本化 TOML 包在机器之间搬运 —— 可 review、可 diff、可入私有 dotfiles 仓库。包里**绝不含密钥**。
+
+```bash
+cc-fleet export --out fleet-providers.toml          # 全部 provider
+cc-fleet export --provider deepseek,glm > roster.toml
+cc-fleet import fleet-providers.toml                # 在新机器上应用
+```
+
+随包走的:每个 provider 的配置(protocol、base URL、OpenAI-protocol 的 upstream URL、models endpoint、模型档位、effort、默认权限、key 轮换、enabled、secret 后端 + 引用)与全局默认。不走的:**密钥本身**(file 后端的密钥留在源机;`pass`/`1password`/`vault`/`keyring` 只带引用),以及 **codex** provider(其登录是机器本地的 —— 导出时省略、导入时跳过)。
+
+`import` 在写入任何东西之前先整体校验,坏包不会动你的名册。与现有 provider 冲突的行默认跳过,除非 `--force`;`--force` 会先备份 `providers.toml`,再用一次原子写替换。daemon-backed(OpenAI-protocol)provider 的 loopback `base_url` 在目标机重新派生 —— 随包走的是它的 `upstream_url`。导入只写配置、绝不联网;profile 在之后重建(派生缓存 —— 若该步报错,重跑 `repair`)。
+
+> 只导入你信任的包:它的 base URL、models endpoint、secret 引用会驱动后续本地 secret 管理器读取与带密钥的请求。
+
+导入后收尾:
+
+```bash
+printf '%s' "$KEY" | cc-fleet edit deepseek --api-key-stdin   # 重新录入 file 后端密钥
+cc-fleet codex login                                          # 任何 codex provider
+cc-fleet doctor
+```
+
+文件里的 `bundle_version` 是包格式版本 —— 刻意与 `providers.toml` 的 `version`(schema 版本)区分开。
 
 ## Subagent — 一次性 headless 调用
 

--- a/internal/codexproxy/scan.go
+++ b/internal/codexproxy/scan.go
@@ -58,6 +58,19 @@ func ChoosePort(preferred int) (int, error) {
 	return 0, fmt.Errorf("no free port in %d-%d; pass --port", defaultPortBase, defaultPortBase+portScanWidth-1)
 }
 
+// ChoosePortBatch picks a usable loopback port not in reserved, scanning the reserved
+// range. Unlike ChoosePort it does not read providers.toml — the caller seeds reserved
+// with the ports of other daemon-backed providers plus any assigned earlier in the same
+// batch, so importing several daemon-backed providers at once never double-assigns.
+func ChoosePortBatch(reserved map[int]bool) (int, error) {
+	for p := defaultPortBase; p < defaultPortBase+portScanWidth; p++ {
+		if !reserved[p] && portUsable(p) {
+			return p, nil
+		}
+	}
+	return 0, fmt.Errorf("no free port in %d-%d for the imported daemon-backed providers", defaultPortBase, defaultPortBase+portScanWidth-1)
+}
+
 // assignedPorts is the set of loopback ports already bound to a daemon-backed
 // provider in providers.toml, so a new provider never reuses one. A config-load
 // failure yields an empty set (the bind check below still guards live ports).

--- a/internal/config/bundle.go
+++ b/internal/config/bundle.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/BurntSushi/toml"
+)
+
+// BundleVersion is the export/import bundle format version. It is DELIBERATELY
+// separate from SchemaVersion (the providers.toml schema): the bundle is a portable,
+// keyless subset, so its format can evolve independently of the on-disk config.
+const BundleVersion = 1
+
+// Bundle is a portable, keyless provider roster: provider config rows plus the global
+// default, carrying NO key material. It serializes like providers.toml but keyed by
+// `bundle_version`. A daemon-backed (OpenAI-protocol) row's loopback base_url is left
+// empty here — it is re-derived on the target machine at import time.
+type Bundle struct {
+	Version         int
+	DefaultProvider string
+	Providers       map[string]*Provider
+}
+
+// reservedBundleProviderName reports whether name collides with a top-level bundle key, so
+// a provider table named it would clash with the scalar and the bundle would not parse
+// back. Enforced on both marshal and parse so the two stay symmetric.
+func reservedBundleProviderName(name string) bool {
+	return name == "bundle_version" || name == "default_provider"
+}
+
+// MarshalBundle serializes b as TOML: `bundle_version`, an optional `default_provider`,
+// and one [name] table per provider in sorted order. A provider name that collides with a
+// reserved top-level key is rejected.
+func MarshalBundle(b *Bundle) ([]byte, error) {
+	for name := range b.Providers {
+		if reservedBundleProviderName(name) {
+			return nil, fmt.Errorf("config: %q cannot be a provider name in a bundle (reserved key)", name)
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "bundle_version = %d\n", b.Version)
+	if b.DefaultProvider != "" {
+		fmt.Fprintf(&buf, "default_provider = %q\n", b.DefaultProvider)
+	}
+	names := make([]string, 0, len(b.Providers))
+	for name := range b.Providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	enc := toml.NewEncoder(&buf)
+	for _, name := range names {
+		buf.WriteString("\n[")
+		buf.WriteString(name)
+		buf.WriteString("]\n")
+		if err := enc.Encode(b.Providers[name]); err != nil {
+			return nil, fmt.Errorf("config: encode bundle provider %q: %w", name, err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// ParseBundle decodes a bundle's TOML and requires a recognized bundle_version. It does
+// NOT validate provider rows — the import path merges them into a Config and runs
+// Config.Validate(), the single strict gate.
+func ParseBundle(data []byte) (*Bundle, error) {
+	var raw map[string]any
+	if _, err := toml.Decode(string(data), &raw); err != nil {
+		return nil, fmt.Errorf("config: parse bundle toml: %w", err)
+	}
+	v, ok := raw["bundle_version"]
+	if !ok {
+		return nil, fmt.Errorf("config: not a cc-fleet provider bundle (missing bundle_version)")
+	}
+	b := &Bundle{Providers: map[string]*Provider{}}
+	switch n := v.(type) {
+	case int64:
+		b.Version = int(n)
+	case int:
+		b.Version = n
+	default:
+		return nil, fmt.Errorf("config: bundle_version has wrong type %T (want integer)", v)
+	}
+	if b.Version != BundleVersion {
+		return nil, fmt.Errorf("config: unsupported bundle_version %d (this build understands %d)", b.Version, BundleVersion)
+	}
+
+	defaultIsScalar := false
+	if dv, ok := raw["default_provider"]; ok {
+		if s, isStr := dv.(string); isStr {
+			b.DefaultProvider = s
+			defaultIsScalar = true
+		}
+	}
+	for key, val := range raw {
+		if key == "bundle_version" {
+			continue
+		}
+		if key == "default_provider" && defaultIsScalar {
+			continue
+		}
+		if reservedBundleProviderName(key) {
+			return nil, fmt.Errorf("config: %q cannot be a provider name in a bundle (reserved key)", key)
+		}
+		sub, ok := val.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("config: bundle key %q is not a table", key)
+		}
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(sub); err != nil {
+			return nil, fmt.Errorf("config: re-encode bundle provider %q: %w", key, err)
+		}
+		p := &Provider{}
+		if _, err := toml.Decode(buf.String(), p); err != nil {
+			return nil, fmt.Errorf("config: decode bundle provider %q: %w", key, err)
+		}
+		p.Name = key
+		b.Providers[key] = p
+	}
+	return b, nil
+}

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -475,6 +475,13 @@ func (c *Config) Validate() error {
 	if c.Version != SchemaVersion {
 		return fmt.Errorf("config: unsupported version %d (want %d)", c.Version, SchemaVersion)
 	}
+	// Save always writes the top-level `version` scalar, so a provider TABLE named
+	// "version" would make providers.toml un-parseable on the next load (a key that is both
+	// a scalar and a table). Reject it so it can never be written — for every writer (add,
+	// import, edit) at once.
+	if _, clash := c.Providers["version"]; clash {
+		return errors.New(`config: a provider named "version" conflicts with the providers.toml version key — rename the provider`)
+	}
 	// A scalar default_provider key and a provider TABLE named "default_provider" can't
 	// coexist — Save would emit both and the next parse would hit a TOML key/table
 	// collision. Reject the combination so it can never be written (a legacy

--- a/internal/userops/exportimport.go
+++ b/internal/userops/exportimport.go
@@ -1,0 +1,286 @@
+package userops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/codexproxy"
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+// ExportRequest selects which providers to export; an empty Providers list exports all
+// non-codex providers.
+type ExportRequest struct {
+	Providers []string
+}
+
+// ExportResult is a keyless provider bundle plus a record of what travelled and what was
+// omitted (codex rows have no portable credential).
+type ExportResult struct {
+	Bundle       []byte   `json:"-"`
+	Written      []string `json:"written"`
+	OmittedCodex []string `json:"omitted_codex"`
+}
+
+// Export builds a keyless, versioned TOML bundle of the provider roster + the global
+// default. codex providers are omitted (their auth is a machine-local login, not a
+// portable reference); a daemon-backed provider's loopback base_url is dropped (it is
+// re-derived on import). No key material is read.
+func Export(req ExportRequest) (*ExportResult, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, opErr(CodeConfigLoadFailed, err)
+	}
+
+	want := map[string]bool{}
+	for _, n := range req.Providers {
+		if _, ok := cfg.Providers[n]; !ok {
+			return nil, opErr(CodeProviderUnknown, fmt.Errorf("no such provider %q", n))
+		}
+		want[n] = true
+	}
+
+	b := &config.Bundle{Version: config.BundleVersion, Providers: map[string]*config.Provider{}}
+	res := &ExportResult{Written: []string{}, OmittedCodex: []string{}}
+	for _, name := range sortedProviderNames(cfg.Providers) {
+		if len(want) > 0 && !want[name] {
+			continue
+		}
+		v := cfg.Providers[name]
+		if v.EffectiveProtocol() == config.ProtocolCodexOAuth {
+			res.OmittedCodex = append(res.OmittedCodex, name)
+			continue
+		}
+		b.Providers[name] = portableCopy(v)
+		res.Written = append(res.Written, name)
+	}
+	// Carry the default only if its target survived the filter/codex-omit.
+	if cfg.DefaultProvider != "" {
+		if _, ok := b.Providers[cfg.DefaultProvider]; ok {
+			b.DefaultProvider = cfg.DefaultProvider
+		}
+	}
+
+	data, err := config.MarshalBundle(b)
+	if err != nil {
+		return nil, opErr(CodeExportFailed, err)
+	}
+	res.Bundle = data
+	return res, nil
+}
+
+// portableCopy strips a daemon-backed provider's loopback base_url (re-derived on the
+// target). The key was never in the row; added_at is overwritten on import.
+func portableCopy(v *config.Provider) *config.Provider {
+	c := *v
+	if c.DaemonBacked() {
+		c.BaseURL = ""
+	}
+	return &c
+}
+
+// ImportRequest is a bundle to apply. Force overwrites colliding providers (after backing
+// up providers.toml); without it, collisions are skipped.
+type ImportRequest struct {
+	Bundle []byte
+	Force  bool
+}
+
+// ImportResult records the per-provider outcome, the default-provider result, and the
+// backup path (set only when Force backed up an existing config).
+type ImportResult struct {
+	Added            []string `json:"added"`
+	Overwritten      []string `json:"overwritten"`
+	SkippedCollision []string `json:"skipped_collision"`
+	SkippedCodex     []string `json:"skipped_codex"`
+	DefaultSet       string   `json:"default_set,omitempty"`
+	DefaultDropped   string   `json:"default_dropped,omitempty"`
+	BackupPath       string   `json:"backup_path,omitempty"`
+}
+
+// Import merges a keyless bundle into providers.toml under the providers lock. It fully
+// validates the merged candidate before a single atomic write — a bad bundle leaves the
+// roster untouched. codex rows are skipped; colliding rows are skipped unless Force.
+// A daemon-backed row's loopback base_url is re-derived with a batch-aware port allocator.
+// It writes config only — profiles are rebuilt afterward by Repair.
+func Import(req ImportRequest) (*ImportResult, error) {
+	return withProvidersLock(func() (*ImportResult, error) {
+		bundle, err := config.ParseBundle(req.Bundle)
+		if err != nil {
+			return nil, opErr(CodeImportFailed, err)
+		}
+		cfg, err := config.Load()
+		if err != nil {
+			return nil, opErr(CodeConfigLoadFailed, err)
+		}
+
+		res := &ImportResult{Added: []string{}, Overwritten: []string{}, SkippedCollision: []string{}, SkippedCodex: []string{}}
+
+		// Pass 1: classify the rows we will actually apply (skip codex; skip collisions
+		// unless Force), validating each file-backend secret_ref. (A hand-edited bundle
+		// could carry a codex row even though export omits them.)
+		type applyRow struct {
+			p        *config.Provider
+			existing *config.Provider // nil for a fresh add
+		}
+		apply := map[string]applyRow{}
+		for _, name := range sortedProviderNames(bundle.Providers) {
+			p := bundle.Providers[name]
+			// The same per-provider persistence policy add enforces (reserved native
+			// name + path-safe file secret_ref) — config.Validate alone misses these, so
+			// share addLocked's guard. A [claude] row or an unsafe ref fails closed.
+			if err := guardProviderForPersistence(name, p.SecretBackend, p.SecretRef); err != nil {
+				return nil, err
+			}
+			if p.EffectiveProtocol() == config.ProtocolCodexOAuth {
+				res.SkippedCodex = append(res.SkippedCodex, name)
+				continue
+			}
+			existing, collision := cfg.Providers[name]
+			if collision && !req.Force {
+				res.SkippedCollision = append(res.SkippedCollision, name)
+				continue
+			}
+			ar := applyRow{p: p}
+			if collision {
+				ar.existing = existing
+			}
+			apply[name] = ar
+		}
+
+		// Reserve loopback ports BEFORE allocating any new one, so an addition can never
+		// grab a port that a same-name daemon-backed overwrite will reuse. A surviving
+		// daemon-backed provider keeps its port; a port is freed only when its existing
+		// daemon row is overwritten by a NON-daemon-backed row.
+		reserved := map[int]bool{}
+		for name, v := range cfg.Providers {
+			if !v.DaemonBacked() {
+				continue
+			}
+			if ar, ok := apply[name]; ok && !ar.p.DaemonBacked() {
+				continue
+			}
+			if port, e := codexproxy.PortFromBaseURL(v.BaseURL); e == nil {
+				reserved[port] = true
+			}
+		}
+
+		// Pass 2: apply each row, re-deriving a loopback base_url for daemon-backed rows.
+		for _, name := range sortedProviderNames(bundle.Providers) {
+			ar, ok := apply[name]
+			if !ok {
+				continue // skipped in pass 1
+			}
+			p := ar.p
+			if p.DaemonBacked() {
+				port := 0
+				if ar.existing != nil && ar.existing.DaemonBacked() {
+					if pp, e := codexproxy.PortFromBaseURL(ar.existing.BaseURL); e == nil {
+						port = pp // reuse the overwritten row's own port (already reserved)
+					}
+				}
+				if port == 0 {
+					if port, err = codexproxy.ChoosePortBatch(reserved); err != nil {
+						return nil, opErr(CodeImportFailed, fmt.Errorf("provider %q: %w", name, err))
+					}
+				}
+				reserved[port] = true
+				p.BaseURL = fmt.Sprintf("http://127.0.0.1:%d/", port)
+			}
+			if ar.existing != nil {
+				p.AddedAt = ar.existing.AddedAt // keep the original add time on overwrite
+				res.Overwritten = append(res.Overwritten, name)
+			} else {
+				p.AddedAt = time.Now()
+				res.Added = append(res.Added, name)
+			}
+			cfg.Providers[name] = p
+		}
+
+		// Restore the default under the same policy SetDefaultProvider enforces (shared via
+		// defaultChangeAllowed): never the reserved leaf, the target must survive, and an
+		// existing different default is not silently repinned without --force. If the policy
+		// refuses, the bundle default is dropped rather than failing the whole import.
+		if d := bundle.DefaultProvider; d != "" {
+			if err := defaultChangeAllowed(cfg, d, req.Force); err != nil {
+				res.DefaultDropped = d
+			} else {
+				cfg.DefaultProvider = d
+				res.DefaultSet = d
+			}
+		}
+
+		// The single strict gate over the merged roster — a bad bundle is rejected here,
+		// before any write.
+		if err := cfg.Validate(); err != nil {
+			return nil, opErr(CodeImportFailed, err)
+		}
+
+		// Back up the existing config before a forced overwrite.
+		if req.Force {
+			if bp, err := backupProviders(); err != nil {
+				return nil, opErr(CodeImportFailed, err)
+			} else if bp != "" {
+				res.BackupPath = bp
+			}
+		}
+
+		if err := config.Save(cfg); err != nil {
+			return nil, opErr(CodeConfigSaveFailed, err)
+		}
+		return res, nil
+	})
+}
+
+// backupProviders copies the current providers.toml to a timestamped sibling. It returns
+// "" (no error) when there is no existing config to back up.
+func backupProviders() (string, error) {
+	path, err := config.ProvidersPath()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read providers.toml for backup: %w", err)
+	}
+	// O_EXCL create-temp so rapid successive --force imports never clobber an earlier
+	// backup (a second-granularity timestamp alone would collide).
+	f, err := os.CreateTemp(filepath.Dir(path), fmt.Sprintf("providers.toml.bak-%d-*", time.Now().Unix()))
+	if err != nil {
+		return "", fmt.Errorf("create backup: %w", err)
+	}
+	name := f.Name()
+	fail := func(e error) (string, error) {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return "", e
+	}
+	if err := f.Chmod(0o600); err != nil {
+		return fail(fmt.Errorf("chmod backup: %w", err))
+	}
+	if _, err := f.Write(data); err != nil {
+		return fail(fmt.Errorf("write backup: %w", err))
+	}
+	// Close explicitly and treat a flush error as a failed backup — this is the only
+	// automatic recovery copy for a --force import, so it must be durable before we save.
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return "", fmt.Errorf("flush backup: %w", err)
+	}
+	return name, nil
+}
+
+func sortedProviderNames(m map[string]*config.Provider) []string {
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/userops/exportimport_test.go
+++ b/internal/userops/exportimport_test.go
@@ -1,0 +1,437 @@
+package userops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/config"
+)
+
+func seedConfig(t *testing.T, providers []*config.Provider, def string) {
+	t.Helper()
+	c := &config.Config{Version: config.SchemaVersion, Providers: map[string]*config.Provider{}, DefaultProvider: def}
+	for _, p := range providers {
+		c.Providers[p.Name] = p
+	}
+	if err := config.Save(c); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+}
+
+func anthropicProvider(name string) *config.Provider {
+	return &config.Provider{
+		Name: name, BaseURL: "https://api." + name + ".example", DefaultModel: name + "-x",
+		ModelsEndpoint: "https://api." + name + ".example/v1/models",
+		SecretBackend:  "file", SecretRef: name + ".key", Enabled: true,
+	}
+}
+
+func openaiProvider(name string) *config.Provider {
+	return &config.Provider{
+		Name: name, Protocol: config.ProtocolOpenAIChat, SecretBackend: "file", SecretRef: name + ".key",
+		BaseURL: "http://127.0.0.1:17225/", UpstreamURL: "https://api.openai.com/v1",
+		ModelsEndpoint: "https://api.openai.com/v1/models", DefaultModel: "gpt-4o", Enabled: true,
+	}
+}
+
+func TestExportImport_RoundTrip(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek"), anthropicProvider("glm")}, "deepseek")
+
+	ex, err := Export(ExportRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex.Written) != 2 {
+		t.Fatalf("written = %v, want 2", ex.Written)
+	}
+	if !strings.Contains(string(ex.Bundle), "bundle_version") {
+		t.Error("bundle is missing bundle_version")
+	}
+
+	// Fresh machine: wipe the roster.
+	seedConfig(t, nil, "")
+	im, err := Import(ImportRequest{Bundle: ex.Bundle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(im.Added) != 2 || im.DefaultSet != "deepseek" {
+		t.Fatalf("import result = %+v", im)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Providers) != 2 || cfg.DefaultProvider != "deepseek" {
+		t.Fatalf("roster = %d providers, default %q", len(cfg.Providers), cfg.DefaultProvider)
+	}
+	if cfg.Providers["glm"].ModelsEndpoint != "https://api.glm.example/v1/models" {
+		t.Errorf("a portable field was lost: %q", cfg.Providers["glm"].ModelsEndpoint)
+	}
+}
+
+// TestExportImport_RichFieldsRoundTrip: every portable field the docs promise travels —
+// model roster, effort, default_permission, key_rotation, enabled=false — survives a full
+// export → import, not just models_endpoint.
+func TestExportImport_RichFieldsRoundTrip(t *testing.T) {
+	setupHome(t)
+	src := &config.Provider{
+		Name: "kimi", BaseURL: "https://api.kimi.example", DefaultModel: "kimi-k2",
+		ModelsEndpoint: "https://api.kimi.example/v1/models", SecretBackend: "file", SecretRef: "kimi.key",
+		StrongModel: "kimi-k2-strong", FastModel: "kimi-k2-fast", Effort: "high",
+		DefaultPermission: "acceptEdits", KeyRotation: "round_robin", Enabled: false,
+	}
+	seedConfig(t, []*config.Provider{src}, "")
+
+	ex, err := Export(ExportRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedConfig(t, nil, "") // fresh target
+	if _, err := Import(ImportRequest{Bundle: ex.Bundle}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Providers["kimi"]
+	if got == nil {
+		t.Fatal("kimi not imported")
+	}
+	for _, c := range []struct{ field, want, have string }{
+		{"base_url", src.BaseURL, got.BaseURL},
+		{"default_model", src.DefaultModel, got.DefaultModel},
+		{"models_endpoint", src.ModelsEndpoint, got.ModelsEndpoint},
+		{"strong_model", src.StrongModel, got.StrongModel},
+		{"fast_model", src.FastModel, got.FastModel},
+		{"effort", src.Effort, got.Effort},
+		{"default_permission", src.DefaultPermission, got.DefaultPermission},
+		{"key_rotation", src.KeyRotation, got.KeyRotation},
+		{"secret_backend", src.SecretBackend, got.SecretBackend},
+		{"secret_ref", src.SecretRef, got.SecretRef},
+	} {
+		if c.have != c.want {
+			t.Errorf("%s = %q, want %q", c.field, c.have, c.want)
+		}
+	}
+	if got.Enabled {
+		t.Error("enabled = true, want false")
+	}
+}
+
+func TestExport_IsKeyless(t *testing.T) {
+	home := setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek")}, "")
+	// Plant a key on disk; export must not slurp it.
+	secretsDir := filepath.Join(home, ".config", "cc-fleet", "secrets")
+	if err := os.MkdirAll(secretsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretsDir, "deepseek.key"), []byte("SK-SECRET-KEY-BYTES"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := Export(ExportRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(ex.Bundle), "SK-SECRET-KEY-BYTES") {
+		t.Fatal("bundle leaked key material")
+	}
+}
+
+func TestExport_OmitsCodex(t *testing.T) {
+	setupHome(t)
+	codex := &config.Provider{
+		Name: "codex", Protocol: config.ProtocolCodexOAuth, SecretBackend: "codex-oauth", SecretRef: "codex-oauth",
+		BaseURL: "http://127.0.0.1:17299/", ModelsEndpoint: "http://127.0.0.1:17299/v1/models",
+		DefaultModel: "gpt-5", Enabled: true,
+	}
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek"), codex}, "")
+	ex, err := Export(ExportRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex.Written) != 1 || ex.Written[0] != "deepseek" {
+		t.Fatalf("written = %v, want [deepseek]", ex.Written)
+	}
+	if len(ex.OmittedCodex) != 1 || ex.OmittedCodex[0] != "codex" {
+		t.Fatalf("omitted = %v, want [codex]", ex.OmittedCodex)
+	}
+	if strings.Contains(string(ex.Bundle), "[codex]") {
+		t.Error("bundle still carries the codex row")
+	}
+}
+
+func TestImport_StrictRefusalLeavesRosterUntouched(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek")}, "")
+
+	// Unknown bundle_version.
+	if _, err := Import(ImportRequest{Bundle: []byte("bundle_version = 99\n")}); err == nil {
+		t.Error("unknown bundle_version should be rejected")
+	}
+	// A row that fails Config.Validate (non-http base_url).
+	bad := "bundle_version = 1\n\n[bogus]\nbase_url = \"ftp://x\"\nmodels_endpoint = \"https://x/v1/models\"\nsecret_backend = \"file\"\nsecret_ref = \"x.key\"\n"
+	if _, err := Import(ImportRequest{Bundle: []byte(bad)}); err == nil {
+		t.Error("invalid provider row should be rejected")
+	}
+	cfg, _ := config.Load()
+	if len(cfg.Providers) != 1 || cfg.Providers["bogus"] != nil {
+		t.Fatalf("roster mutated on a rejected import: %d providers", len(cfg.Providers))
+	}
+}
+
+func TestImport_CollisionSkipVsForce(t *testing.T) {
+	setupHome(t)
+	existing := anthropicProvider("deepseek")
+	existing.DefaultModel = "old-model"
+	seedConfig(t, []*config.Provider{existing}, "")
+
+	// Bundle: a modified deepseek (collision) + a new glm.
+	modified := anthropicProvider("deepseek")
+	modified.DefaultModel = "new-model"
+	bundle := mustBundle(t, []*config.Provider{modified, anthropicProvider("glm")}, "")
+
+	// Without --force: glm added, deepseek skipped + unchanged.
+	im, err := Import(ImportRequest{Bundle: bundle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(im.Added) != 1 || im.Added[0] != "glm" || len(im.SkippedCollision) != 1 {
+		t.Fatalf("no-force result = %+v", im)
+	}
+	cfg, _ := config.Load()
+	if cfg.Providers["deepseek"].DefaultModel != "old-model" {
+		t.Error("collision was overwritten without --force")
+	}
+
+	// With --force, against a clean roster of just the original deepseek: deepseek
+	// overwritten, glm added, backup written.
+	seedConfig(t, []*config.Provider{existing}, "")
+	im, err = Import(ImportRequest{Bundle: bundle, Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(im.Overwritten) != 1 || im.Overwritten[0] != "deepseek" || len(im.Added) != 1 || im.BackupPath == "" {
+		t.Fatalf("force result = %+v", im)
+	}
+	if _, err := os.Stat(im.BackupPath); err != nil {
+		t.Errorf("backup not written: %v", err)
+	}
+	cfg, _ = config.Load()
+	if cfg.Providers["deepseek"].DefaultModel != "new-model" {
+		t.Error("--force did not overwrite the colliding row")
+	}
+}
+
+// TestImport_ForceBackupsAreDistinct: two rapid --force imports (same wall-clock second)
+// must produce distinct backups, both preserved — the first backup is the only copy of the
+// pre-import config and must never be clobbered.
+func TestImport_ForceBackupsAreDistinct(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek")}, "")
+	bundle := mustBundle(t, []*config.Provider{anthropicProvider("deepseek")}, "")
+
+	im1, err := Import(ImportRequest{Bundle: bundle, Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	im2, err := Import(ImportRequest{Bundle: bundle, Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im1.BackupPath == "" || im2.BackupPath == "" || im1.BackupPath == im2.BackupPath {
+		t.Fatalf("backups not distinct: %q vs %q", im1.BackupPath, im2.BackupPath)
+	}
+	for _, p := range []string{im1.BackupPath, im2.BackupPath} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("backup %s missing: %v", p, err)
+		}
+	}
+}
+
+func TestImport_OpenAIPortRederived(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, nil, "")
+	bundle := mustBundle(t, []*config.Provider{openaiProvider("oai")}, "")
+	// The bundle drops the loopback base_url.
+	if strings.Contains(string(bundle), "127.0.0.1") {
+		t.Error("bundle should not carry the machine-local loopback base_url")
+	}
+	im, err := Import(ImportRequest{Bundle: bundle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(im.Added) != 1 {
+		t.Fatalf("import = %+v", im)
+	}
+	cfg, _ := config.Load()
+	if got := cfg.Providers["oai"].BaseURL; !strings.HasPrefix(got, "http://127.0.0.1:") {
+		t.Errorf("openai base_url not re-derived: %q", got)
+	}
+}
+
+// TestImport_ForceDaemonPortsDistinct guards the batch allocator: a new daemon-backed
+// provider whose name sorts BEFORE a forced daemon-backed overwrite must not take the
+// port the overwrite reuses — the two must end on distinct loopback base_urls.
+func TestImport_ForceDaemonPortsDistinct(t *testing.T) {
+	setupHome(t)
+	existing := openaiProvider("zoai")
+	existing.BaseURL = "http://127.0.0.1:17222/"
+	seedConfig(t, []*config.Provider{existing}, "")
+
+	// "aoai" (new) sorts before "zoai" (forced overwrite); both daemon-backed.
+	bundle := mustBundle(t, []*config.Provider{openaiProvider("aoai"), openaiProvider("zoai")}, "")
+	if _, err := Import(ImportRequest{Bundle: bundle, Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := config.Load()
+	if a, z := cfg.Providers["aoai"].BaseURL, cfg.Providers["zoai"].BaseURL; a == z {
+		t.Fatalf("two daemon-backed providers share a loopback base_url: %q", a)
+	}
+}
+
+// TestImport_RejectsVersionProviderRow: a provider named "version" collides with the
+// always-written providers.toml `version` scalar; config.Validate must reject it so import
+// can't persist an unparseable config. (Also closes the latent same bug in `cc-fleet add`.)
+func TestImport_RejectsVersionProviderRow(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek")}, "")
+	bundle := mustBundle(t, []*config.Provider{anthropicProvider("version")}, "")
+	if _, err := Import(ImportRequest{Bundle: bundle}); err == nil {
+		t.Fatal("a [version] provider row should be rejected (clashes with the version scalar)")
+	}
+	if cfg, _ := config.Load(); cfg.Providers["version"] != nil || len(cfg.Providers) != 1 {
+		t.Errorf("roster mutated on a rejected import: %d providers", len(cfg.Providers))
+	}
+}
+
+func TestImport_DanglingDefaultDropped(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, nil, "")
+	// Bundle whose default names a provider not in the bundle.
+	bundle := mustBundle(t, []*config.Provider{anthropicProvider("glm")}, "deepseek")
+	im, err := Import(ImportRequest{Bundle: bundle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im.DefaultDropped != "deepseek" || im.DefaultSet != "" {
+		t.Fatalf("dangling default not dropped: %+v", im)
+	}
+	cfg, _ := config.Load()
+	if cfg.DefaultProvider != "" {
+		t.Errorf("dangling default was written: %q", cfg.DefaultProvider)
+	}
+}
+
+// TestImport_RejectsReservedNativeName: a hand-edited bundle with a [claude] row must be
+// rejected (the name is reserved for the native leaf) and leave the roster untouched.
+// TestExport_RejectsReservedProviderName: a provider whose name collides with a reserved
+// bundle key (bundle_version) must fail export rather than emit an unparseable bundle.
+func TestExport_RejectsReservedProviderName(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("bundle_version")}, "")
+	if _, err := Export(ExportRequest{}); err == nil {
+		t.Fatal("a provider named bundle_version should fail export (reserved-key clash)")
+	}
+}
+
+func TestImport_RejectsReservedNativeName(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek")}, "")
+	bundle := mustBundle(t, []*config.Provider{anthropicProvider("claude")}, "")
+	if _, err := Import(ImportRequest{Bundle: bundle, Force: true}); err == nil {
+		t.Fatal("a bundle with the reserved [claude] row should be rejected")
+	}
+	cfg, _ := config.Load()
+	if cfg.Providers["claude"] != nil || len(cfg.Providers) != 1 {
+		t.Errorf("reserved row written or roster mutated: %d providers", len(cfg.Providers))
+	}
+}
+
+// TestImport_DefaultNotRepinnedWithoutForce: a non-force import must not silently change
+// an existing different default (mirrors SetDefaultProvider's force rule); --force does.
+func TestImport_DefaultNotRepinnedWithoutForce(t *testing.T) {
+	setupHome(t)
+	seedConfig(t, []*config.Provider{anthropicProvider("deepseek")}, "deepseek")
+	bundle := mustBundle(t, []*config.Provider{anthropicProvider("glm")}, "glm")
+
+	im, err := Import(ImportRequest{Bundle: bundle}) // no force
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im.DefaultSet != "" || im.DefaultDropped != "glm" {
+		t.Fatalf("no-force default = %+v", im)
+	}
+	if cfg, _ := config.Load(); cfg.DefaultProvider != "deepseek" {
+		t.Errorf("existing default silently changed to %q", cfg.DefaultProvider)
+	}
+
+	im, err = Import(ImportRequest{Bundle: bundle, Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im.DefaultSet != "glm" {
+		t.Fatalf("force default = %+v", im)
+	}
+	if cfg, _ := config.Load(); cfg.DefaultProvider != "glm" {
+		t.Errorf("--force did not change the default: %q", cfg.DefaultProvider)
+	}
+}
+
+// TestImport_ReservedDefaultDroppedEvenIfRowExists: a bundle default of "claude" must be
+// dropped even on a target that already holds a (hand-edited) [claude] row — the reserved
+// leaf can never be the default.
+func TestImport_ReservedDefaultDroppedEvenIfRowExists(t *testing.T) {
+	setupHome(t)
+	// A stale [claude] row that config.Load tolerates (Validate doesn't reject reserved names).
+	seedConfig(t, []*config.Provider{anthropicProvider("claude"), anthropicProvider("glm")}, "")
+	bundle := mustBundle(t, []*config.Provider{anthropicProvider("deepseek")}, "claude")
+	im, err := Import(ImportRequest{Bundle: bundle, Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im.DefaultSet == "claude" || im.DefaultDropped != "claude" {
+		t.Fatalf("reserved default not dropped: %+v", im)
+	}
+	if cfg, _ := config.Load(); cfg.DefaultProvider == config.ReservedNativeProvider {
+		t.Error("default_provider was set to the reserved native leaf")
+	}
+}
+
+func TestParseBundle_Rejects(t *testing.T) {
+	if _, err := config.ParseBundle([]byte("version = 1\n")); err == nil {
+		t.Error("a providers.toml (version, not bundle_version) should be rejected")
+	}
+	if _, err := config.ParseBundle([]byte("bundle_version = 2\n")); err == nil {
+		t.Error("an unknown bundle_version should be rejected")
+	}
+	// A [default_provider] provider table (not the scalar) must be rejected, symmetric
+	// with MarshalBundle, so import can't persist a bundle-incompatible row.
+	dp := "bundle_version = 1\n\n[default_provider]\nbase_url = \"https://x\"\nmodels_endpoint = \"https://x/v1/models\"\nsecret_backend = \"file\"\nsecret_ref = \"x.key\"\n"
+	if _, err := config.ParseBundle([]byte(dp)); err == nil {
+		t.Error("a [default_provider] provider table should be rejected")
+	}
+}
+
+// mustBundle builds a bundle directly via MarshalBundle (bypassing Export) so a test can
+// craft arbitrary rows. It applies the same portability transform Export does.
+func mustBundle(t *testing.T, providers []*config.Provider, def string) []byte {
+	t.Helper()
+	b := &config.Bundle{Version: config.BundleVersion, DefaultProvider: def, Providers: map[string]*config.Provider{}}
+	for _, p := range providers {
+		c := *p
+		if c.DaemonBacked() {
+			c.BaseURL = ""
+		}
+		b.Providers[p.Name] = &c
+	}
+	data, err := config.MarshalBundle(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/internal/userops/userops.go
+++ b/internal/userops/userops.go
@@ -45,6 +45,8 @@ const (
 	CodeRepairFailed        = "REPAIR_FAILED"
 	CodeUninstallFailed     = "UNINSTALL_FAILED"
 	CodeDefaultAlreadySet   = "DEFAULT_ALREADY_SET"
+	CodeExportFailed        = "EXPORT_FAILED"
+	CodeImportFailed        = "IMPORT_FAILED"
 )
 
 // probeTimeout caps the synchronous /v1/models probe Add performs after
@@ -247,13 +249,48 @@ func Add(req AddRequest) (*AddResult, error) {
 	return withProvidersLock(func() (*AddResult, error) { return addLocked(req) })
 }
 
+// guardProviderForPersistence enforces the per-provider policies that config.Validate
+// (schema only) does not: the reserved native name, and a path-safe file-backend
+// secret_ref. addLocked and Import share it so the two validation paths can't drift — a
+// guard added here applies to both add and import.
+func guardProviderForPersistence(name, secretBackend, secretRef string) error {
+	if name == config.ReservedNativeProvider {
+		return opErr(CodeProviderNameInvalid,
+			fmt.Errorf("name %q is reserved for the native leaf (the official claude CLI on your own login)", name))
+	}
+	if secretBackend == "file" {
+		if err := secrets.SafeRef(secretRef); err != nil {
+			return opErr(CodeInvalidBackend, err)
+		}
+	}
+	return nil
+}
+
+// defaultChangeAllowed reports whether default_provider may be set to name, given the
+// current config and force. Shared by SetDefaultProvider and Import so the default policy
+// can't drift: the reserved native leaf is never the default, the target must exist, and
+// an existing different default is not silently changed without force.
+func defaultChangeAllowed(cfg *config.Config, name string, force bool) error {
+	if name == config.ReservedNativeProvider {
+		return opErr(CodeProviderNameInvalid,
+			fmt.Errorf("%q is the native leaf — explicit-only, it can't be the default provider", name))
+	}
+	if _, ok := cfg.Providers[name]; !ok {
+		return opErr(CodeProviderUnknown, fmt.Errorf("provider %q not in providers.toml", name))
+	}
+	if cfg.DefaultProvider != "" && cfg.DefaultProvider != name && !force {
+		return opErr(CodeDefaultAlreadySet,
+			fmt.Errorf("default provider is already %q; pass --force to change it", cfg.DefaultProvider))
+	}
+	return nil
+}
+
 func addLocked(req AddRequest) (*AddResult, error) {
 	if err := ValidateProviderName(req.Name); err != nil {
 		return nil, opErr(CodeProviderNameInvalid, err)
 	}
-	if req.Name == config.ReservedNativeProvider {
-		return nil, opErr(CodeProviderNameInvalid,
-			fmt.Errorf("name %q is reserved for the native leaf (the official claude CLI on your own login)", req.Name))
+	if err := guardProviderForPersistence(req.Name, req.SecretBackend, req.SecretRef); err != nil {
+		return nil, err
 	}
 
 	cfg, err := config.Load()
@@ -276,9 +313,7 @@ func addLocked(req AddRequest) (*AddResult, error) {
 		if req.SecretRef == "" {
 			return nil, opErr(CodeInvalidBackend, errors.New("--secret-ref is required when --api-key is set"))
 		}
-		if err := secrets.SafeRef(req.SecretRef); err != nil {
-			return nil, opErr(CodeInvalidBackend, err)
-		}
+		// secret_ref path-safety is enforced by guardProviderForPersistence above.
 		if err := writeFileSecret(req.SecretRef, []byte(req.APIKey)); err != nil {
 			return nil, opErr(CodeSecretWriteFailed, err)
 		}
@@ -903,16 +938,8 @@ func SetDefaultProvider(name string, force bool) (*DefaultProviderView, error) {
 		if err := ValidateProviderName(name); err != nil {
 			return struct{}{}, opErr(CodeProviderNameInvalid, err)
 		}
-		if name == config.ReservedNativeProvider {
-			return struct{}{}, opErr(CodeProviderNameInvalid,
-				fmt.Errorf("%q is the native leaf — explicit-only, it can't be the default provider", name))
-		}
-		if _, ok := cfg.Providers[name]; !ok {
-			return struct{}{}, opErr(CodeProviderUnknown, fmt.Errorf("provider %q not in providers.toml", name))
-		}
-		if cfg.DefaultProvider != "" && cfg.DefaultProvider != name && !force {
-			return struct{}{}, opErr(CodeDefaultAlreadySet,
-				fmt.Errorf("default provider is already %q; pass --force to change it", cfg.DefaultProvider))
+		if err := defaultChangeAllowed(cfg, name, force); err != nil {
+			return struct{}{}, err
 		}
 		cfg.DefaultProvider = name
 		if err := config.Save(cfg); err != nil {


### PR DESCRIPTION
There was no way to carry a provider roster between machines — a second machine meant re-running `cc-fleet add` per provider and re-typing every flag. `cc-fleet export` now writes a versioned, human-readable TOML bundle of the provider config plus the global default, with no key material, and `cc-fleet import` validates the whole bundle then merges it onto the target. file-backend keys stay on the source (only the secret reference travels); `pass`/`1password`/`vault`/`keyring` rows carry their reference; codex providers are omitted because their login is machine-local. Re-enter keys with `cc-fleet edit --api-key-stdin/--api-key-file` and re-run `cc-fleet codex login` on the target.

Import is fail-closed and writes config only (it never probes a provider): it validates the whole merged roster before a single atomic write, so a bad bundle leaves `providers.toml` untouched. A colliding provider is skipped unless `--force`, which backs up the existing config to a unique file before replacing it; an OpenAI-protocol provider's machine-local loopback `base_url` is re-derived on the target with a batch-aware port allocator; and the global default is restored only under the same policy `cc-fleet default` enforces (never the reserved native leaf, the target must survive, and an existing default is not silently repinned without `--force`).

Getting import right surfaced that the import path and the interactive verbs validated through different paths, so the persistence policies were factored into shared guards that `add`/`default` and `import` now both use, with a providers.toml top-level-key collision rejected canonically in `config.Validate`. That refactor also fixes two latent bugs in `cc-fleet add` independent of import: a file-backend `secret_ref` is now path-checked even without an inline `--api-key`, and a provider named `version` (which would otherwise write an unparseable `providers.toml`) is rejected before any write.

Closes #80.
