### PR TITLE
feat(tui): add a searchable session browser to the Agents Board

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ Platform splits live in `procintrospect` and per-package `_unix.go` / `_windows.
 
 - **Pane identity is (tmux socket, pane id)** — never (team, name). The default server is the empty socket; out-of-tmux teammates live on a per-team `cc-fleet-swarm-<team>` socket. All tmux access goes through the single `tmux.Server` outlet.
 - `config.Load` is **strict**: an invalid `key_rotation`, unknown `secret_backend`, or wrong schema version is rejected at load, not defaulted.
-- The TUI (`tui`) is one Bubbletea app: the provider hub (add/edit forms, key manager, codex login) and a project-first master-detail **Agents Board** over teammates, subagent jobs, and workflow runs — with per-leaf hold/restart, prompt/answer drill-in, and spend columns. `teamhist` keeps ended teams visible as faint snapshot rows; `pinned` marks records as out-of-band files so they survive GC and clears. The whole palette is adaptive (dark/light).
+- The TUI (`tui`) is one Bubbletea app: the provider hub (add/edit forms, key manager, codex login) and a project-first master-detail **Agents Board** over teammates, subagent jobs, and workflow runs — with per-leaf hold/restart, prompt/answer drill-in, spend columns, and a `ctrl+f` flat session browser that filters every past job / run / team by substring and opens the selected one's existing detail. `teamhist` keeps ended teams visible as faint snapshot rows; `pinned` marks records as out-of-band files so they survive GC and clears. The whole palette is adaptive (dark/light).
 
 ## Distribution & self-update (`selfupdate`, `version`)
 

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -1,0 +1,508 @@
+package tui
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ethanhq/cc-fleet/internal/sessiontitle"
+)
+
+// browserKind tags a flat row's lane so a row can re-find its source after a refresh and
+// route Enter to the right detail view. It also tags an L3 entity anchor (job vs teammate).
+type browserKind int
+
+const (
+	browserJob  browserKind = iota // a standalone subagent job (RunID == "")
+	browserRun                     // a workflow run
+	browserTeam                    // a team session
+	browserMate                    // an L3 entity anchor only: a teammate (never a flat browser row)
+)
+
+// browserRef is a row's stable identity, used both as the flat browser cursor anchor and as
+// the L3 entity-cursor anchor. id is the kind's key: a job/run id, a teammate's mateKey, or
+// leadSessionID+"\x00"+team for a team session — so it survives the wholesale slice swap a
+// board refresh does.
+type browserRef struct {
+	kind browserKind
+	id   string
+}
+
+// browserRow is one flat, newest-first list entry. The display fields feed the filter (title +
+// provider + lane) and the rendered line; the id fields carry exactly what Enter needs to set
+// the board's navigation state for that entity's existing detail view.
+type browserRow struct {
+	ref      browserRef
+	title    string
+	provider string
+	lane     string
+	project  string // the session's project dir — filterable; its basename shows on the row
+	session  string // the parent session's title (subagent/workflow rows; teams carry it in title)
+	when     time.Time
+	hasWhen  bool
+
+	// Enter targets.
+	jobID         string
+	runID         string
+	sessionID     string // run's launching session (the board grouping key)
+	leadSessionID string // job/team session root
+	team          string // team name (browserTeam)
+}
+
+// teamRefID is a team session's anchor id: its session root and name together (a team named
+// "" — the "(no team)" bucket — still gets a stable, distinct key per session).
+func teamRefID(leadSessionID, team string) string { return leadSessionID + "\x00" + team }
+
+// browserRows flattens the board's already-loaded slices into the flat list, newest-first.
+// It reuses the board's per-lane row helpers (jobRowLabel / runLabel / sessionLabel) so there
+// is no second title path: a job with no --label shows a short id, which the filter still
+// matches on provider/lane/project/session. Standalone jobs only (RunID == "") — workflow leaves belong
+// to their run row; teams come from the session tree. Ties break by id for a stable order as
+// the board polls underneath.
+func (m Model) browserRows() []browserRow {
+	var rows []browserRow
+
+	for _, j := range m.jobs {
+		if j.RunID != "" {
+			continue // a workflow leaf belongs to its run row, never listed standalone
+		}
+		row := browserRow{
+			ref:           browserRef{kind: browserJob, id: j.JobID},
+			title:         jobRowLabel(j),
+			provider:      j.Provider,
+			lane:          "subagent",
+			project:       m.sessionMeta[j.LeadSessionID].Cwd,
+			session:       m.browserSessionTitle(j.LeadSessionID),
+			jobID:         j.JobID,
+			leadSessionID: j.LeadSessionID,
+		}
+		if ts, err := time.Parse(time.RFC3339, j.StartedAt); err == nil {
+			row.when, row.hasWhen = ts, true
+		}
+		rows = append(rows, row)
+	}
+
+	for _, g := range m.wfGroups() {
+		row := browserRow{
+			ref:       browserRef{kind: browserRun, id: g.runID},
+			title:     m.runLabel(g),
+			provider:  runProvider(g),
+			lane:      "workflow",
+			project:   g.cwd,
+			session:   m.browserSessionTitle(g.sessionID),
+			runID:     g.runID,
+			sessionID: g.sessionID,
+		}
+		if ts, err := time.Parse(time.RFC3339, g.startedAt); err == nil {
+			row.when, row.hasWhen = ts, true
+		}
+		rows = append(rows, row)
+	}
+
+	for _, s := range m.asSessions() {
+		for _, t := range s.teams {
+			row := browserRow{
+				ref:           browserRef{kind: browserTeam, id: teamRefID(s.sessionID, t.name)},
+				title:         teamTitle(m, s.sessionID, t.name),
+				provider:      teamProvider(t),
+				lane:          "team",
+				project:       sessionProjectDir(s, m.sessionMeta),
+				leadSessionID: s.sessionID,
+				team:          t.name,
+			}
+			if when, ok := teamWhen(t); ok {
+				row.when, row.hasWhen = when, true
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.hasWhen != b.hasWhen {
+			return a.hasWhen // timed rows before undated ones
+		}
+		if a.hasWhen && !a.when.Equal(b.when) {
+			return a.when.After(b.when) // newest first
+		}
+		return a.ref.id < b.ref.id // stable tiebreak
+	})
+	return rows
+}
+
+// runProvider is a run's display provider: the first leaf's provider (a run is usually
+// single-provider; a mixed run just shows the first, which still feeds the filter).
+func runProvider(g runGroup) string {
+	for _, p := range g.phases {
+		for _, j := range p.jobs {
+			if j.Provider != "" {
+				return j.Provider
+			}
+		}
+	}
+	return ""
+}
+
+// teamProvider is a team's display provider: its first live member's provider, else the first
+// member's (an ended team still shows a recorded provider when one survives).
+func teamProvider(t asTeam) string {
+	for _, mem := range t.members {
+		if mem.Status != endedStatus && mem.Provider != "" {
+			return mem.Provider
+		}
+	}
+	for _, mem := range t.members {
+		if mem.Provider != "" {
+			return mem.Provider
+		}
+	}
+	return ""
+}
+
+// teamTitle names a team row: "<team> · <session>" so the same team across sessions stays
+// distinguishable, falling back to the session label when a team has no name.
+func teamTitle(m Model, sessionID, team string) string {
+	sess := m.sessionLabel(sessionID)
+	if name := sessiontitle.CleanTitle(team); name != "" {
+		return trunc(name, 24) + " · " + sess
+	}
+	return sess
+}
+
+// teamWhen is a team session's sort time: the earliest member SpawnTime (its "created").
+func teamWhen(t asTeam) (time.Time, bool) {
+	var earliest int64
+	for _, mem := range t.members {
+		if mem.SpawnTime > 0 && (earliest == 0 || mem.SpawnTime < earliest) {
+			earliest = mem.SpawnTime
+		}
+	}
+	if earliest == 0 {
+		return time.Time{}, false
+	}
+	return time.UnixMilli(earliest), true
+}
+
+// browserSessionTitle is the parent Claude session's title (its /rename or AI title) for a row,
+// empty when the conversation was never titled — so a row only ever shows a real session name, not
+// a raw id. The id stays filterable via the row's leadSessionID/sessionID.
+func (m Model) browserSessionTitle(id string) string {
+	return trunc(sessiontitle.CleanTitle(m.sessionMeta[id].Title), 40)
+}
+
+// filteredBrowserRows narrows browserRows by a case-insensitive substring over the row's title,
+// provider, lane, project dir, parent-session title, and parent-session id. An empty filter returns
+// the full list.
+func (m Model) filteredBrowserRows() []browserRow {
+	all := m.browserRows()
+	if m.browserFilter == "" {
+		return all
+	}
+	q := strings.ToLower(m.browserFilter)
+	var out []browserRow
+	for _, r := range all {
+		hay := strings.ToLower(strings.Join([]string{
+			r.title, r.provider, r.lane, r.project, r.session, r.leadSessionID, r.sessionID,
+		}, " "))
+		if strings.Contains(hay, q) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// openBrowser switches the board into the flat session browser. It is a DEDICATED entry path
+// (NOT the boardEntryRoute reset, which forces asModeBoxes on the first refresh): asModeBrowser
+// is preserved by rerootSpawn's own branch, so the browser survives the board's polling.
+func (m Model) openBrowser() (tea.Model, tea.Cmd) {
+	m.browserReturnMode = m.asMode // restored on esc, so the browser closes back to the board
+	m.asMode = asModeBrowser
+	m.browserFilter = ""
+	m.browserCursor = 0
+	m.browserAnchor = browserRef{}
+	if rows := m.filteredBrowserRows(); len(rows) > 0 {
+		m.browserAnchor = rows[0].ref
+	}
+	return m, nil
+}
+
+// updateBrowser drives the flat browser: keystrokes route to the filter FIRST (printable runes,
+// backspace, ↑/↓, enter, esc) — only ctrl+c stays global (consumed before this in Update). A
+// filter edit resets the cursor to the top; Enter opens the cursored row's existing detail.
+func (m Model) updateBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	rows := m.filteredBrowserRows()
+	switch msg.String() {
+	case "esc":
+		m.asMode = m.browserReturnMode // close the browser back to the board level it opened from
+		return m, nil
+	case "up":
+		if m.browserCursor > 0 {
+			m.browserCursor--
+		}
+		m.syncBrowserAnchor(rows)
+	case "down":
+		if m.browserCursor < len(rows)-1 {
+			m.browserCursor++
+		}
+		m.syncBrowserAnchor(rows)
+	case "enter":
+		if m.browserCursor >= 0 && m.browserCursor < len(rows) {
+			return m.enterBrowserRow(rows[m.browserCursor])
+		}
+	case "backspace", "ctrl+h": // some terminals report Backspace as Ctrl-H
+		if m.browserFilter != "" {
+			r := []rune(m.browserFilter)
+			m.browserFilter = string(r[:len(r)-1])
+			m.browserCursor = 0
+			m.syncBrowserAnchor(m.filteredBrowserRows())
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			m.browserFilter += string(msg.Runes)
+			m.browserCursor = 0
+			m.syncBrowserAnchor(m.filteredBrowserRows())
+		}
+	}
+	return m, nil
+}
+
+// syncBrowserAnchor records the cursored row's identity, so a refresh that reshapes the list
+// can re-find it (reanchorBrowser) instead of letting the index drift onto another row.
+func (m *Model) syncBrowserAnchor(rows []browserRow) {
+	if m.browserCursor >= 0 && m.browserCursor < len(rows) {
+		m.browserAnchor = rows[m.browserCursor].ref
+	}
+}
+
+// reanchorBrowser re-finds the anchored row's index after a refresh rebuilds the rows. When the
+// anchored row is gone it clamps the cursor and re-anchors to whatever row the cursor now lands
+// on, so identity tracking resumes (else every later refresh re-fails the stale anchor and the
+// cursor silently drifts back to positional).
+func (m *Model) reanchorBrowser() {
+	rows := m.filteredBrowserRows()
+	for i, r := range rows {
+		if r.ref == m.browserAnchor {
+			m.browserCursor = i
+			return
+		}
+	}
+	m.browserCursor = clampIndex(m.browserCursor, len(rows))
+	if m.browserCursor < len(rows) {
+		m.browserAnchor = rows[m.browserCursor].ref
+	} else {
+		m.browserAnchor = browserRef{}
+	}
+}
+
+// enterBrowserRow opens the row's entity in its EXISTING board detail view by setting the same
+// navigation state a hand-drill would (mirror enterSession / asDescend), and marks browserOrigin
+// so esc returns here while ← does normal board ascent. It roots the session and its project (so
+// the run drill survives a refresh and ← climbs into the right project) and seeds asBoxCursor to
+// the entity's L2 row, so a later ← — and any row action there (d/p/s) — targets the right
+// run/team/job instead of a stale one.
+func (m Model) enterBrowserRow(row browserRow) (tea.Model, tea.Cmd) {
+	m.browserOrigin = true
+	switch row.ref.kind {
+	case browserRun:
+		m.focusedSessionID = row.sessionID
+		m.rootBrowserProject()
+		m.asBoxCursor = m.browserBoxCursor(row)
+		m.focusedRunID = row.runID
+		m.wfPhaseCursor, m.wfAgentCursor = 0, 0
+		m.asMode = asModeRunPhases
+		return m, nil
+	case browserTeam:
+		m.focusedSessionID = row.leadSessionID
+		m.rootBrowserProject()
+		m.asBoxCursor = m.browserBoxCursor(row)
+		m.asEntitySrc = asRailRef{team: row.team}
+		m.asEntityCursor, m.asCardScroll = 0, 0
+		m.asMode = asModeEntity
+		return m.focusEntityIO()
+	default: // browserJob
+		m.focusedSessionID = row.leadSessionID
+		m.rootBrowserProject()
+		m.asBoxCursor = m.browserBoxCursor(row)
+		m.asEntitySrc = asRailRef{jobs: true}
+		m.asEntityCursor = m.jobIndex(row.jobID)
+		m.asCardScroll = 0
+		m.asMode = asModeEntity
+		return m.focusEntityIO()
+	}
+}
+
+// browserBoxCursor is the L2 continuum index (runs, then teams, then jobs — mirror boxRowRef) of
+// the entered row's entity in the now-focused session, so ← out of a browser-entered detail lands
+// the boxes cursor on the right row. Requires focusedSessionID already set; a vanished entity → 0.
+func (m Model) browserBoxCursor(row browserRow) int {
+	s, ok := m.focusedSession()
+	if !ok {
+		return 0
+	}
+	switch row.ref.kind {
+	case browserRun:
+		for i, g := range s.runs {
+			if g.runID == row.runID {
+				return i
+			}
+		}
+	case browserTeam:
+		for i, t := range s.teams {
+			if t.name == row.team {
+				return len(s.runs) + i
+			}
+		}
+	default: // browserJob
+		for i, j := range s.jobs {
+			if j.JobID == row.jobID {
+				return len(s.runs) + len(s.teams) + i
+			}
+		}
+	}
+	return 0
+}
+
+// rootBrowserProject sets focusedProject from the now-focused session (mirror rerootSpawn) so a
+// browser-entered detail's ← ascent climbs into the right project immediately, before the next
+// refresh would re-derive it. Requires focusedSessionID already set.
+func (m *Model) rootBrowserProject() {
+	if s, ok := m.focusedSession(); ok {
+		m.focusedProject = sessionProjectDir(s, m.sessionMeta)
+	}
+}
+
+// jobIndex is the focused job's index in the now-current session jobs slice (the L3 cursor
+// indexes that per-tick-rebuilt slice). A vanished job clamps to 0.
+func (m Model) jobIndex(jobID string) int {
+	_, jobs := m.railEntities()
+	for i, j := range jobs {
+		if j.JobID == jobID {
+			return i
+		}
+	}
+	return 0
+}
+
+// viewBrowser renders the flat session browser in the resume style: a "Session browser · N records"
+// header, a rounded search box, then two-line entries (label · session title, then a dim relative-
+// time metadata line) spaced by a blank line and windowed to the cursor. The board's warning/footer
+// tail is appended by viewSpawn — the same tail every board mode shares.
+func (m Model) viewBrowser() string {
+	all := m.browserRows()
+	rows := m.filteredBrowserRows()
+
+	count := fmt.Sprintf("%d records", len(all))
+	if m.browserFilter != "" {
+		count = fmt.Sprintf("%d / %d", len(rows), len(all))
+	}
+	header := titleStyle.Render("cc-fleet · Session browser") + faintStyle.Render(" · "+count)
+
+	glyph := contentStyle.Render("⌕")
+	field := glyph + " " + faintStyle.Render("Search…")
+	if m.browserFilter != "" {
+		field = glyph + " " + contentStyle.Render(m.browserFilter)
+	}
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "237", Dark: "252"}).
+		Padding(0, 1).
+		Width(m.boardInner() - 4).
+		Render(field)
+
+	var body []string
+	switch {
+	case len(all) == 0:
+		body = append(body, faintStyle.Render("(no past sessions yet)"))
+	case len(rows) == 0:
+		body = append(body, faintStyle.Render("no match — backspace to widen the filter"))
+	default:
+		// Window to the real terminal height — NOT boardBodyHeight, which budgets the master-detail
+		// chrome the browser doesn't draw. The browser's own chrome is the header + blank + 3-row
+		// search box + blank above and a blank + footer below (~9 rows); each entry is 2 lines + a blank.
+		// The 24-row fallback is ONLY for the pre-WindowSizeMsg state; a real (even tiny) height wins.
+		h := m.height
+		if h <= 0 {
+			h = 24
+		}
+		visible := (h - 9) / 3
+		if visible < 1 {
+			visible = 1
+		}
+		start, end := windowBounds(m.browserCursor, len(rows), visible)
+		for i := start; i < end; i++ {
+			body = append(body, m.browserEntryLines(rows[i], i, start, end, len(rows))...)
+			if i < end-1 {
+				body = append(body, "")
+			}
+		}
+	}
+
+	// Trailing blank line so the shared footer viewSpawn appends below sits off the last entry.
+	content := header + "\n\n" + box + "\n\n" + strings.Join(body, "\n") + "\n"
+	return indentBox(content, boardMargin)
+}
+
+// browserEntryLines renders one entry as two lines: the entity label · parent-session title (with a
+// cursor / scroll-edge marker), then a dim "<relative time> · provider · lane · project" line.
+func (m Model) browserEntryLines(r browserRow, i, start, end, total int) []string {
+	marker, style := "  ", contentStyle
+	switch {
+	case i == m.browserCursor:
+		marker, style = cursorStyle.Render("❯ "), selectedStyle
+	case i == start && start > 0:
+		marker = faintStyle.Render("↑ ") // more above the window
+	case i == end-1 && end < total:
+		marker = faintStyle.Render("↓ ") // more below the window
+	}
+	name := r.title
+	if r.session != "" {
+		name += " · " + r.session
+	}
+	titleLine := marker + style.Render(trunc(name, m.boardInner()-4))
+
+	parts := make([]string, 0, 4)
+	if r.hasWhen {
+		parts = append(parts, relAgo(r.when))
+	}
+	// Scrub ANSI/BEL/OSC from every displayed metadata field (provider from on-disk records, the raw
+	// cwd basename) before render — the board's CleanTitle-at-render invariant. lane is a literal.
+	if p := sessiontitle.CleanTitle(r.provider); p != "" {
+		parts = append(parts, p)
+	}
+	parts = append(parts, r.lane)
+	if p := sessiontitle.CleanTitle(filepath.Base(r.project)); p != "" {
+		parts = append(parts, p)
+	}
+	metaLine := "  " + faintStyle.Render(trunc(strings.Join(parts, " · "), m.boardInner()-4))
+	return []string{titleLine, metaLine}
+}
+
+// relAgo renders a coarse "N units ago" for a row's time — second / minute / hour / day, singular-
+// aware, "just now" under a second.
+func relAgo(t time.Time) string {
+	d := time.Since(t)
+	if d < time.Second {
+		return "just now"
+	}
+	var n int
+	var unit string
+	switch {
+	case d < time.Minute:
+		n, unit = int(d.Seconds()), "second"
+	case d < time.Hour:
+		n, unit = int(d.Minutes()), "minute"
+	case d < 24*time.Hour:
+		n, unit = int(d.Hours()), "hour"
+	default:
+		n, unit = int(d.Hours())/24, "day"
+	}
+	if n == 1 {
+		return "1 " + unit + " ago"
+	}
+	return fmt.Sprintf("%d %ss ago", n, unit)
+}

--- a/internal/tui/browser_test.go
+++ b/internal/tui/browser_test.go
@@ -1,0 +1,581 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/sessiontitle"
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+	"github.com/ethanhq/cc-fleet/internal/teardown"
+)
+
+// browserModel parks a model on the Agents Board with the given teammates / standalone jobs /
+// workflow runs (+ their leaves) loaded, then opens the flat session browser via ctrl+f.
+func browserModel(t *testing.T, tms []teardown.Teammate, jobs []subagent.Result, runs []subagent.WorkflowRun) Model {
+	t.Helper()
+	m := boardModel(t, nil, nil)
+	m, _ = step(t, m, boardMsg{teammates: tms, jobs: jobs, runs: runs, epoch: m.boardEpoch})
+	m, _ = step(t, m, keyMsg("ctrl+f"))
+	if m.asMode != asModeBrowser {
+		t.Fatalf("ctrl+f should open the browser, mode=%d", m.asMode)
+	}
+	return m
+}
+
+// TestBrowserFilterNarrowsAndResetsCursor: typing narrows the flat list over title/provider/lane
+// (case-insensitive substring) and resets the cursor to the top on every edit.
+func TestBrowserFilterNarrowsAndResetsCursor(t *testing.T) {
+	m := browserModel(t,
+		[]teardown.Teammate{{Name: "alice", Team: "squad", Provider: "kimi", PaneID: "%1", LeadSessionID: "s1", SpawnTime: 1_000}},
+		[]subagent.Result{
+			{JobID: "job-aaaa", Label: "indexer", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s2"},
+			{JobID: "job-bbbb", Label: "summary", Provider: "deepseek", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "s2"},
+		}, nil)
+
+	if got := len(m.browserRows()); got != 3 {
+		t.Fatalf("flat rows = %d, want 3 (2 jobs + 1 team)", got)
+	}
+	m, _ = press(t, m, "down") // move the cursor off the top
+	if m.browserCursor != 1 {
+		t.Fatalf("cursor = %d, want 1 after down", m.browserCursor)
+	}
+
+	// Filter by a provider only the team carries.
+	for _, r := range "kimi" {
+		m, _ = press(t, m, string(r))
+	}
+	if rows := m.filteredBrowserRows(); len(rows) != 1 || rows[0].ref.kind != browserTeam {
+		t.Fatalf("filter kimi → %+v, want the one team row", rows)
+	}
+	if m.browserCursor != 0 {
+		t.Fatalf("cursor = %d, want 0 (reset on filter edit)", m.browserCursor)
+	}
+
+	// Backspace widens; filter by a lane keyword.
+	m = clearFilter(t, m)
+	for _, r := range "subagent" {
+		m, _ = press(t, m, string(r))
+	}
+	if rows := m.filteredBrowserRows(); len(rows) != 2 {
+		t.Fatalf("filter by lane 'subagent' → %d rows, want the 2 jobs", len(rows))
+	}
+	// Filter by a title substring.
+	m = clearFilter(t, m)
+	for _, r := range "index" {
+		m, _ = press(t, m, string(r))
+	}
+	if rows := m.filteredBrowserRows(); len(rows) != 1 || rows[0].title != "indexer" {
+		t.Fatalf("filter index → %+v, want the indexer job", rows)
+	}
+}
+
+// clearFilter backspaces the browser filter empty.
+func clearFilter(t *testing.T, m Model) Model {
+	t.Helper()
+	for m.browserFilter != "" {
+		m, _ = press(t, m, "backspace")
+	}
+	return m
+}
+
+// TestBrowserNewestFirstOrdering: rows sort newest-first by their time basis across lanes.
+func TestBrowserNewestFirstOrdering(t *testing.T) {
+	m := browserModel(t,
+		[]teardown.Teammate{{Name: "alice", Team: "t", Provider: "glm", PaneID: "%1", LeadSessionID: "s-team", SpawnTime: 1_700_000_000_000}},
+		[]subagent.Result{
+			{JobID: "job-old", Label: "old-job", Provider: "glm", Status: "done", StartedAt: "2020-01-01T00:00:00Z", LeadSessionID: "s-j"},
+		},
+		[]subagent.WorkflowRun{
+			{RunID: "run-x", Name: "newest-run", SessionID: "s-r", StartedAt: "2030-01-01T00:00:00Z"},
+		})
+	rows := m.browserRows()
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	if rows[0].ref.kind != browserRun {
+		t.Fatalf("newest row = %+v, want the 2030 run first", rows[0])
+	}
+	if rows[2].title != "old-job" {
+		t.Fatalf("oldest row = %q, want old-job last", rows[2].title)
+	}
+}
+
+// TestBrowserJobRowsStandaloneOnly: a job tagged with a RunID is NOT a standalone browser row
+// (it belongs to its run); only RunID=="" jobs list as subagent rows.
+func TestBrowserJobRowsStandaloneOnly(t *testing.T) {
+	m := browserModel(t, nil,
+		[]subagent.Result{
+			{JobID: "job-free", Label: "free", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"},
+			{JobID: "job-leaf", Label: "leaf", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", RunID: "run-1", Phase: "p"},
+		},
+		[]subagent.WorkflowRun{{RunID: "run-1", Name: "the-run", SessionID: "sR", StartedAt: "2026-06-01T00:00:00Z"}})
+	for _, r := range m.browserRows() {
+		if r.ref.kind == browserJob && r.jobID == "job-leaf" {
+			t.Fatalf("a RunID-tagged leaf must not be a standalone job row: %+v", r)
+		}
+	}
+	// The leaf surfaces ONLY through its run row, never doubled.
+	var jobs, runs int
+	for _, r := range m.browserRows() {
+		switch r.ref.kind {
+		case browserJob:
+			jobs++
+		case browserRun:
+			runs++
+		}
+	}
+	if jobs != 1 || runs != 1 {
+		t.Fatalf("rows = %d standalone jobs + %d runs, want 1 + 1", jobs, runs)
+	}
+}
+
+// TestBrowserEnterJobSetsFocus: Enter on a job row opens its existing entity detail by id.
+func TestBrowserEnterJobSetsFocus(t *testing.T) {
+	m := browserModel(t, nil,
+		[]subagent.Result{{JobID: "job-target", Label: "target", Provider: "glm", Status: "done",
+			StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sess-job"}}, nil)
+	m, _ = press(t, m, "enter")
+	if m.asMode != asModeEntity || !m.asEntitySrc.jobs {
+		t.Fatalf("enter on a job → mode=%d src.jobs=%v, want entity+jobs", m.asMode, m.asEntitySrc.jobs)
+	}
+	if m.focusedSessionID != "sess-job" {
+		t.Fatalf("focusedSessionID = %q, want sess-job", m.focusedSessionID)
+	}
+	if j, ok := m.selectedJob(); !ok || j.JobID != "job-target" {
+		t.Fatalf("selected job = %+v ok=%v, want job-target", j, ok)
+	}
+	if !m.browserOrigin {
+		t.Fatal("browserOrigin must be set after a browser Enter")
+	}
+}
+
+// TestBrowserEnterRunRootsSession: Enter on a run row roots the SESSION (not just focusedRunID)
+// and lands on the run's Phases — required for refresh preservation + wfAscend.
+func TestBrowserEnterRunRootsSession(t *testing.T) {
+	m := browserModel(t, nil, nil,
+		[]subagent.WorkflowRun{{RunID: "run-1", Name: "sweep", SessionID: "sess-run", Cwd: "/proj",
+			StartedAt: "2026-06-01T00:00:00Z", Phases: []subagent.RunPhase{{Title: "map"}}}})
+	m, _ = press(t, m, "enter")
+	if m.asMode != asModeRunPhases {
+		t.Fatalf("enter on a run → mode=%d, want runPhases", m.asMode)
+	}
+	if m.focusedRunID != "run-1" || m.focusedSessionID != "sess-run" {
+		t.Fatalf("run/session focus = %q/%q, want run-1/sess-run", m.focusedRunID, m.focusedSessionID)
+	}
+	if m.focusedProject != "/proj" {
+		t.Fatalf("focusedProject = %q, want /proj (from the run cwd)", m.focusedProject)
+	}
+	// The drill survives a refresh (focusedGroup + focusedSession both valid).
+	jobs := []subagent.Result{{RunID: "run-1", Phase: "map", Label: "m1", Status: "done", JobID: "j", StartedAt: "2026-06-01T00:00:01Z"}}
+	runs := []subagent.WorkflowRun{{RunID: "run-1", Name: "sweep", SessionID: "sess-run", Cwd: "/proj",
+		StartedAt: "2026-06-01T00:00:00Z", Phases: []subagent.RunPhase{{Title: "map"}}}}
+	m, _ = step(t, m, boardMsg{jobs: jobs, runs: runs, epoch: m.boardEpoch})
+	if m.asMode != asModeRunPhases || m.focusedRunID != "run-1" {
+		t.Fatalf("run drill not preserved across refresh: mode=%d run=%q", m.asMode, m.focusedRunID)
+	}
+}
+
+// TestBrowserEnterTeamSetsFocus: Enter on a team row opens its entity (team) detail by id.
+func TestBrowserEnterTeamSetsFocus(t *testing.T) {
+	m := browserModel(t,
+		[]teardown.Teammate{
+			{Name: "alice", Team: "squad", Provider: "glm", PaneID: "%1", LeadSessionID: "sess-team", SpawnTime: 1_000},
+			{Name: "bob", Team: "squad", Provider: "glm", PaneID: "%2", LeadSessionID: "sess-team", SpawnTime: 1_001},
+		}, nil, nil)
+	m, _ = press(t, m, "enter")
+	if m.asMode != asModeEntity || m.asEntitySrc.team != "squad" {
+		t.Fatalf("enter on a team → mode=%d src.team=%q, want entity+squad", m.asMode, m.asEntitySrc.team)
+	}
+	if m.focusedSessionID != "sess-team" {
+		t.Fatalf("focusedSessionID = %q, want sess-team", m.focusedSessionID)
+	}
+	if m.asEntityCursor != 0 {
+		t.Fatalf("team entity cursor = %d, want 0 (first member)", m.asEntityCursor)
+	}
+}
+
+// TestBrowserCursorReanchorsAcrossRefresh: when a refresh inserts a newer row ABOVE the cursor,
+// the cursor re-finds its anchored row by identity instead of staying at the same index.
+func TestBrowserCursorReanchorsAcrossRefresh(t *testing.T) {
+	jobs := []subagent.Result{
+		{JobID: "job-keep", Label: "keep", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "s"},
+		{JobID: "job-old", Label: "old", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"},
+	}
+	m := browserModel(t, nil, jobs, nil)
+	// Cursor on the SECOND row (job-old): rows are newest-first, so index 1 is job-old.
+	m, _ = press(t, m, "down")
+	if m.browserAnchor.id != "job-old" {
+		t.Fatalf("anchor = %q, want job-old", m.browserAnchor.id)
+	}
+	// A refresh inserts a NEWER job above both → job-old shifts from index 1 to index 2.
+	withNew := append([]subagent.Result{
+		{JobID: "job-new", Label: "new", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:09Z", LeadSessionID: "s"},
+	}, jobs...)
+	m, _ = step(t, m, boardMsg{jobs: withNew, epoch: m.boardEpoch})
+	rows := m.filteredBrowserRows()
+	if m.browserCursor >= len(rows) || rows[m.browserCursor].ref.id != "job-old" {
+		t.Fatalf("cursor=%d row=%q after insert, want it to still point at job-old", m.browserCursor, rows[m.browserCursor].ref.id)
+	}
+}
+
+// TestBrowserEnteredJobEntityReanchors: after entering a job's detail from the browser, a
+// refresh that inserts a newer job above keeps the L3 cursor on the SAME job (identity anchor),
+// not drifting to the neighbor that now occupies its old index.
+func TestBrowserEnteredJobEntityReanchors(t *testing.T) {
+	jobs := []subagent.Result{
+		{JobID: "job-keep", Label: "keep", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "s"},
+		{JobID: "job-other", Label: "other", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"},
+	}
+	m := browserModel(t, nil, jobs, nil)
+	// The two jobs share session "s"; entering it lands on the jobs entity list. Filter to the
+	// keep job so Enter targets it deterministically.
+	for _, r := range "keep" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter")
+	if j, ok := m.selectedJob(); !ok || j.JobID != "job-keep" {
+		t.Fatalf("entered job = %+v ok=%v, want job-keep", j, ok)
+	}
+	// A refresh adds a NEWER job to the same session → s.jobs reorders, job-keep's index shifts.
+	withNew := append([]subagent.Result{
+		{JobID: "job-new", Label: "new", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:09Z", LeadSessionID: "s"},
+	}, jobs...)
+	m, _ = step(t, m, boardMsg{jobs: withNew, epoch: m.boardEpoch})
+	if j, ok := m.selectedJob(); !ok || j.JobID != "job-keep" {
+		t.Fatalf("after refresh selected job = %+v ok=%v, want still job-keep (identity anchor)", j, ok)
+	}
+}
+
+// TestBrowserEscReturnsLeftAscends: esc from a browser-entered detail returns to the browser;
+// ← does normal board ascent (and drops the browser-origin link).
+func TestBrowserEscReturnsLeftAscends(t *testing.T) {
+	job := []subagent.Result{{JobID: "job-x", Label: "x", Provider: "glm", Status: "done",
+		StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sess-x"}}
+
+	// esc path: detail → browser.
+	m := browserModel(t, nil, job, nil)
+	m, _ = press(t, m, "enter")
+	if m.asMode != asModeEntity {
+		t.Fatalf("setup: mode=%d, want entity", m.asMode)
+	}
+	m, _ = press(t, m, "esc")
+	if m.asMode != asModeBrowser {
+		t.Fatalf("esc from a browser-entered detail → mode=%d, want browser", m.asMode)
+	}
+	if m.browserOrigin {
+		t.Fatal("browserOrigin should be cleared after returning to the browser")
+	}
+
+	// left path: detail → normal board ascent, origin cleared.
+	m2 := browserModel(t, nil, job, nil)
+	m2, _ = press(t, m2, "enter")
+	m2, _ = press(t, m2, "left")
+	if m2.asMode == asModeBrowser {
+		t.Fatal("left must do normal board ascent, not return to the browser")
+	}
+	if m2.browserOrigin {
+		t.Fatal("left must clear the browser-origin link")
+	}
+}
+
+// TestBrowserEnterSeedsBoxCursor: entering a row seeds asBoxCursor to the entity's L2 row, so a
+// later ← into the boxes level lands on the right run/team/job — not a stale row that a follow-up
+// d/p/s would hit.
+func TestBrowserEnterSeedsBoxCursor(t *testing.T) {
+	// A multi-kind session (one team + one job): box order is teams, then jobs, so the job sits at
+	// continuum index 1 — entering it must seed asBoxCursor=1, not leave it at the team (index 0).
+	m := browserModel(t,
+		[]teardown.Teammate{{Name: "alice", Team: "squad", Provider: "glm", PaneID: "%1", LeadSessionID: "sess", SpawnTime: 1_000}},
+		[]subagent.Result{{JobID: "job-1", Label: "indexer", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sess"}},
+		nil)
+	for _, r := range "indexer" { // filter so Enter targets the job deterministically
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter")
+	if _, ok := m.selectedJob(); !ok {
+		t.Fatal("setup: expected to enter the job's entity detail")
+	}
+	m, _ = press(t, m, "left") // ← ascends to the boxes level
+	if m.asMode != asModeBoxes {
+		t.Fatalf("left → mode=%d, want boxes", m.asMode)
+	}
+	ref, ok := m.boxRowRef()
+	if !ok || ref.jobID != "job-1" {
+		t.Fatalf("boxes cursor = %+v ok=%v, want the entered job-1", ref, ok)
+	}
+}
+
+// TestBrowserAnchorResyncsWhenRowVanishes: when the anchored row disappears, the cursor re-anchors
+// to the row it now lands on, instead of holding a dead identity that every later refresh re-fails.
+func TestBrowserAnchorResyncsWhenRowVanishes(t *testing.T) {
+	jobs := []subagent.Result{
+		{JobID: "job-a", Label: "a", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:03Z", LeadSessionID: "s"},
+		{JobID: "job-b", Label: "b", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "s"},
+	}
+	m := browserModel(t, nil, jobs, nil)
+	m, _ = press(t, m, "down") // anchor on job-b (index 1)
+	if m.browserAnchor.id != "job-b" {
+		t.Fatalf("anchor = %q, want job-b", m.browserAnchor.id)
+	}
+	m, _ = step(t, m, boardMsg{jobs: jobs[:1], epoch: m.boardEpoch}) // job-b vanishes
+	if m.browserAnchor.id == "job-b" {
+		t.Fatalf("anchor still %q after the row vanished, want a re-sync", m.browserAnchor.id)
+	}
+	rows := m.filteredBrowserRows()
+	if m.browserCursor >= len(rows) || m.browserAnchor != rows[m.browserCursor].ref {
+		t.Fatalf("anchor %+v not synced to cursor row %d", m.browserAnchor, m.browserCursor)
+	}
+}
+
+// TestBrowserRunAgentBackKeys: a browser-entered run drilled to the Agent level retraces to Phases
+// on esc (the browser-origin return lives only at the entry/Phases level), then esc at Phases
+// returns to the browser.
+func TestBrowserRunAgentBackKeys(t *testing.T) {
+	runs := []subagent.WorkflowRun{{RunID: "run-1", Name: "sweep", SessionID: "sess-run", Cwd: "/proj",
+		StartedAt: "2026-06-01T00:00:00Z", Phases: []subagent.RunPhase{{Title: "map"}}}}
+	jobs := []subagent.Result{{RunID: "run-1", Phase: "map", Label: "m1", Status: "done", JobID: "j1", StartedAt: "2026-06-01T00:00:01Z"}}
+	m := browserModel(t, nil, jobs, runs)
+	m, _ = press(t, m, "enter") // run → Phases
+	m, _ = press(t, m, "enter") // Phases → Agent
+	if m.asMode != asModeRunAgent {
+		t.Fatalf("setup: mode=%d, want runAgent", m.asMode)
+	}
+	m, _ = press(t, m, "esc") // retrace one level to Phases, not straight to the browser
+	if m.asMode != asModeRunPhases {
+		t.Fatalf("esc at agent → mode=%d, want runPhases (retrace)", m.asMode)
+	}
+	if !m.browserOrigin {
+		t.Fatal("browser-origin must survive the Agent→Phases retrace")
+	}
+	m, _ = press(t, m, "esc") // entry level returns to the browser
+	if m.asMode != asModeBrowser {
+		t.Fatalf("esc at phases → mode=%d, want browser", m.asMode)
+	}
+}
+
+// TestBrowserOriginClearedOnRefreshDemotion: when a browser-entered run vanishes mid-refresh and
+// the board demotes to boxes, the browser back-link is dropped — so hand-descending into a
+// different detail and pressing esc does normal ascent, not a jump back to the browser.
+func TestBrowserOriginClearedOnRefreshDemotion(t *testing.T) {
+	// A run and a team share session sR; the team keeps sR alive after the run vanishes, so the
+	// board demotes to boxes (not a full reroute) — the exact spot the back-link must drop.
+	tms := []teardown.Teammate{
+		{Name: "alice", Team: "squad", Provider: "glm", PaneID: "%1", LeadSessionID: "sR", SpawnTime: 1_000},
+		{Name: "bob", Team: "squad", Provider: "glm", PaneID: "%2", LeadSessionID: "sR", SpawnTime: 1_001},
+	}
+	runs := []subagent.WorkflowRun{{RunID: "run-a", Name: "sweep", SessionID: "sR", Cwd: "/proj",
+		StartedAt: "2026-06-01T00:00:05Z", Phases: []subagent.RunPhase{{Title: "map"}}}}
+	m := browserModel(t, tms, nil, runs)
+	m, _ = press(t, m, "enter") // the run is the newest row
+	if m.asMode != asModeRunPhases || !m.browserOrigin {
+		t.Fatalf("setup: mode=%d origin=%v, want runPhases+origin", m.asMode, m.browserOrigin)
+	}
+	// run-a vanishes; sR survives via the team → demote to boxes, origin dropped.
+	m, _ = step(t, m, boardMsg{teammates: tms, runs: nil, epoch: m.boardEpoch})
+	if m.asMode != asModeBoxes || m.browserOrigin {
+		t.Fatalf("after demote: mode=%d origin=%v, want boxes + origin cleared", m.asMode, m.browserOrigin)
+	}
+	m, _ = press(t, m, "enter") // hand-descend into the team's detail
+	if m.asMode != asModeEntity {
+		t.Fatalf("descend → mode=%d, want entity", m.asMode)
+	}
+	m, _ = press(t, m, "esc")
+	if m.asMode == asModeBrowser {
+		t.Fatal("esc from a hand-opened detail must not jump to the browser after the origin was dropped")
+	}
+}
+
+// TestBrowserEnterJobRootsProject: entering a job whose session lives in a different project than
+// the board last showed roots focusedProject on that session's project, so an immediate ← ascends
+// into the right project list (not the stale one) before the next refresh.
+func TestBrowserEnterJobRootsProject(t *testing.T) {
+	m := boardModel(t, nil, nil)
+	jobs := []subagent.Result{
+		{JobID: "job-a", Label: "alpha", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "sA"},
+		{JobID: "job-b", Label: "bravo", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sB"},
+	}
+	meta := map[string]sessiontitle.Meta{"sA": {Cwd: "/projA"}, "sB": {Cwd: "/projB"}}
+	m, _ = step(t, m, boardMsg{jobs: jobs, sessionMeta: meta, epoch: m.boardEpoch})
+	m, _ = step(t, m, keyMsg("ctrl+f"))
+	for _, r := range "bravo" { // filter to job-b (in /projB)
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter")
+	if j, ok := m.selectedJob(); !ok || j.JobID != "job-b" {
+		t.Fatalf("entered job = %+v, want job-b", j)
+	}
+	if m.focusedProject != "/projB" {
+		t.Fatalf("focusedProject = %q, want /projB (the entered job's session project)", m.focusedProject)
+	}
+}
+
+// TestBrowserOriginClearedWhenEnteredJobVanishesSiblingRemains: when a browser-entered job is
+// removed mid-refresh but a sibling job keeps the session at the entity level, the cursor falls to
+// the sibling and the browser back-link is dropped — esc must then do normal ascent.
+func TestBrowserOriginClearedWhenEnteredJobVanishesSiblingRemains(t *testing.T) {
+	jobs := []subagent.Result{
+		{JobID: "job-a", Label: "alpha", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "s"},
+		{JobID: "job-b", Label: "bravo", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"},
+	}
+	m := browserModel(t, nil, jobs, nil)
+	for _, r := range "bravo" { // enter job-b
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter")
+	if j, ok := m.selectedJob(); !ok || j.JobID != "job-b" {
+		t.Fatalf("entered job = %+v, want job-b", j)
+	}
+	// job-b vanishes; sibling job-a keeps the session at asModeEntity → cursor falls to job-a.
+	m, _ = step(t, m, boardMsg{jobs: jobs[:1], epoch: m.boardEpoch})
+	if m.browserOrigin {
+		t.Fatal("browserOrigin must clear when the entered job vanishes and the cursor falls to a sibling")
+	}
+	m, _ = press(t, m, "esc")
+	if m.asMode == asModeBrowser {
+		t.Fatal("esc must not return to the browser after the entered job vanished")
+	}
+}
+
+// TestBrowserEnteredRunKeepsOriginAcrossRefresh: a prior job-detail visit leaves asEntitySrc set;
+// entering a RUN from the browser must keep its back-link across a refresh — the stale entity state
+// must not be read as a live entity focus and clear browserOrigin.
+func TestBrowserEnteredRunKeepsOriginAcrossRefresh(t *testing.T) {
+	jobs := []subagent.Result{{JobID: "job-z", Label: "zeta", Provider: "glm", Status: "done",
+		StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sM"}}
+	runs := []subagent.WorkflowRun{{RunID: "run-r", Name: "sweep", SessionID: "sM", Cwd: "/proj",
+		StartedAt: "2026-06-01T00:00:05Z", Phases: []subagent.RunPhase{{Title: "map"}}}}
+	m := browserModel(t, nil, jobs, runs)
+	// Visit the job first (leaves asEntitySrc.jobs set), then return to the browser.
+	for _, r := range "zeta" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter")
+	if !m.asEntitySrc.jobs {
+		t.Fatal("setup: expected asEntitySrc.jobs after entering the job")
+	}
+	m, _ = press(t, m, "esc")
+	m = clearFilter(t, m)
+	// Now enter the run; asEntitySrc.jobs is still set from the prior visit.
+	for _, r := range "sweep" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter")
+	if m.asMode != asModeRunPhases || !m.browserOrigin {
+		t.Fatalf("setup: mode=%d origin=%v, want runPhases+origin", m.asMode, m.browserOrigin)
+	}
+	m, _ = step(t, m, boardMsg{jobs: jobs, runs: runs, epoch: m.boardEpoch})
+	if !m.browserOrigin {
+		t.Fatal("a browser-entered run must keep browserOrigin across refresh despite stale entity state")
+	}
+	m, _ = press(t, m, "esc")
+	if m.asMode != asModeBrowser {
+		t.Fatalf("esc from the browser-entered run → mode=%d, want browser", m.asMode)
+	}
+}
+
+// TestBrowserShowsBoardWarnings: the browser shares the board's persistent warning tail, so a
+// jobs-scan failure surfaces here too — a partial list never looks clean.
+func TestBrowserShowsBoardWarnings(t *testing.T) {
+	m := boardModel(t, nil, nil)
+	m, _ = step(t, m, boardMsg{jobsErr: errors.New("scan boom"), epoch: m.boardEpoch})
+	m, _ = step(t, m, keyMsg("ctrl+f"))
+	if m.asMode != asModeBrowser {
+		t.Fatalf("setup: mode=%d, want browser", m.asMode)
+	}
+	if out := m.View(); !strings.Contains(out, "jobs unavailable") {
+		t.Errorf("browser view must surface the jobs-unavailable warning\n---\n%s", out)
+	}
+}
+
+// TestBrowserEscReturnsToBoard: esc from the browser list closes back to the board level ctrl+f was
+// opened from — it does NOT exit to the Model Providers hub.
+func TestBrowserEscReturnsToBoard(t *testing.T) {
+	m := browserModel(t, nil,
+		[]subagent.Result{{JobID: "j", Label: "x", Provider: "glm", Status: "done",
+			StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"}}, nil)
+	want := m.browserReturnMode
+	m, _ = press(t, m, "esc")
+	if m.screen != screenSpawn {
+		t.Fatalf("esc from browser → screen=%d, want screenSpawn (stay on the board, not the hub)", m.screen)
+	}
+	if m.asMode == asModeBrowser || m.asMode != want {
+		t.Fatalf("esc from browser → asMode=%d, want %d (the mode ctrl+f opened from)", m.asMode, want)
+	}
+}
+
+// TestBrowserFilterMatchesProject: typing a project / directory substring narrows to the rows in
+// that project — the session's dir is part of the filter corpus (and its basename shows on the row).
+func TestBrowserFilterMatchesProject(t *testing.T) {
+	m := boardModel(t, nil, nil)
+	jobs := []subagent.Result{
+		{JobID: "job-a", Label: "alpha", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:02Z", LeadSessionID: "sA"},
+		{JobID: "job-b", Label: "bravo", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sB"},
+	}
+	meta := map[string]sessiontitle.Meta{"sA": {Cwd: "/home/me/payments"}, "sB": {Cwd: "/home/me/billing"}}
+	m, _ = step(t, m, boardMsg{jobs: jobs, sessionMeta: meta, epoch: m.boardEpoch})
+	m, _ = step(t, m, keyMsg("ctrl+f"))
+	for _, r := range "payments" { // a directory only job-a's session lives in
+		m, _ = press(t, m, string(r))
+	}
+	rows := m.filteredBrowserRows()
+	if len(rows) != 1 || rows[0].ref.id != "job-a" {
+		t.Fatalf("filter 'payments' → %+v, want only job-a (in /home/me/payments)", rows)
+	}
+}
+
+// TestBrowserRowShowsAndFiltersSession: a subagent/workflow row carries its parent session's title —
+// shown after the label and matchable by the filter — so a label-less job is identifiable; the
+// session id is filterable too.
+func TestBrowserRowShowsAndFiltersSession(t *testing.T) {
+	m := boardModel(t, nil, nil)
+	jobs := []subagent.Result{ // no label → falls back to a short id, so the session title is the human anchor
+		{JobID: "deadbeef0000", Provider: "glm", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "sess-abc"},
+	}
+	meta := map[string]sessiontitle.Meta{"sess-abc": {Cwd: "/proj", Title: "auth refactor"}}
+	m, _ = step(t, m, boardMsg{jobs: jobs, sessionMeta: meta, epoch: m.boardEpoch})
+	m, _ = step(t, m, keyMsg("ctrl+f"))
+	if out := m.View(); !strings.Contains(out, "auth refactor") {
+		t.Errorf("browser row must show the parent session title\n---\n%s", out)
+	}
+	for _, r := range "auth" { // filter by the session title
+		m, _ = press(t, m, string(r))
+	}
+	if rows := m.filteredBrowserRows(); len(rows) != 1 {
+		t.Fatalf("filter 'auth' (session title) → %d rows, want 1", len(rows))
+	}
+	m = clearFilter(t, m)
+	for _, r := range "sess-abc" { // filter by the session id
+		m, _ = press(t, m, string(r))
+	}
+	if rows := m.filteredBrowserRows(); len(rows) != 1 {
+		t.Fatalf("filter by session id → %d rows, want 1", len(rows))
+	}
+}
+
+// TestBrowserSanitizesMetadata: every displayed metadata field carrying a terminal control byte —
+// the provider (from on-disk records) and the project basename (raw cwd) — is CleanTitle-scrubbed
+// before display (the board's render-time invariant), never emitted raw.
+func TestBrowserSanitizesMetadata(t *testing.T) {
+	m := boardModel(t, nil, nil)
+	jobs := []subagent.Result{{JobID: "j", Label: "x", Provider: "gl\am", Status: "done", StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"}} // \a (BEL) in provider
+	meta := map[string]sessiontitle.Meta{"s": {Cwd: "/home/me/pro\aj"}}                                                                           // and in the cwd basename
+	m, _ = step(t, m, boardMsg{jobs: jobs, sessionMeta: meta, epoch: m.boardEpoch})
+	m, _ = step(t, m, keyMsg("ctrl+f"))
+	if strings.ContainsRune(m.View(), '\a') {
+		t.Error("provider / project metadata with a control byte must be CleanTitle-scrubbed before display")
+	}
+}
+
+// TestBrowserView renders the flat list with its title/provider/lane metadata + footer.
+func TestBrowserView(t *testing.T) {
+	m := browserModel(t, nil,
+		[]subagent.Result{{JobID: "job-v", Label: "viewable", Provider: "glm", Status: "done",
+			StartedAt: "2026-06-01T00:00:01Z", LeadSessionID: "s"}}, nil)
+	out := m.View()
+	for _, want := range []string{"viewable", "glm", "subagent", "type to search"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("browser view missing %q\n---\n%s", want, out)
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -97,6 +97,7 @@ const (
 	asModeEntity                  // L3: entity list | the focused entity's inline detail card (j/k scroll)
 	asModeRunPhases               // run drill: the focused run's Phases | the selected phase's agents
 	asModeRunAgent                // run drill: agent list | the selected agent's inline detail (j/k scroll)
+	asModeBrowser                 // flat, type-to-filter session browser; Enter opens an entity's existing detail
 )
 
 // Model is the root bubbletea model.
@@ -264,6 +265,20 @@ type Model struct {
 	// wfPromptExpanded toggles the inline detail's prompt between a collapsed "N lines · ⏎ expand"
 	// summary (default) and the full text; reset to collapsed when the focused leaf changes.
 	wfPromptExpanded bool
+
+	// Session browser (asModeBrowser): a flat, newest-first list of past standalone subagent
+	// jobs + workflow runs + team sessions, type-to-filter over title/provider/lane. browserFilter
+	// is the live query (cursor resets to 0 on every edit); browserCursor indexes the FILTERED
+	// rows. browserAnchor is the highlighted row's {kind,id}, re-found after each refresh so an
+	// inserted/removed row above the cursor can't shift Enter onto a different entity. browserOrigin
+	// marks a detail view entered FROM the browser, so esc returns to it (left still does normal
+	// board ascent — preserving the ended-team delete path). browserReturnMode is the board mode
+	// ctrl+f was opened from, restored on esc so the browser closes back to the board, not the hub.
+	browserFilter     string
+	browserCursor     int
+	browserAnchor     browserRef
+	browserOrigin     bool
+	browserReturnMode asMode
 
 	// Active add/edit form.
 	form     form
@@ -1510,10 +1525,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.boardEntryRoute = false
 			m.asProjectCursor, m.asSessionCursor, m.asBoxCursor, m.asEntityCursor, m.asCardScroll = 0, 0, 0, 0, 0
 			m.focusedProject, m.focusedSessionID, m.asMode = asNoFocus, asNoFocus, asModeBoxes
+			m.browserOrigin = false // a fresh board entry has no browser back-link
 		}
 		// Capture the L2 cursor row's TYPED identity before the data changes, so the
 		// cursor can re-find it (a team by name, a job by id) after the refresh.
 		prevBox, hadBox := m.boxRowRef()
+		prevEntity, hadEntity := m.entityRowRef()
 		m.loading = false
 		m.boardSeen = true
 		// Teammate / session-meta / pin state is full-refresh-only (the 500ms light chain never carries it),
@@ -1549,6 +1566,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.reanchorBox(prevBox)
 		}
 		m.clampAsCursors()
+		if hadEntity && !m.reanchorEntity(prevEntity) {
+			m.browserOrigin = false // the browser-entered entity is gone; the cursor fell to a sibling
+		}
 		m.asCardScroll = m.clampAsCardScroll(m.asCardScroll)
 		// Load (or live-refresh) the focused entity's detail payload — a reroot can land
 		// the board straight on a detail view. Jobs: a non-terminal focused job re-reads
@@ -1618,6 +1638,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.lastRefreshSeq = msg.seq
 		prevBox, hadBox := m.boxRowRef()
+		prevEntity, hadEntity := m.entityRowRef()
 		// The light chain carries the full job list too, so a standalone subagent row's status/usage
 		// refresh at 500ms — otherwise it lags 3s behind its own live snapshot and falls back to a stale,
 		// lower usage (a visible down-jump) and a stuck "running" when the job finishes between full ticks.
@@ -1631,6 +1652,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.reanchorBox(prevBox)
 		}
 		m.clampAsCursors()
+		if hadEntity && !m.reanchorEntity(prevEntity) {
+			m.browserOrigin = false // the browser-entered entity is gone; the cursor fell to a sibling
+		}
 		m.asCardScroll = m.clampAsCardScroll(m.asCardScroll)
 		return m, m.startWfLive()
 
@@ -2039,8 +2063,16 @@ func (m Model) updateSpawn(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.confirm != nil {
 		return m.updateConfirm(msg) // a confirm modal traps focus: ←/→ select, enter runs the choice (no esc)
 	}
+	// The flat browser is a text-entry mode: every printable rune (incl. r/q) is filter
+	// input, so it routes BEFORE the board-global shortcuts below. Only ctrl+c (handled in
+	// Update) stays global.
+	if m.asMode == asModeBrowser {
+		return m.updateBrowser(msg)
+	}
 	atRunLevel := m.asMode == asModeRunPhases || m.asMode == asModeRunAgent
 	switch msg.String() {
+	case "ctrl+f":
+		return m.openBrowser()
 	case "r":
 		if atRunLevel {
 			break // lowercase r is the workflow restart there; R/ctrl+r still refresh
@@ -2287,10 +2319,25 @@ func (m Model) updateAsEntity(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.openConfirm(confirmClear, s.sessionID, "Clear this session's finished tasks?")
 		}
 	case "esc":
+		if m.browserOrigin {
+			return m.returnToBrowser() // esc from a browser-entered detail returns to the browser
+		}
 		return m.asAscend(true)
 	case "left":
+		// ← always does normal board ascent (so an ended team reaches its boxes-level delete);
+		// exiting a browser-entered detail this way drops the browser-origin link.
+		m.browserOrigin = false
 		return m.asAscend(false)
 	}
+	return m, nil
+}
+
+// returnToBrowser re-opens the flat browser from a detail view entered via it, re-finding the
+// row that was opened so the cursor lands back on it.
+func (m Model) returnToBrowser() (tea.Model, tea.Cmd) {
+	m.browserOrigin = false
+	m.asMode = asModeBrowser
+	m.reanchorBrowser()
 	return m, nil
 }
 
@@ -2564,6 +2611,12 @@ func (m *Model) rerootSpawn() {
 	projects := groupProjects(sessions, m.sessionMeta)
 
 	switch m.asMode {
+	case asModeBrowser:
+		// The flat browser is a first-class mode: rebuild its rows from the refreshed slices
+		// and re-find the cursor by identity, WITHOUT routing to boxes/projects (the default
+		// path below would eject it back to the board).
+		m.reanchorBrowser()
+		return
 	case asModeRunPhases, asModeRunAgent:
 		// The run drill keeps its place while the run and its session both survive; a
 		// vanished run demotes to the session's boxes, a vanished session re-routes.
@@ -2578,6 +2631,7 @@ func (m *Model) rerootSpawn() {
 		if s, ok := m.focusedSession(); ok {
 			m.asMode = asModeBoxes
 			m.focusedRunID = ""
+			m.browserOrigin = false // the browser-entered run is gone — drop its esc-return link
 			m.focusedProject = sessionProjectDir(s, m.sessionMeta)
 			m.clampAsCursors()
 			return
@@ -2620,6 +2674,9 @@ func (m *Model) rerootSpawn() {
 		}
 	}
 
+	// The focus chain broke and we re-route below (possibly straight into another session's
+	// detail) — none of it was browser-entered, so drop any stale esc-return link.
+	m.browserOrigin = false
 	m.asProjectCursor, m.asSessionCursor, m.asBoxCursor, m.asEntityCursor, m.asCardScroll = 0, 0, 0, 0, 0
 	m.focusedProject, m.focusedSessionID = asNoFocus, asNoFocus
 	switch {
@@ -2777,6 +2834,52 @@ func (m *Model) reanchorBox(prev asBoxRef) {
 	}
 }
 
+// entityRowRef returns the L3 entity under asEntityCursor as a typed identity — a job by id or a
+// teammate by mateKey — so the cursor can re-find its row after a refresh shifts the indices. It
+// reports nothing outside asModeEntity, so a stale asEntitySrc left by an earlier visit can't be
+// read as a live entity focus while the board is in a run drill (which would wrongly drop the run's
+// browser back-link on the next refresh).
+func (m Model) entityRowRef() (browserRef, bool) {
+	if m.asMode != asModeEntity {
+		return browserRef{}, false
+	}
+	if j, ok := m.selectedJob(); ok {
+		return browserRef{kind: browserJob, id: j.JobID}, true
+	}
+	if t, ok := m.selectedTeammate(); ok {
+		return browserRef{kind: browserMate, id: mateKey(t)}, true
+	}
+	return browserRef{}, false
+}
+
+// reanchorEntity re-finds the previously focused L3 entity by its typed identity after a refresh
+// (mirror reanchorBox), reporting whether it was found. A vanished entity leaves the clamped cursor
+// on a sibling — the caller drops browserOrigin in that case, so esc no longer returns to the
+// browser from a row the user never opened from it.
+func (m *Model) reanchorEntity(prev browserRef) bool {
+	if m.asMode != asModeEntity {
+		return false
+	}
+	members, jobs := m.railEntities()
+	switch prev.kind {
+	case browserJob:
+		for i, j := range jobs {
+			if j.JobID == prev.id {
+				m.asEntityCursor = i
+				return true
+			}
+		}
+	case browserMate:
+		for i, t := range members {
+			if mateKey(t) == prev.id {
+				m.asEntityCursor = i
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // clampAsCardScroll bounds the visible card's scroll to [0, lines-viewport] so j/k never
 // scroll past the content (mirror clampCardScroll). The card lives in the entity view OR
 // inline in the L2 Subagents box — each with its own geometry.
@@ -2914,7 +3017,13 @@ func (m Model) updateWfPhases(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "right", "enter":
 		return m.wfDescend()
-	case "esc", "left":
+	case "esc":
+		if m.browserOrigin {
+			return m.returnToBrowser() // esc from a browser-entered run drill returns to the browser
+		}
+		return m.wfAscend()
+	case "left":
+		m.browserOrigin = false // ← does normal ascent and drops the browser-origin link
 		return m.wfAscend()
 	case "x":
 		return m.stopFocusedPhase()
@@ -2946,6 +3055,8 @@ func (m Model) updateWfAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k":
 		m.wfCardScroll = m.clampCardScroll(m.wfCardScroll - 1)
 	case "left", "esc":
+		// Agent sits below the run's entry level (Phases), so both back keys retrace one level
+		// to Phases, which owns the browser-origin return; the origin survives the retrace.
 		return m.wfAscend()
 	case "right":
 		return m, nil // already at the deepest level

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -481,6 +481,8 @@ func (m Model) viewSpawn() string {
 		b.WriteString(m.viewWfPhases())
 	case m.asMode == asModeRunAgent:
 		b.WriteString(m.viewWfAgent())
+	case m.asMode == asModeBrowser:
+		b.WriteString(m.viewBrowser())
 	default:
 		if _, ok := m.focusedSession(); !ok {
 			b.WriteString(m.boardFallback(
@@ -534,9 +536,9 @@ func (m Model) renderAsFooter() string {
 	var hint string
 	switch m.asMode {
 	case asModeProjects:
-		hint = "↑/↓ project · →/⏎ open · esc/tab providers · r refresh · q quit"
+		hint = "↑/↓ project · →/⏎ open · ctrl+f find · esc/tab providers · r refresh · q quit"
 	case asModeSessions:
-		hint = "↑/↓ session · →/⏎ open · d delete · ← back · r refresh · esc/tab providers · q quit"
+		hint = "↑/↓ session · →/⏎ open · d delete · ← back · ctrl+f find · r refresh · esc/tab providers · q quit"
 	case asModeEntity:
 		// A job IS a record, so it is deletable here; a team's members are not — the team is only
 		// deletable at its outermost (boxes) row. h/s act on live teammate panes, never on jobs.
@@ -549,6 +551,9 @@ func (m Model) renderAsFooter() string {
 		hint = "↑/↓ phase · → agents · r restart · x stop · ←/esc back · R refresh · q quit"
 	case asModeRunAgent:
 		hint = "↑/↓ agent · j/k scroll · ⏎ prompt · r restart agent · x stop · ←/esc back · R refresh · q quit"
+	case asModeBrowser:
+		// q is search text in the browser, so quit is ctrl+c here; esc returns to the board.
+		hint = "type to search · ↑/↓ move · ⏎ open · esc back · ctrl+c quit"
 	default:
 		// save (s) is offered ONLY on a run row — a whole-workflow op belongs to its outermost row.
 		_, onJob := m.boxJob()


### PR DESCRIPTION
Revisiting past work on the Agents Board was entirely navigation-driven — project → session → entity — with no flat list and no way to find a session short of remembering its id. This adds a searchable session browser: `ctrl+f` anywhere on the board opens a flat, newest-first list of every past subagent job, workflow run, and team session; type to filter by substring over the title, provider, lane, project directory, and the parent session's name or id, and enter opens that entry's existing detail view.

The browser is a first-class board mode rather than a separate screen, so it reuses the board's loaded data and refresh cycle and routes enter straight into the existing job card, team card, or run drill by id instead of building a second detail surface. It is read-only — it never launches or resumes anything, only navigates — so resuming from the board is deliberately out of scope here and can land later as an in-board action.

Each entry shows its label and parent session over a dim relative-time, provider, lane, and project line; the cursor and the opened detail are identity-anchored so they survive the board's polling, esc returns to the board level it opened from, and the displayed fields are scrubbed at render like every other board row.

Closes #83.
