### PR TITLE
fix(subagent): stream the background terminal classify past oversized lines

### DIFF
--- a/internal/subagent/activity.go
+++ b/internal/subagent/activity.go
@@ -489,15 +489,40 @@ func clampArg(s string) string {
 }
 
 // extractResultLine scans stream-json stdout for the single `type:"result"` envelope line and
+// returns it for classify. Thin wrapper over the streaming reader for the in-memory sync path.
+func extractResultLine(stdout []byte) []byte {
+	return extractResultLineReader(bytes.NewReader(stdout))
+}
+
+// extractResultLineFile scans a stream-json capture file for the terminal result line without
+// loading the whole capture, so a runaway background transcript can't OOM the classify.
+func extractResultLineFile(path string) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	return extractResultLineReader(f)
+}
+
+// extractResultLineReader scans NDJSON stream-json for the single `type:"result"` envelope line and
 // returns it for classify. The result line is NOT guaranteed to be last (a trailing SessionStart
 // hook_response can follow it), so we scan rather than take the tail; the LAST result line wins if
-// (defensively) more than one appears. An empty return makes classify fall back to SUBAGENT_FAILED.
-func extractResultLine(stdout []byte) []byte {
+// (defensively) more than one appears. Reading is line-by-line and streaming: a physical line over
+// maxChildOutput is drained and discarded without ever being fully buffered, so the scan neither
+// halts nor OOMs. A result line that itself exceeds the cap is discarded like any other oversized
+// line and maps to the honest no-result failure — the same terminal outcome as before this change
+// (practically unreachable: a result envelope is a compact model answer, orders of magnitude under
+// the cap). An empty return makes classify fall back to SUBAGENT_FAILED.
+func extractResultLineReader(r io.Reader) []byte {
 	var out []byte
-	sc := bufio.NewScanner(bytes.NewReader(stdout))
-	sc.Buffer(make([]byte, 0, 64*1024), maxChildOutput)
-	for sc.Scan() {
-		line := sc.Bytes()
+	br := bufio.NewReader(r)
+	var line []byte // accumulates one logical line across ReadSlice refills
+	oversized := false
+	keep := func() {
+		if oversized {
+			return
+		}
 		var head struct {
 			Type string `json:"type"`
 		}
@@ -505,5 +530,36 @@ func extractResultLine(stdout []byte) []byte {
 			out = append(out[:0], line...) // keep the latest result line
 		}
 	}
-	return out
+	for {
+		chunk, err := br.ReadSlice('\n')
+		if err == bufio.ErrBufferFull {
+			// Physical line longer than the reader buffer. Grow up to the acceptance cap, then
+			// discard the rest of the line without buffering it.
+			if !oversized {
+				if len(line)+len(chunk) > maxChildOutput {
+					oversized = true
+					line = line[:0]
+				} else {
+					line = append(line, chunk...)
+				}
+			}
+			continue
+		}
+		if len(chunk) > 0 {
+			if !oversized && len(line)+len(chunk) <= maxChildOutput {
+				line = append(line, chunk...)
+			} else {
+				oversized = true
+			}
+		}
+		if err == nil { // complete line (chunk includes the trailing '\n')
+			keep()
+			line = line[:0]
+			oversized = false
+			continue
+		}
+		// io.EOF (or a read error): a final line without a trailing newline is still complete.
+		keep()
+		return out
+	}
 }

--- a/internal/subagent/activity_test.go
+++ b/internal/subagent/activity_test.go
@@ -76,6 +76,110 @@ func TestExtractResultLine_StructuredOutputLift(t *testing.T) {
 	assertJSONEq(t, res.StructuredOutput, `{"answer":5}`)
 }
 
+// TestExtractResultLine_OversizedLinePrecedingResult: an intermediate line larger than the per-line
+// acceptance cap must not halt the scan — a successful run's terminal type:"result" line is still
+// found and parsed.
+func TestExtractResultLine_OversizedLinePrecedingResult(t *testing.T) {
+	orig := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = orig })
+
+	huge := `{"type":"user","message":{"content":[{"type":"tool_result","content":"` +
+		strings.Repeat("x", maxChildOutput*2) + `"}]}}`
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		huge,
+		`{"type":"result","subtype":"success","is_error":false,"result":"the answer","total_cost_usd":0.01}`,
+		`{"type":"system","subtype":"hook_response"}`,
+	}, "\n") + "\n"
+	path := filepath.Join(t.TempDir(), "job.out")
+	if err := os.WriteFile(path, []byte(stream), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	line := extractResultLineFile(path)
+	var e innerEnvelope
+	if err := json.Unmarshal(line, &e); err != nil {
+		t.Fatalf("extracted line not parseable: %v (%q)", err, line)
+	}
+	if e.Type != "result" || e.Result != "the answer" {
+		t.Fatalf("oversized line halted the scan: %+v", e)
+	}
+}
+
+// TestExtractResultLine_OversizedLineIsLast: an oversized line as the last physical line with no
+// result anywhere yields empty — never a fabricated result (classify then fails honestly).
+func TestExtractResultLine_OversizedLineIsLast(t *testing.T) {
+	orig := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = orig })
+
+	huge := `{"type":"user","message":{"content":"` + strings.Repeat("x", maxChildOutput*2) + `"}`
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		huge,
+	}, "\n") // no trailing newline: the oversized line is the final one
+	path := filepath.Join(t.TempDir(), "job.out")
+	if err := os.WriteFile(path, []byte(stream), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	if got := extractResultLineFile(path); len(got) != 0 {
+		t.Fatalf("resultless capture must yield empty, got %q", got)
+	}
+}
+
+// TestExtractResultLine_OversizedResultLineIsDiscarded: a type:"result" line that itself exceeds the
+// per-line acceptance cap is discarded like any oversized line, so the extract yields empty — an
+// over-cap result maps to no-result (classify then fails honestly), never a fabrication.
+func TestExtractResultLine_OversizedResultLineIsDiscarded(t *testing.T) {
+	orig := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = orig })
+
+	hugeResult := `{"type":"result","subtype":"success","is_error":false,"result":"` +
+		strings.Repeat("x", maxChildOutput*2) + `"}`
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		hugeResult,
+	}, "\n") + "\n"
+	path := filepath.Join(t.TempDir(), "job.out")
+	if err := os.WriteFile(path, []byte(stream), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	if got := extractResultLineFile(path); len(got) != 0 {
+		t.Fatalf("over-cap result line must be discarded (yield empty), got %q", got)
+	}
+}
+
+// TestExtractResultLine_MemoryBounded: several oversized lines totaling many multiples of the cap
+// still let the result line be found — the streaming reader never buffers a whole oversized body.
+func TestExtractResultLine_MemoryBounded(t *testing.T) {
+	orig := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = orig })
+
+	big := strings.Repeat("x", maxChildOutput*3)
+	stream := strings.Join([]string{
+		`{"type":"user","message":{"content":"` + big + `"}`,
+		`{"type":"user","message":{"content":"` + big + `"}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"found it"}`,
+		`{"type":"user","message":{"content":"` + big + `"}`,
+	}, "\n") + "\n"
+	path := filepath.Join(t.TempDir(), "job.out")
+	if err := os.WriteFile(path, []byte(stream), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	line := extractResultLineFile(path)
+	var e innerEnvelope
+	if err := json.Unmarshal(line, &e); err != nil {
+		t.Fatalf("extracted line not parseable: %v (%q)", err, line)
+	}
+	if e.Type != "result" || e.Result != "found it" {
+		t.Fatalf("result not found among oversized lines: %+v", e)
+	}
+}
+
 // TestToolArgPreview: the primary arg value is extracted (known key first), key-masked, length-capped.
 func TestToolArgPreview(t *testing.T) {
 	cases := map[string]string{

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -515,8 +515,8 @@ func StatusFor(jobID string) Result {
 		// A detached job has no live activity writer, so each poll scans its growing stream-json .out
 		// for the running token count, parsing ONLY the bytes appended since the last poll (tracked by
 		// the <jobID>.scan checkpoint) so the cost stays flat and the total is kept for the whole
-		// capture regardless of size. The terminal classify below reads the whole file for the exact
-		// count.
+		// capture regardless of size. The terminal classify below scans the whole capture for the
+		// exact count.
 		if meta.Stream {
 			res.Usage = scanLiveUsage(filepath.Join(dir, jobID+".out"), filepath.Join(dir, jobID+".scan"))
 		}
@@ -525,18 +525,23 @@ func StatusFor(jobID string) Result {
 
 	// Dead → classify the captured output. The detached child was Released, so we can't reap a real
 	// exit code; the terminal envelope is the only signal. This runs ONCE per job (the result is then
-	// cached), so it reads the whole .out: a stream-json transcript's type:"result" line carries the
-	// full answer and can sit anywhere, so the classify read must be complete — only the per-poll
-	// running scan above is incremental (best-effort live; the terminal must be exact).
+	// cached). A stream-json transcript's type:"result" line carries the full answer and can sit
+	// anywhere, so the terminal scan is COMPLETE — it reads to EOF — but streaming and bounded: it
+	// never buffers the capture whole. Only the per-poll running scan above is incremental
+	// (best-effort live; the terminal must be exact).
 	outPath := filepath.Join(dir, jobID+".out")
 	errPath := filepath.Join(dir, jobID+".err")
-	stdout, _ := os.ReadFile(outPath)
-	stderr, _ := os.ReadFile(errPath)
+	stderr := readCapped(errPath, stderrPreviewMax<<7) // stderr only feeds a short preview
 	innerJSON := meta.JSON || meta.OutputFormat == "json"
 	// A stream-json .out is multi-line NDJSON; classify wants the single type:"result" line, so
-	// distill it (the sync StreamActivity path does the same). A legacy json .out passes through.
+	// distill it, streaming so a runaway capture is never loaded whole (the sync StreamActivity
+	// path shares the same extractor). A legacy json .out is a single tiny envelope parsed whole, so
+	// an over-cap capture yields nil (classify as vanished) rather than a trusted truncated prefix.
+	var stdout []byte
 	if meta.Stream {
-		stdout = extractResultLine(stdout)
+		stdout = extractResultLineFile(outPath)
+	} else {
+		stdout = readWholeUnderCap(outPath, int64(maxChildOutput))
 	}
 	// A detached leaf can be seen dead a moment before its result write lands. When the result
 	// capture is empty, re-read once after a short delay before classifying, so a late write
@@ -545,12 +550,12 @@ func StatusFor(jobID string) Result {
 	// (reserved `claude`) job legitimately lacks. A non-empty result skips the wait.
 	if _, statErr := os.Stat(outPath); statErr == nil && innerJSON && strings.TrimSpace(string(stdout)) == "" {
 		time.Sleep(statusConfirmDelay)
-		stderr, _ = os.ReadFile(errPath)
-		raw, _ := os.ReadFile(outPath)
+		stderr = readCapped(errPath, stderrPreviewMax<<7)
 		if meta.Stream {
-			raw = extractResultLine(raw)
+			stdout = extractResultLineFile(outPath)
+		} else {
+			stdout = readWholeUnderCap(outPath, int64(maxChildOutput))
 		}
-		stdout = raw
 	}
 	var res Result
 	if vanishedWithoutResult(stdout, innerJSON) {
@@ -1079,6 +1084,43 @@ func writeMeta(dir string, m jobMeta) error {
 		return err
 	}
 	return os.WriteFile(metaPath(dir, m.JobID), data, 0o600)
+}
+
+// readCapped reads at most limit bytes of a job file, so a runaway capture can't OOM the terminal
+// classify. Best-effort: a missing/unreadable file yields nil, matching os.ReadFile's error handling.
+// It TRUNCATES silently, so use it only where a bounded prefix is acceptable (e.g. a stderr preview).
+func readCapped(path string, limit int64) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, limit))
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// readWholeUnderCap reads a job file only when it fits within limit bytes, returning nil when the
+// capture is larger. The legacy (non-stream) .out is parsed as an authoritative whole-input envelope
+// (parseInner rejects trailing garbage), so an over-cap capture must classify as vanished (honest)
+// rather than trust a truncated prefix that could parse clean and fabricate a done. Best-effort: a
+// missing/unreadable file yields nil, matching os.ReadFile's error handling.
+func readWholeUnderCap(path string, limit int64) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil
+	}
+	if int64(len(data)) > limit {
+		return nil // over-cap: don't trust a truncated prefix as a complete envelope
+	}
+	return data
 }
 
 func readMeta(dir, jobID string) (jobMeta, error) {

--- a/internal/subagent/status_vanish_test.go
+++ b/internal/subagent/status_vanish_test.go
@@ -128,3 +128,126 @@ func TestStatusForConfirmDelayRecoversLateEnvelope(t *testing.T) {
 		t.Errorf("recovered result = %q, want \"late answer\"", st.Result)
 	}
 }
+
+// A dead legacy (non-stream) json bg leaf whose .out exceeds the cap fails honestly, even when its
+// under-cap prefix is a VALID result envelope: an over-cap capture is parsed as vanished, never a
+// truncated prefix trusted as done (which would fabricate a result the run never authoritatively wrote).
+func TestStatusFor_OverCapLegacyOutFailsNotFabricated(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	statusConfirmDelay = 0
+	origCap := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = origCap })
+
+	pid := deadPID(t)
+	m := jobMeta{JobID: "jobcap", PID: pid, PGID: pid, Status: "running", JSON: true, // legacy: Stream=false
+		SettingsPath: "/no/such/profile", Provider: "v", Model: "mm",
+		StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	// A valid envelope under the cap, then whitespace past the cap, then garbage: a truncating read
+	// at the cap would strip to the clean envelope and fabricate done; the whole capture is over-cap.
+	envelope := `{"type":"result","subtype":"success","is_error":false,"result":"the answer","num_turns":1,"total_cost_usd":0.001}`
+	content := envelope + strings.Repeat(" ", maxChildOutput) + "GARBAGE-PAST-THE-CAP"
+	if err := os.WriteFile(filepath.Join(dir, "jobcap.out"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st := StatusFor("jobcap")
+	if st.Status != "failed" || st.OK || st.ErrorCode != ErrCodeFailed {
+		t.Fatalf("over-cap legacy .out must fail via failVanished, not fabricate done: %+v", st)
+	}
+	if st.Result == "the answer" {
+		t.Fatalf("fabricated a result from a truncated over-cap prefix: %q", st.Result)
+	}
+}
+
+// A dead stream-json bg leaf whose transcript has an oversized intermediate line before a success
+// result classifies done — the oversized line no longer halts the terminal extract into a failure.
+func TestStatusFor_OversizedStreamClassifiesDone(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	statusConfirmDelay = 0
+	origCap := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = origCap })
+
+	pid := deadPID(t)
+	m := jobMeta{JobID: "jobov", PID: pid, PGID: pid, Status: "running", JSON: true, Stream: true,
+		SettingsPath: "/no/such/profile", Provider: "v", Model: "mm",
+		StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	huge := `{"type":"user","message":{"content":"` + strings.Repeat("x", maxChildOutput*2) + `"}`
+	transcript := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		huge,
+		`{"type":"result","subtype":"success","is_error":false,"result":"the answer","num_turns":1,"total_cost_usd":0.001}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "jobov.out"), []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st := StatusFor("jobov")
+	if !st.OK || st.Status != "done" || st.Result != "the answer" {
+		t.Fatalf("oversized stream classify: %+v", st)
+	}
+	// The done result is cached (finalize-once).
+	cached, err := os.ReadFile(filepath.Join(dir, "jobov.result.json"))
+	if err != nil {
+		t.Fatalf("terminal result not cached: %v", err)
+	}
+	if !strings.Contains(string(cached), "the answer") {
+		t.Fatalf("cached result missing the answer: %s", cached)
+	}
+}
+
+// A dead stream-json bg leaf whose transcript has an oversized line and NO result line still fails
+// honestly via failVanished — the tolerant extract never fabricates a result.
+func TestStatusFor_ResultlessStreamStillFails(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	statusConfirmDelay = 0
+	origCap := maxChildOutput
+	maxChildOutput = 4096
+	t.Cleanup(func() { maxChildOutput = origCap })
+
+	pid := deadPID(t)
+	m := jobMeta{JobID: "jobrl", PID: pid, PGID: pid, Status: "running", JSON: true, Stream: true,
+		SettingsPath: "/no/such/profile", Provider: "v", Model: "mm",
+		StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	huge := `{"type":"user","message":{"content":"` + strings.Repeat("x", maxChildOutput*2) + `"}`
+	transcript := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		huge,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "jobrl.out"), []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st := StatusFor("jobrl")
+	if st.Status != "failed" || st.OK || st.ErrorCode != ErrCodeFailed {
+		t.Fatalf("resultless stream must fail via failVanished: %+v", st)
+	}
+}


### PR DESCRIPTION
A detached background job streams its stdout to disk uncapped by design — the background lane exists for long, large runs. But the terminal dead-classify both loaded that whole capture into memory and distilled it with a scanner capped at 32 MiB per line that silently swallowed its overflow error: one oversized intermediate `tool_result` line aborted the scan before the trailing `type:"result"` line was reached, so a fully successful job was classified and permanently cached as failed, and the unbounded whole-file read could OOM the board or CLI on a huge capture.

The fix is read-side only. `extractResultLine` becomes a streaming, oversized-line-tolerant reader with file and in-memory entries sharing one loop: a physical line over the cap is drained and discarded — it cannot be the compact result envelope — so the scan neither halts nor buffers it, and memory stays bounded at one line. The dead-classify now streams stream-json captures via `extractResultLineFile`, reads legacy single-envelope captures through `readWholeUnderCap` (which refuses a capture larger than the cap rather than trusting a truncated prefix that could parse clean and fabricate a success), and bounds the stderr previews with a truncating `readCapped`.

The contract: an oversized transcript with a valid result line classifies done; a genuinely resultless capture still fails as vanished; nothing is fabricated; the write path and the incremental live-scan path are untouched.

Tests cover oversized-intermediate-line recovery, oversized-result-line and resultless honesty, memory-bounded streaming, the over-cap legacy fabrication refusal, and end-to-end StatusFor classification of both shapes.

Closes #88
