### PR TITLE
ci(release): pin release workflow actions to SHAs, goreleaser to v2.16.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   version-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: bash scripts/version-guard.sh "${GITHUB_REF_NAME}"
 
   goreleaser:
@@ -31,10 +31,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
       # Fail the release if the public key embedded in the binary does not match the
@@ -43,10 +43,10 @@ jobs:
       - run: bash scripts/signing-preflight.sh
         env:
           CCF_RELEASE_SIGNING_KEY: ${{ secrets.CCF_RELEASE_SIGNING_KEY }}
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: "v2.16.0" # pinned exact goreleaser (was "~> v2")
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,8 +75,8 @@ jobs:
       run:
         working-directory: npm
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ archives:
       - tar.gz
     # Windows ships a .zip (goreleaser auto-appends .exe to the binary);
     # `formats` plural needs goreleaser >=2.6, which the release workflow's
-    # latest-v2 resolution satisfies.
+    # pinned goreleaser v2.16.0 satisfies.
     format_overrides:
       - goos: windows
         formats:


### PR DESCRIPTION
Fixes #91.

## What
Pins every `uses:` in the release workflow to a commit SHA and pins the goreleaser binary to an exact version, closing the mutable-tag exposure flagged in #91.

## Why
The signing-gated `goreleaser` job runs with the Ed25519 signing seed `CCF_RELEASE_SIGNING_KEY` and a `contents: write` `GITHUB_TOKEN` in its env, yet `goreleaser/goreleaser-action` was pinned only to the mutable major tag `@v7` and the goreleaser binary to `~> v2`. A repointed tag or upstream compromise (cf. tj-actions/changed-files, March 2025) would run attacker code with the signing seed and could exfiltrate it, letting an attacker forge a validly-signed release every auto-updating `cc-fleet update` client accepts — fleet-wide RCE. The environment approval gates the deployment event, not the SHA the tag resolves to at run time.

## Changes
- `goreleaser/goreleaser-action@v7` → `@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3` (the commit `v7` currently resolves to — behaviorally identical today, just immutable).
- goreleaser binary `version: "~> v2"` → `"v2.16.0"` (current latest stable v2; removes runtime-mutable resolution).
- First-party actions pinned to the commit their `@v6` tag points to, across all three jobs (they share the signing job's blast radius and the npm-publish `id-token: write` OIDC credential): `actions/checkout` `df4cb1c…`, `actions/setup-go` `924ae3a…`, `actions/setup-node` `48b55a…`.
- Corrected the now-stale `.goreleaser.yaml` comment that referenced "latest-v2 resolution".

## Validation
`actionlint` clean; `goreleaser check` passes under the pinned goreleaser v2.16.0; every pinned SHA confirmed against its tag via the GitHub API; `v2.16.0` confirmed to ship the expected Linux asset and `checksums.txt`.

## Notes / residuals (deliberately out of scope)
- A `github-actions` Dependabot config would keep the `uses:` SHA pins fresh, but it does not update the `with.version` input — the goreleaser binary version must be bumped manually.
- The goreleaser binary is still downloaded at release time and verified only by goreleaser-action's own checksum step; pinning the version is reproducibility/drift-reduction, not a binary-digest guarantee.
- Keeping `CCF_RELEASE_SIGNING_KEY` out of the third-party action entirely (a separate first-party signing step) is a stronger end state but a larger change; deferred.
- The `npm-publish` job still runs `npm install -g npm@latest` (a mutable version selector) before `npm publish`. That job carries only the OIDC trusted-publishing credential, not the signing seed, so its exposure is the npm distribution channel rather than the signed release binary; Dependabot also cannot track a version pinned inside a `run:` string, so a pin here would be a manual-only bump. Left mutable deliberately as a low-risk residual, to be pinned when a specific npm version is required.
