### PR TITLE
fix(workflow): make isolation-worktree reclamation crash-safe and store-scoped

### DIFF
--- a/cmd/cc-fleet/workflow.go
+++ b/cmd/cc-fleet/workflow.go
@@ -459,9 +459,9 @@ with 'workflow status' or watch the board. --foreground runs inline to completio
 			}
 
 			// A detached --resume serializes against the board's restart and any concurrent
-			// resume/stop via the per-run execution lock; a foreground resume IS the engine
-			// running inline (it self-stamps its pid synchronously) and must not hold the lock
-			// around Execute, so it is not wrapped.
+			// resume/stop via the per-run execution lock, held across launch + child registration.
+			// A foreground resume must not hold that lock around the inline Execute, so the CLI
+			// leaves it unwrapped — Launch itself serializes just the foreground resume preflight.
 			id, err := func() (string, error) {
 				if resume != "" && !foreground {
 					var rid string

--- a/internal/ids/validate.go
+++ b/internal/ids/validate.go
@@ -12,6 +12,20 @@ import (
 	"strings"
 )
 
+// WorktreeSegment maps a run id to a single path-safe segment for the isolation-worktree temp root,
+// collapsing the path separators and the worktree-root-remapping characters ('/' '\' '.' ':') to '-'.
+// It is NON-injective — ids "a.b", "a:b", and "a-b" all yield segment "a-b" — so one segment can be
+// co-owned by several run ids; a caller reclaiming a segment by identity must treat it as path-safe
+// only when it equals its own id (WorktreeSegment(id) == id).
+func WorktreeSegment(id string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == '.' || r == ':' {
+			return '-'
+		}
+		return r
+	}, id)
+}
+
 // ErrInvalidTeamName is returned by ValidateTeamName for any input that fails
 // the path-safety rules. Use errors.Is for dispatch.
 var ErrInvalidTeamName = errors.New("invalid team name")

--- a/internal/ids/validate_test.go
+++ b/internal/ids/validate_test.go
@@ -175,3 +175,19 @@ func TestValidateJobID_AcceptsUUID(t *testing.T) {
 		}
 	}
 }
+
+// TestWorktreeSegment: the run-id → path-safe segment mapping (relocated from workflow). It collapses
+// separators and the worktree-root-remap chars ('/' '\' '.' ':') to '-', and is NON-injective so a
+// segment can be co-owned (the collision the segment reclaim verdict guards).
+func TestWorktreeSegment(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"a.b", "a-b"}, {"a:b", "a-b"}, {"a-b", "a-b"}, {"x/y", "x-y"}, {`p\q`, "p-q"}, {"plain", "plain"},
+	} {
+		if got := WorktreeSegment(c.in); got != c.want {
+			t.Errorf("WorktreeSegment(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	if WorktreeSegment("a.b") != WorktreeSegment("a-b") {
+		t.Error("a.b and a-b must collapse to the same segment (co-ownership)")
+	}
+}

--- a/internal/subagent/clearfinished.go
+++ b/internal/subagent/clearfinished.go
@@ -2,7 +2,6 @@ package subagent
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/pinned"
@@ -58,8 +57,6 @@ func ClearFinished(sessionID string, pins pinned.Set) (int, error) {
 	pinnedMemberRun := pinnedRunMembers(jobs, pins)
 
 	removed := 0
-	removedJob := map[string]bool{}
-	runsPath := filepath.Join(dir, runsDirName)
 	for _, r := range runs {
 		if r.SessionID != sessionID || !terminalStatus(r.Status) {
 			continue
@@ -72,22 +69,23 @@ func ClearFinished(sessionID string, pins pinned.Set) (int, error) {
 		if ids.ValidateJobID(r.RunID) != nil {
 			continue
 		}
-		// Reap the run's (unpinned) member jobs, then its manifest. pinnedMemberRun already
-		// excluded a run with a pinned member, so no member here is pinned.
-		for _, j := range jobs {
-			if j.RunID == r.RunID && ids.ValidateJobID(j.JobID) == nil {
-				removeJob(dir, j.JobID)
-				removedJob[j.JobID] = true
+		// Delete the run through the SINGLE chokepoint — WithRunLock + PurgeRun — so the liveness / leaf /
+		// segment guards AND PurgeRun's workdir-before-record ordering apply: a blind-stopped FgAlive run
+		// (or one with a live orphan leaf, or a colliding-segment owner) is refused → skip-and-continue,
+		// cleared on a later pass once the engine/orphan is gone — never deleted under a live engine or
+		// stranded unknown-present. Mirrors PruneRuns. PurgeRun reaps the run's member jobs too.
+		_ = WithRunLock(r.RunID, func() error {
+			if PurgeRun(r.RunID) == nil {
+				removed++
 			}
-		}
-		removeRun(runsPath, r.RunID)
-		removed++
+			return nil
+		})
 	}
 
-	// Standalone jobs (no run) that are finished, in-session, and unpinned. Run members are
-	// handled above; a member of a KEPT run stays attached to it.
+	// Standalone jobs (no run) that are finished, in-session, and unpinned. Run members are handled
+	// above (PurgeRun reaps them); a member of a KEPT run stays attached to it.
 	for _, j := range jobs {
-		if j.RunID != "" || removedJob[j.JobID] {
+		if j.RunID != "" {
 			continue
 		}
 		if j.LeadSessionID != sessionID || !terminalStatus(j.Status) {
@@ -102,13 +100,14 @@ func ClearFinished(sessionID string, pins pinned.Set) (int, error) {
 	return removed, nil
 }
 
-// DeleteSession removes EVERY record of one session — workflow runs (any status; a live run's engine
-// is stopped first by PurgeRun) and standalone subagent jobs (a still-live one's process tree is
-// reaped first) — EXCEPT pinned ones (a pinned run, a run with a pinned member, or a pinned job is
-// kept; pins are removed only by an explicit per-record delete). Each run delete runs under the
-// per-run lock so it can't race a concurrent restart/resume. A run that won't delete (its engine
-// can't be stopped in time) is skipped and REPORTED: the error names how many were skipped, alongside
-// the count actually removed.
+// DeleteSession removes EVERY record of one session — workflow runs (a verifiably-live detached run's
+// engine is stopped first by PurgeRun; an unverifiable or foreground live run is refused and skipped)
+// and standalone subagent jobs (a still-live one's process tree is reaped first) — EXCEPT pinned ones
+// (a pinned run, a run with a pinned member, or a pinned job is kept; pins are removed only by an
+// explicit per-record delete). Each run delete runs under the per-run lock so it can't race a
+// concurrent restart/resume. A run that won't delete (a live engine that can't be verify-reaped, or a
+// live orphan leaf) is skipped and REPORTED: the error names how many were skipped, alongside the
+// count actually removed.
 func DeleteSession(sessionID string, pins pinned.Set) (int, error) {
 	if sessionID == "" {
 		return 0, fmt.Errorf("subagent: DeleteSession requires a session id")
@@ -141,7 +140,7 @@ func DeleteSession(sessionID string, pins pinned.Set) (int, error) {
 		}
 		id := r.RunID
 		_ = WithRunLock(id, func() error {
-			// PurgeRun stops a live engine first, then reaps the run + members.
+			// PurgeRun refuses a live-or-unverifiable engine (reported as skipped), else reaps run + members.
 			if perr := PurgeRun(id); perr != nil {
 				skipped++
 				if skipErr == nil {
@@ -185,6 +184,16 @@ func DeleteJob(jobID string) error {
 	dir, err := jobsDir()
 	if err != nil {
 		return err
+	}
+	// A member leaf whose recorded CHILD is alive-or-unverifiable is veto evidence for its worktree
+	// segment — refuse (retry once the child exits), mirroring PurgeRun's live-orphan refusal. Keyed on
+	// the NARROW isLiveOrphanVetoEvidence (ChildPID>0), NOT the automated keep-rule: a still-identity-
+	// PENDING member (Start-window crash, no ChildPID — a state that never self-resolves) is therefore
+	// NOT blocked. This is the explicit record-only RECOVERY escape: a user DeleteJob on the pending job
+	// proceeds (declared intent), after which its run is no longer member-blocked and cleans up normally;
+	// no workdir is deleted under an unverifiable orphan (the user resolved it).
+	if meta, merr := readMeta(dir, jobID); merr == nil && isLiveOrphanVetoEvidence(meta) {
+		return fmt.Errorf("subagent: job %s is a run member whose leaf is still running; retry the delete after it exits", jobID)
 	}
 	removeJob(dir, jobID)
 	_ = pinned.Unpin(pinned.Job, jobID)

--- a/internal/subagent/engine_alive_unverifiable_test.go
+++ b/internal/subagent/engine_alive_unverifiable_test.go
@@ -1,0 +1,83 @@
+package subagent
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEngineAliveUnverifiableFailsSoft (codex r30): EngineAlive must fail SOFT to alive on an
+// alive-but-UNVERIFIABLE detached pid (argv unreadable AND its recorded token unreadable). The old code
+// collapsed a token-read failure to false, so consumers that read !EngineAlive as death proof —
+// critically WaitEngineStopped's poll after a reap — could succeed prematurely on a still-live engine.
+func TestEngineAliveUnverifiableFailsSoft(t *testing.T) {
+	self := os.Getpid()
+	const dead = 0x7ffffffe
+	origArgv, origPS := reuseGuardArgv, procStartFn
+	t.Cleanup(func() { reuseGuardArgv, procStartFn = origArgv, origPS })
+
+	// pidAlive + argv unreadable + a RECORDED token that the platform can't read → Unknown → ALIVE.
+	reuseGuardArgv = func(int) ([]string, bool) { return nil, false }
+	procStartFn = func(int) (string, bool) { return "", false }
+	unverif := WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: "tok"}
+	if !EngineAlive(unverif) {
+		t.Error("an alive-but-unverifiable pid (argv+token unreadable) must read ALIVE, never a false gone")
+	}
+
+	// The recycled/dead shapes still read gone (a READABLE argv mismatch, or a dead pid).
+	reuseGuardArgv = func(int) ([]string, bool) { return []string{"other", "proc"}, true }
+	if EngineAlive(WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: "tok"}) {
+		t.Error("a readable argv mismatch (recycled) must read gone")
+	}
+	reuseGuardArgv = func(int) ([]string, bool) { return nil, false }
+	if EngineAlive(WorkflowRun{RunID: "r1", EnginePID: dead, EngineProcStart: "tok"}) {
+		t.Error("a dead pid must read gone")
+	}
+}
+
+// TestWaitEngineStoppedFailClosedOnUnverifiable (codex r30): WaitEngineStopped must TIME OUT (false) on
+// an alive-but-unverifiable engine — the fail-closed path — instead of succeeding as it did when
+// EngineAlive collapsed the token failure to false; a genuinely-dead pid still passes immediately. And
+// StopRun's DetachedLive reap path, when the pid won't verify dead, surfaces the did-not-stop error
+// rather than finalizing/flipping under a possibly-live engine.
+func TestWaitEngineStoppedFailClosedOnUnverifiable(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origArgv, origPS, origReap, origTO := reuseGuardArgv, procStartFn, reapEngineTreeFn, stopReapTimeout
+	stopReapTimeout = 150 * time.Millisecond // keep the fail-closed path fast
+	t.Cleanup(func() {
+		reuseGuardArgv, procStartFn, reapEngineTreeFn, stopReapTimeout = origArgv, origPS, origReap, origTO
+	})
+
+	// A genuinely-dead pid passes Wait immediately.
+	writeRunForTest(t, WorkflowRun{RunID: "dead", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: deadEnginePID})
+	if !WaitEngineStopped("dead", time.Second) {
+		t.Error("WaitEngineStopped must return true immediately for a dead pid")
+	}
+
+	// An alive-but-unverifiable engine: Wait must TIME OUT (fail-closed), not falsely report stopped.
+	reuseGuardArgv = func(int) ([]string, bool) { return nil, false }
+	procStartFn = func(int) (string, bool) { return "", false }
+	writeRunForTest(t, WorkflowRun{RunID: "unverif", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self, EngineProcStart: "tok"})
+	if WaitEngineStopped("unverif", 150*time.Millisecond) {
+		t.Error("WaitEngineStopped must fail closed (time out) on an alive-but-unverifiable engine")
+	}
+
+	// StopRun's DetachedLive reap that doesn't verify the pid dead surfaces the did-not-stop error.
+	// reuseGuardArgv reads the engine argv as a MATCH (→ DetachedLive going in); the reap seam is a no-op,
+	// so the pid stays Live/unverifiable and WaitEngineStopped times out → StopRun fails closed.
+	reuseGuardArgv = func(int) ([]string, bool) {
+		return []string{"cc-fleet", "workflow", "run", "--run-id", "live", "s.js"}, true
+	}
+	reapEngineTreeFn = func(int) {} // reap sends the signal but the engine won't die in time
+	writeRunForTest(t, WorkflowRun{RunID: "live", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self})
+	_, err := StopRun("live")
+	if err == nil || !strings.Contains(err.Error(), "did not stop in time") {
+		t.Fatalf("StopRun's Live reap must surface the did-not-stop error when the pid won't verify dead, got %v", err)
+	}
+	if run, _ := ReadRun("live"); run.Status != "running" {
+		t.Errorf("a did-not-stop reap must NOT flip the run stopped (fail closed), got %q", run.Status)
+	}
+}

--- a/internal/subagent/engine_alive_unverifiable_test.go
+++ b/internal/subagent/engine_alive_unverifiable_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// TestEngineAliveUnverifiableFailsSoft (codex r30): EngineAlive must fail SOFT to alive on an
+// TestEngineAliveUnverifiableFailsSoft: EngineAlive must fail SOFT to alive on an
 // alive-but-UNVERIFIABLE detached pid (argv unreadable AND its recorded token unreadable). The old code
 // collapsed a token-read failure to false, so consumers that read !EngineAlive as death proof —
 // critically WaitEngineStopped's poll after a reap — could succeed prematurely on a still-live engine.
@@ -36,7 +36,7 @@ func TestEngineAliveUnverifiableFailsSoft(t *testing.T) {
 	}
 }
 
-// TestWaitEngineStoppedFailClosedOnUnverifiable (codex r30): WaitEngineStopped must TIME OUT (false) on
+// TestWaitEngineStoppedFailClosedOnUnverifiable: WaitEngineStopped must TIME OUT (false) on
 // an alive-but-unverifiable engine — the fail-closed path — instead of succeeding as it did when
 // EngineAlive collapsed the token failure to false; a genuinely-dead pid still passes immediately. And
 // StopRun's DetachedLive reap path, when the pid won't verify dead, surfaces the did-not-stop error

--- a/internal/subagent/engine_provably_dead_test.go
+++ b/internal/subagent/engine_provably_dead_test.go
@@ -58,4 +58,96 @@ func TestRunEngineProvablyNotLive(t *testing.T) {
 	if RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "running", EnginePID: self}) {
 		t.Error("an alive-but-unverifiable pid must not read as provably dead")
 	}
+
+	// FOREGROUND identity path (EnginePID 0): the run is provably dead iff its recorded fg engine is.
+	origPS := procStartFn
+	t.Cleanup(func() { procStartFn = origPS })
+	procStartFn = func(int) (string, bool) { return "fg-tok", true }
+	// A Ctrl-C'd / crashed fg run — recorded fg pid now DEAD → provably dead.
+	if !RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "stopped", EnginePID: 0, FgEnginePID: dead, FgEngineProcStart: "fg-tok"}) {
+		t.Error("a stopped fg run with a dead fg pid must be provably dead")
+	}
+	if !RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "running", EnginePID: 0, FgEnginePID: dead}) {
+		t.Error("a crashed fg run (running + dead fg pid) must be provably dead")
+	}
+	// A still-live fg engine (pid alive + token matches) → NOT provably dead.
+	if RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: "fg-tok"}) {
+		t.Error("a blind-stopped LIVE fg engine must not read as provably dead")
+	}
+	// A recycled fg pid (alive + token MISMATCH) → provably dead.
+	if !RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: "stale"}) {
+		t.Error("a recycled fg pid (token mismatch) must be provably dead")
+	}
+}
+
+// TestClassifyDetachedEngine drives the DETACHED tri-state via the reuseGuardArgv + procStartFn seams:
+// no pid → Unknown; dead pid → Dead; alive+argv-match → Live; alive+argv-mismatch → Dead (recycled);
+// alive+argv-unreadable+token-match → Live, +token-mismatch → Dead; alive+argv-unreadable+token-UNREADABLE
+// → Unknown (a binary !EngineAlive would wrongly call this dead); alive+nothing-recorded → Unknown.
+func TestClassifyDetachedEngine(t *testing.T) {
+	origArgv := reuseGuardArgv
+	origPS := procStartFn
+	t.Cleanup(func() { reuseGuardArgv = origArgv; procStartFn = origPS })
+	self := os.Getpid()
+	const dead = 0x7ffffffe
+	engineArgv := []string{"cc-fleet", "workflow", "run", "--run-id", "r1", "s.js"}
+	otherArgv := []string{"some", "other", "proc"}
+	argvOK := func(a []string) func(int) ([]string, bool) { return func(int) ([]string, bool) { return a, true } }
+	argvFail := func(int) ([]string, bool) { return nil, false }
+	tokOK := func(s string) func(int) (string, bool) { return func(int) (string, bool) { return s, true } }
+	tokFail := func(int) (string, bool) { return "", false }
+
+	cases := []struct {
+		name  string
+		run   WorkflowRun
+		argv  func(int) ([]string, bool)
+		token func(int) (string, bool)
+		want  DetachedLiveness
+	}{
+		{"no pid", WorkflowRun{RunID: "r1", EnginePID: 0}, argvFail, tokFail, DetachedUnknown},
+		{"dead pid", WorkflowRun{RunID: "r1", EnginePID: dead}, argvOK(engineArgv), tokOK("t"), DetachedDead},
+		{"alive + argv match", WorkflowRun{RunID: "r1", EnginePID: self}, argvOK(engineArgv), tokFail, DetachedLive},
+		{"alive + argv mismatch (recycled)", WorkflowRun{RunID: "r1", EnginePID: self}, argvOK(otherArgv), tokOK("t"), DetachedDead},
+		{"alive + argv unreadable + token match", WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: "tok"}, argvFail, tokOK("tok"), DetachedLive},
+		{"alive + argv unreadable + token mismatch", WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: "old"}, argvFail, tokOK("new"), DetachedDead},
+		{"alive + argv and token unreadable", WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: "tok"}, argvFail, tokFail, DetachedUnknown},
+		{"alive + nothing recorded (pre-token)", WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: ""}, argvFail, tokOK("t"), DetachedUnknown},
+	}
+	for _, c := range cases {
+		reuseGuardArgv = c.argv
+		procStartFn = c.token
+		if got := ClassifyDetachedEngine(c.run); got != c.want {
+			t.Errorf("%s: ClassifyDetachedEngine = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestClassifyFgEngine drives the foreground liveness classifier directly via the procStartFn seam:
+// no fg pid → Unknown; dead pid → Dead; alive+token-match → Alive; alive+token-mismatch → Dead
+// (recycled); alive+token-unreadable or unrecorded → Unknown (fail-safe). No argv is ever consulted.
+func TestClassifyFgEngine(t *testing.T) {
+	orig := procStartFn
+	t.Cleanup(func() { procStartFn = orig })
+	self := os.Getpid()
+	const dead = 0x7ffffffe
+
+	cases := []struct {
+		name  string
+		run   WorkflowRun
+		token func(int) (string, bool)
+		want  FgLiveness
+	}{
+		{"no fg pid", WorkflowRun{FgEnginePID: 0}, func(int) (string, bool) { return "t", true }, FgUnknown},
+		{"dead pid", WorkflowRun{FgEnginePID: dead, FgEngineProcStart: "t"}, func(int) (string, bool) { return "t", true }, FgDead},
+		{"alive + token match", WorkflowRun{FgEnginePID: self, FgEngineProcStart: "t"}, func(int) (string, bool) { return "t", true }, FgAlive},
+		{"alive + token mismatch (recycled)", WorkflowRun{FgEnginePID: self, FgEngineProcStart: "old"}, func(int) (string, bool) { return "new", true }, FgDead},
+		{"alive + token unreadable", WorkflowRun{FgEnginePID: self, FgEngineProcStart: "t"}, func(int) (string, bool) { return "", false }, FgUnknown},
+		{"alive + no recorded token", WorkflowRun{FgEnginePID: self, FgEngineProcStart: ""}, func(int) (string, bool) { return "t", true }, FgUnknown},
+	}
+	for _, c := range cases {
+		procStartFn = c.token
+		if got := ClassifyFgEngine(c.run); got != c.want {
+			t.Errorf("%s: ClassifyFgEngine = %v, want %v", c.name, got, c.want)
+		}
+	}
 }

--- a/internal/subagent/engine_provably_dead_test.go
+++ b/internal/subagent/engine_provably_dead_test.go
@@ -1,0 +1,61 @@
+package subagent
+
+import (
+	"os"
+	"testing"
+)
+
+// TestRunEngineProvablyNotLive: the ONLY death proof is a recorded detached EnginePID that is
+// positively dead or recycled (!EngineAlive). Terminal status ALONE is not proof — a live
+// foreground run blind-flipped to "stopped" keeps EnginePID 0 — and a foreground/pre-stamp run
+// (EnginePID 0) is never provably dead. A live matching engine (even under a terminal status) and
+// an alive-but-unverifiable pid are both spared.
+func TestRunEngineProvablyNotLive(t *testing.T) {
+	orig := reuseGuardArgv
+	t.Cleanup(func() { reuseGuardArgv = orig })
+	self := os.Getpid()
+	const dead = 0x7ffffffe
+	engineArgv := []string{"cc-fleet", "workflow", "run", "--run-id", "r1", "s.js"}
+
+	// A recorded detached pid that is DEAD → provably dead, whatever the status: a crash left it
+	// "running", and a StopRun'd detached run left it "stopped" with its dead pid retained.
+	for _, st := range []string{"running", "stopped", "failed", "done"} {
+		reuseGuardArgv = func(int) ([]string, bool) { return engineArgv, true }
+		if !RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: st, EnginePID: dead}) {
+			t.Errorf("status %q with a dead detached pid must be provably dead", st)
+		}
+	}
+
+	// Terminal status ALONE is not proof: a foreground run blind-flipped to a terminal state keeps
+	// EnginePID 0, and its engine may still be live.
+	for _, st := range []string{"stopped", "failed", "done"} {
+		if RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: st, EnginePID: 0}) {
+			t.Errorf("terminal status %q with EnginePID 0 must NOT be provably dead (terminal alone is not proof)", st)
+		}
+	}
+
+	// A running foreground engine (EnginePID 0) keeps writing — not provably dead.
+	if RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "running", EnginePID: 0}) {
+		t.Error("a running foreground engine (EnginePID 0) must not read as provably dead")
+	}
+
+	// A live pid recycled to an unrelated process (argv mismatch) → provably dead.
+	reuseGuardArgv = func(int) ([]string, bool) { return []string{"some", "other"}, true }
+	if !RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "running", EnginePID: self}) {
+		t.Error("a recycled detached pid must read as provably dead")
+	}
+
+	// A live pid still this run's engine → not provably dead, even under a terminal status.
+	for _, st := range []string{"running", "stopped", "done"} {
+		reuseGuardArgv = func(int) ([]string, bool) { return engineArgv, true }
+		if RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: st, EnginePID: self}) {
+			t.Errorf("status %q with a live matching engine must not read as provably dead", st)
+		}
+	}
+
+	// A live pid whose identity can't be read (no argv, no token) → not provably dead (fail SAFE).
+	reuseGuardArgv = func(int) ([]string, bool) { return nil, false }
+	if RunEngineProvablyNotLive(WorkflowRun{RunID: "r1", Status: "running", EnginePID: self}) {
+		t.Error("an alive-but-unverifiable pid must not read as provably dead")
+	}
+}

--- a/internal/subagent/fg_liveness_test.go
+++ b/internal/subagent/fg_liveness_test.go
@@ -1,0 +1,67 @@
+package subagent
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPruneAndPurgeHonorFgLiveness: prune/delete must honor the foreground death proof. A
+// blind-stopped LIVE foreground run ({stopped, 0, FgAlive}) is SPARED by PruneRuns and REFUSED by a
+// direct PurgeRun (its engine runs in the user's terminal — unreapable, fail closed). A Ctrl-C'd fg
+// run ({stopped, 0, FgDead}) and an old pre-field record ({stopped, 0, no fg}) are both prunable and
+// directly deletable — consistent with resume now allowing the dead one and old records staying
+// cleanable.
+func TestPruneAndPurgeHonorFgLiveness(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orig := procStartFn
+	procStartFn = func(int) (string, bool) { return "fg-tok", true }
+	t.Cleanup(func() { procStartFn = orig })
+	self := os.Getpid()
+	const dead = 0x7ffffffe
+
+	live := WorkflowRun{RunID: "fg-live", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: "fg-tok"}
+	deadFg := WorkflowRun{RunID: "fg-dead", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: dead}
+	oldRec := WorkflowRun{RunID: "fg-old", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0}
+	seed := func() {
+		for _, r := range []WorkflowRun{live, deadFg, oldRec} {
+			if err := SaveRun(r); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Direct PurgeRun: the live fg run is refused (and survives); the others delete.
+	seed()
+	if err := PurgeRun("fg-live"); err == nil || !strings.Contains(err.Error(), "running in the foreground") {
+		t.Errorf("PurgeRun of a live fg run must be refused, got %v", err)
+	}
+	if _, rerr := ReadRun("fg-live"); rerr != nil {
+		t.Error("a refused live fg run must still exist")
+	}
+	if err := PurgeRun("fg-dead"); err != nil {
+		t.Errorf("PurgeRun of a Ctrl-C'd fg run must succeed, got %v", err)
+	}
+	if err := PurgeRun("fg-old"); err != nil {
+		t.Errorf("PurgeRun of an old-record run must succeed, got %v", err)
+	}
+
+	// PruneRuns: spares the live fg run, reaps the dead + old ones.
+	seed()
+	removed, err := PruneRuns()
+	if err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("PruneRuns removed = %d, want 2 (dead fg + old record; live fg spared)", removed)
+	}
+	if _, rerr := ReadRun("fg-live"); rerr != nil {
+		t.Error("PruneRuns must spare a live fg run")
+	}
+	for _, id := range []string{"fg-dead", "fg-old"} {
+		if _, rerr := ReadRun(id); rerr == nil {
+			t.Errorf("PruneRuns must reap %q", id)
+		}
+	}
+}

--- a/internal/subagent/fg_recorded_pid_purge_test.go
+++ b/internal/subagent/fg_recorded_pid_purge_test.go
@@ -1,0 +1,132 @@
+package subagent
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/pinned"
+)
+
+// TestFgRecordedLivePidRefused (codex r28b): a foreground record whose FgEnginePID is ALIVE but whose
+// token is empty/unreadable classifies FgUnknown. Because a recorded live pid we cannot disprove must
+// be treated like FgAlive (the detached principle), every automated deletion path — PurgeRun, PruneRuns,
+// ClearFinished, PurgeJobs — must REFUSE/SPARE it (its record survives) until the pid exits (→ FgDead),
+// then all proceed. The r23-adjudicated legacy shape (FgEnginePID<=0, no token) stays deletable.
+func TestFgRecordedLivePidRefused(t *testing.T) {
+	self := os.Getpid()
+
+	// The bug shape: {stopped, EnginePID 0, FgEnginePID=live, FgEngineProcStart=""} → FgUnknown WITH a
+	// recorded pid. The empty recorded token forces FgUnknown regardless of what the platform reads.
+	live := func() WorkflowRun {
+		return WorkflowRun{RunID: "fg-live", SessionID: "s", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: ""}
+	}
+
+	t.Run("classification + guards spare the recorded-live-pid shape", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		run := live()
+		if got := ClassifyFgEngine(run); got != FgUnknown {
+			t.Fatalf("an empty recorded token must classify FgUnknown, got %v", got)
+		}
+		if RunEngineProvablyNotLive(run) {
+			t.Error("a recorded live fg pid must NOT be provably dead")
+		}
+		if !isLiveOrUnverifiable(run) {
+			t.Error("PruneRuns eligibility must SPARE a recorded live fg pid")
+		}
+	})
+
+	t.Run("PurgeRun refuses; record survives", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		writeRunForTest(t, live())
+		if err := PurgeRun("fg-live"); err == nil || !strings.Contains(err.Error(), "foreground") {
+			t.Errorf("PurgeRun must refuse under a recorded live fg pid, got %v", err)
+		}
+		if _, rerr := ReadRun("fg-live"); rerr != nil {
+			t.Error("the refused PurgeRun must leave the record")
+		}
+	})
+
+	t.Run("PruneRuns spares; record survives", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		writeRunForTest(t, live())
+		if removed, err := PruneRuns(); err != nil || removed != 0 {
+			t.Errorf("PruneRuns must spare the recorded live fg pid, removed=%d err=%v", removed, err)
+		}
+		if _, rerr := ReadRun("fg-live"); rerr != nil {
+			t.Error("PruneRuns must leave the record")
+		}
+	})
+
+	t.Run("ClearFinished + PurgeJobs leave it; record survives", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		writeRunForTest(t, live())
+		if _, err := ClearFinished("s", pinned.Set{}); err != nil {
+			t.Fatalf("ClearFinished: %v", err)
+		}
+		if _, rerr := ReadRun("fg-live"); rerr != nil {
+			t.Error("ClearFinished routes through PurgeRun → must leave the record")
+		}
+		if _, _, _, err := PurgeJobs(); err != nil {
+			t.Fatalf("PurgeJobs: %v", err)
+		}
+		if _, rerr := ReadRun("fg-live"); rerr != nil {
+			t.Error("PurgeJobs routes through PurgeRun → must leave the record")
+		}
+	})
+
+	t.Run("pid dead (FgDead) → PurgeRun proceeds", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		dead := live()
+		dead.FgEnginePID = deadEnginePID // a dead recorded pid → FgDead → self-clearing
+		if ClassifyFgEngine(dead) != FgDead {
+			t.Fatal("a dead recorded fg pid must classify FgDead")
+		}
+		writeRunForTest(t, dead)
+		if err := PurgeRun("fg-live"); err != nil {
+			t.Errorf("once the fg pid is gone the delete must proceed, got %v", err)
+		}
+		if _, rerr := ReadRun("fg-live"); rerr == nil {
+			t.Error("a FgDead record must be removed")
+		}
+	})
+
+	t.Run("FgAlive (recorded pid + matching token) still refuses", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		origPS := procStartFn
+		procStartFn = func(int) (string, bool) { return "tok", true }
+		t.Cleanup(func() { procStartFn = origPS })
+		alive := live()
+		alive.FgEngineProcStart = "tok" // matching token → FgAlive
+		if ClassifyFgEngine(alive) != FgAlive {
+			t.Fatal("a matching recorded token must classify FgAlive")
+		}
+		writeRunForTest(t, alive)
+		if err := PurgeRun("fg-live"); err == nil || !strings.Contains(err.Error(), "foreground") {
+			t.Errorf("FgAlive refusal must be unchanged, got %v", err)
+		}
+	})
+
+	t.Run("legacy no-fg-pid stays deletable (r23 preserved)", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		// {stopped, 0, no fg fields}: FgUnknown with NO recorded pid — status-based, prunable/deletable.
+		legacy := WorkflowRun{RunID: "fg-legacy", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0}
+		if isLiveOrUnverifiable(legacy) {
+			t.Error("a terminal legacy no-fg record must NOT be spared (r23)")
+		}
+		writeRunForTest(t, legacy)
+		if err := PurgeRun("fg-legacy"); err != nil {
+			t.Errorf("a legacy no-fg record must stay deletable, got %v", err)
+		}
+		if _, rerr := ReadRun("fg-legacy"); rerr == nil {
+			t.Error("PurgeRun must remove the legacy no-fg record")
+		}
+	})
+}

--- a/internal/subagent/fg_recorded_pid_purge_test.go
+++ b/internal/subagent/fg_recorded_pid_purge_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/pinned"
 )
 
-// TestFgRecordedLivePidRefused (codex r28b): a foreground record whose FgEnginePID is ALIVE but whose
+// TestFgRecordedLivePidRefused: a foreground record whose FgEnginePID is ALIVE but whose
 // token is empty/unreadable classifies FgUnknown. Because a recorded live pid we cannot disprove must
 // be treated like FgAlive (the detached principle), every automated deletion path — PurgeRun, PruneRuns,
 // ClearFinished, PurgeJobs — must REFUSE/SPARE it (its record survives) until the pid exits (→ FgDead),
-// then all proceed. The r23-adjudicated legacy shape (FgEnginePID<=0, no token) stays deletable.
+// then all proceed. The legacy shape (FgEnginePID<=0, no token) stays deletable.
 func TestFgRecordedLivePidRefused(t *testing.T) {
 	self := os.Getpid()
 
@@ -113,7 +113,7 @@ func TestFgRecordedLivePidRefused(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy no-fg-pid stays deletable (r23 preserved)", func(t *testing.T) {
+	t.Run("legacy no-fg-pid stays deletable", func(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		t.Setenv("HOME", t.TempDir())
 		// {stopped, 0, no fg fields}: FgUnknown with NO recorded pid — status-based, prunable/deletable.

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -787,8 +787,11 @@ func gcRunManifests(jobsDir string, cutoff time.Time, pins pinned.Set) {
 		}
 		// No surviving member. Keep only a manifest that PROVES it is still recent
 		// (a fresh, not-yet-populated run); an unreadable/unparseable manifest can't
-		// prove recency → treated as an aged orphan and removed below.
-		if data, rerr := os.ReadFile(filepath.Join(dir, name)); rerr == nil {
+		// prove recency → treated as an aged orphan and removed below. readFileRetry
+		// absorbs a transient Windows sharing violation so a fresh/resuming run isn't
+		// misread as unprovable; a persistent read error still falls through to PurgeRun,
+		// which then fails closed (deletes nothing) rather than reap under a live engine.
+		if data, rerr := readFileRetry(filepath.Join(dir, name)); rerr == nil {
 			var run WorkflowRun
 			if json.Unmarshal(data, &run) == nil {
 				if runIsRecent(run, cutoff) {

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -1195,7 +1195,11 @@ func readWholeUnderCap(path string, limit int64) []byte {
 
 func readMeta(dir, jobID string) (jobMeta, error) {
 	var m jobMeta
-	data, err := os.ReadFile(metaPath(dir, jobID))
+	// readFileRetry, not os.ReadFile: writeMeta renames the meta into place (AtomicWrite), so on
+	// windows a concurrent reader can hit a transient ERROR_SHARING_VIOLATION for the instant the
+	// replace holds the target. The retry absorbs only that window; a real read/parse error still
+	// surfaces. No-op on unix (rename never yields it).
+	data, err := readFileRetry(metaPath(dir, jobID))
 	if err != nil {
 		return m, err
 	}

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ethanhq/cc-fleet/internal/childenv"
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/fileutil"
 	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/pinned"
 	"github.com/ethanhq/cc-fleet/internal/procintrospect"
@@ -71,6 +72,24 @@ type jobMeta struct {
 	// carries a new start time, so equality proves identity. Empty (legacy meta /
 	// capture failure) degrades to the bare liveness check.
 	ProcStart string `json:"proc_start,omitempty"`
+	// ChildPID / ChildProcStart identify a SYNC leaf's `claude -p` CHILD (its own pid + kernel start
+	// token, captured right after Start) — the piece meta.PID does NOT carry, since a sync job's PID is
+	// the ENGINE, whose liveness only "proxies" the leaf (a proxy a bare SIGKILL breaks: the child, in
+	// its own process group with cwd = the isolation worktree, outlives it). The worktree reclaimers
+	// read them to tell a live orphaned leaf from a dead one — identity OUTRANKS any cached result,
+	// because after the engine dies StatusFor synthesizes a terminal (failVanished) for a still-live
+	// orphan. A background job leaves them zero (its PID already IS the child); an old sync meta too.
+	ChildPID       int    `json:"child_pid,omitempty"`
+	ChildProcStart string `json:"child_proc_start,omitempty"`
+	// ChildIdentityPending marks a SYNC member (RunID != "") registered but not yet past the
+	// cmd.Start→recordChildIdentity window: ChildPID is not stamped yet, but a crash in that ~ms window
+	// leaves a LIVE orphan whose identity was never recorded. It is the discriminator that lets automated
+	// cleanup (GC/PurgeJobs) keep such a meta as veto evidence WITHOUT keeping every identity-less legacy
+	// meta (which lacks this field → false, preserving the GC contract for pre-change jobs). recordChildIdentity clears
+	// it in the same write that stamps ChildPID; a REAPED terminal finalize (runClaude returned → child
+	// provably not running) also clears it — and zeroes the engine-proxy PID — so a cmd.Start failure
+	// can't strand a false pending veto that force-keeps the meta forever.
+	ChildIdentityPending bool `json:"child_identity_pending,omitempty"`
 	// ProxyPort is the loopback conversion-daemon port this job's provider rides
 	// (0 for a non-daemon-backed provider). The Windows codexproxy daemon counts
 	// live workers from the job store instead of process argv, and this field is
@@ -706,6 +725,13 @@ func GC(olderThan time.Duration) Result {
 		if pins.Has(pinned.Job, jobID) || (meta.RunID != "" && pins.Has(pinned.Run, meta.RunID)) {
 			continue
 		}
+		// A member leaf whose recorded CHILD is alive-or-unverifiable — OR whose identity write is still
+		// PENDING (the Start window) — is kept regardless of age or a cached terminal: it is the veto
+		// evidence a colliding worktree segment relies on (a SIGKILLed engine's orphan outlives the
+		// engine; StatusFor may have synthesized a terminal for it).
+		if isLiveOrPendingOrphanEvidence(meta) {
+			continue
+		}
 		// A cached <id>.result.json is the authoritative terminal signal.
 		// processAlive can lie under PID reuse (sync jobs record the cc-fleet
 		// PID with empty SettingsPath, so a recycled PID looks alive forever).
@@ -770,7 +796,15 @@ func gcRunManifests(jobsDir string, cutoff time.Time, pins pinned.Set) {
 				}
 			}
 		}
-		removeRun(dir, runID)
+		// Remove the aged manifest through the CHOKEPOINT (WithRunLock + PurgeRun), not a bare removeRun:
+		// PurgeRun drops a leaked isolation WORKDIR before the manifest (its physical segment snapshot),
+		// so the run is never left as an unknown-present strand, and its refusal gates skip a run whose
+		// engine is still live or that has a live-orphan member (as PruneRuns/ClearFinished do). Ordering
+		// vs the job-meta pass above is immaterial: that pass reaps only DEAD members (a live-orphan one is
+		// kept, which also keeps this manifest via survivingRunIDs), and PurgeRun removes the segment's
+		// workdirs by that physical snapshot — not by member metas — so its ordered cleanup holds no matter
+		// which members were already reaped.
+		_ = WithRunLock(runID, func() error { _ = PurgeRun(runID); return nil })
 	}
 	sweepOrphanRunSidecars(dir, cutoff, false, pins)
 }
@@ -877,12 +911,22 @@ func PurgeJobs() (dir string, removedFinished []string, running []string, err er
 			continue
 		}
 		jobID := strings.TrimSuffix(name, ".json")
+		meta, merr := readMeta(dir, jobID)
+		// A member leaf whose recorded CHILD is alive-or-unverifiable, OR still identity-PENDING (the
+		// Start window), is kept regardless of a cached terminal — the veto evidence a colliding worktree
+		// segment relies on (mirrors GC). Keeping it also keeps its run's manifest (runningRuns), so the
+		// chokepoint purge never reaches the run under the possibly-live orphan.
+		if merr == nil && isLiveOrPendingOrphanEvidence(meta) {
+			running = append(running, jobID)
+			runningRuns[meta.RunID] = true
+			continue
+		}
 		// result-cache-first liveness (mirrors GC): a cached terminal result means
 		// done regardless of pid; only without it do we consult processAlive. A
 		// meta we can't read can't be polled, so it falls through to removal.
 		resultPath := filepath.Join(dir, jobID+".result.json")
 		if _, resultErr := os.Stat(resultPath); resultErr != nil {
-			if meta, merr := readMeta(dir, jobID); merr == nil && (processAlive(meta.PID, meta.SettingsPath, meta.ProcStart) || queuedPlaceholder(meta)) {
+			if merr == nil && (processAlive(meta.PID, meta.SettingsPath, meta.ProcStart) || queuedPlaceholder(meta)) {
 				running = append(running, jobID)
 				if meta.RunID != "" {
 					runningRuns[meta.RunID] = true
@@ -896,29 +940,38 @@ func PurgeJobs() (dir string, removedFinished []string, running []string, err er
 		removedFinished = append(removedFinished, jobID)
 	}
 
-	purgeRunManifests(dir, runningRuns)
+	survived := purgeRunManifests(dir, runningRuns)
 
 	sort.Strings(removedFinished)
 	sort.Strings(running)
 
-	// Drop the dir when nothing is left running. RemoveAll (not Remove) so a leftover
-	// per-run .lock file — deliberately not a GC'd sidecar — can't strand the dir at an
-	// exclusive uninstall; with nothing running, no lock is held, so this is safe.
-	if len(running) == 0 {
+	// Drop the jobs dir only when NOTHING survived: no live member job (len(running)==0) AND no run
+	// PurgeRun refused (survived — a live foreground / unverifiable engine leaves its manifest but has no
+	// running member job, so `running` alone would miss it and this wholesale RemoveAll would erase its
+	// manifest/journal/ctl under a live engine, bypassing the chokepoint). When survivors exist the
+	// partial-cleanup path already ran: it removed every finished/dead member job group + every
+	// provably-dead run (manifest + workdir, via PurgeRun) + orphan sidecars, and KEPT the refused run's
+	// manifest/sidecars, its live member jobs, and the dir itself. RemoveAll (not Remove) so a leftover
+	// per-run .lock (not a GC'd sidecar) can't strand the dir at an exclusive uninstall; nothing surviving
+	// means no lock is held.
+	if len(running) == 0 && !survived {
 		_ = os.RemoveAll(dir)
 	}
 	return dir, removedFinished, running, nil
 }
 
-// purgeRunManifests removes every run manifest whose RunID has no live member
-// (runningRuns), then removes the now-empty runs/ dir best-effort. A missing runs/
-// dir is a no-op. Keeping the runs/ dir empty-and-removable is what lets PurgeJobs
-// finally os.Remove the jobs dir when nothing is running.
-func purgeRunManifests(jobsDir string, runningRuns map[string]bool) {
+// purgeRunManifests removes every run manifest whose RunID has no live member (runningRuns) through the
+// chokepoint (skip-on-refusal), then removes the now-empty runs/ dir best-effort. A missing runs/ dir is
+// a no-op. Returns whether any run PurgeRun REFUSED (a live foreground / unverifiable engine keeps its
+// manifest) — so the caller must NOT wholesale-remove the jobs dir on top of it, which would erase under
+// a live engine a run the chokepoint deliberately kept. A leftover per-run .lock does NOT count as a
+// survivor (it is a lock artifact, cleared by the caller's RemoveAll). Keeping the runs/ dir
+// empty-and-removable is what lets PurgeJobs finally drop the jobs dir when nothing is running.
+func purgeRunManifests(jobsDir string, runningRuns map[string]bool) (survived bool) {
 	dir := filepath.Join(jobsDir, runsDirName)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return // no runs dir → nothing to purge
+		return false // no runs dir → nothing survived
 	}
 	for _, e := range entries {
 		name := e.Name()
@@ -932,10 +985,22 @@ func purgeRunManifests(jobsDir string, runningRuns map[string]bool) {
 		if runningRuns[runID] {
 			continue // live member → keep this run's manifest
 		}
-		removeRun(dir, runID)
+		// Route through the CHOKEPOINT (WithRunLock + PurgeRun), not a bare removeRun: PurgeRun drops a
+		// leaked isolation WORKDIR before the manifest (its physical segment snapshot) so nothing strands
+		// unknown-present, and its gates skip a live engine / live-orphan member. Ordering vs the member
+		// pass above is immaterial (same property as gcRunManifests): that pass reaps only DEAD members —
+		// a live-orphan one is KEPT, so runningRuns holds it and this loop already skipped it above — and
+		// PurgeRun removes the segment's workdirs by physical snapshot, not by member metas.
+		_ = WithRunLock(runID, func() error {
+			if PurgeRun(runID) != nil {
+				survived = true // REFUSED (live engine) → its manifest remains; the jobs dir must be kept
+			}
+			return nil
+		})
 	}
 	sweepOrphanRunSidecars(dir, time.Time{}, true, pinned.Set{}) // uninstall: empty pin set → drop every orphan sidecar so the dir can empty
-	_ = os.Remove(dir)                                           // succeeds only when empty (all manifests + sidecars gone)
+	_ = os.Remove(dir)                                           // best-effort: removes the runs/ dir when empty (a leftover per-run .lock, cleared by the caller's RemoveAll, is the only non-survivor that can block it)
+	return survived
 }
 
 // procRoot is the procfs mount point. A package var so tests can point the
@@ -1083,7 +1148,12 @@ func writeMeta(dir string, m jobMeta) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(metaPath(dir, m.JobID), data, 0o600)
+	// AtomicWrite (temp + rename), not a plain WriteFile: the meta is load-bearing death evidence
+	// (ChildPID) that runLeafScan reads, so a reader must never see a half-written file — a torn write
+	// would read as a corrupt/partial meta. The single meta outlet, so every writer (registerSyncJob on
+	// the spawn path, recordChildIdentity, the hold-protocol rewrites, finalize) is atomic; the temp
+	// files are `.<name>.*.tmp` and every jobs-dir scanner skips non-".json" names.
+	return fileutil.AtomicWrite(metaPath(dir, m.JobID), data, 0o600)
 }
 
 // readCapped reads at most limit bytes of a job file, so a runaway capture can't OOM the terminal
@@ -1261,6 +1331,10 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 		PersistIO:     req.PersistIO,
 		PromptProfile: effective,
 		SlimDowngrade: downgrade,
+		// A SYNC MEMBER starts in the identity-pending state — the child pid is stamped later by
+		// recordChildIdentity (after cmd.Start). Marks the Start-window so a crash there keeps its
+		// veto evidence; a standalone sync job (no run) never needs it.
+		ChildIdentityPending: req.RunID != "",
 		// SettingsPath deliberately empty (see processAlive). Sync writes no .out
 		// file, so the deferred result cache is the authoritative done signal.
 	}
@@ -1288,6 +1362,36 @@ func registerSyncJob(jobID string, req Request, model string, effective, downgra
 		_ = os.WriteFile(filepath.Join(dir, jobID+".prompt"), []byte(req.IOPrompt), 0o600)
 	}
 	return registerOK
+}
+
+// recordChildIdentity captures a SYNC leaf's `claude -p` CHILD pid + start token into its meta right
+// after Start — the engine-as-proxy meta.PID does not identify the child, which a bare SIGKILL can
+// orphan alive. A jobMetaMu read-modify-write that updates ONLY ChildPID/ChildProcStart, preserving
+// every other field (Status/PID/PGID/attempt/hold bookkeeping). It writes even onto a HELD row: the
+// hold protocol premarks {held, PID 0} BEFORE killing the child, so an engine crash in that window
+// leaves a LIVE orphan only this recorded identity can protect from the reclaimers — and adding the
+// child fields cannot resurrect a parked row (StatusFor still classifies by Status=="held", the
+// reclaimers read ChildPID). A GONE meta is skipped. The attempt guard rejects a stale write across a
+// restart: a held→restarted leaf bumps meta.Attempt, so a late attempt-N child must never stamp an
+// attempt-M row (and vice versa).
+func recordChildIdentity(jobID string, childPID, attempt int) {
+	if jobID == "" || childPID <= 0 {
+		return
+	}
+	dir, err := jobsDir()
+	if err != nil {
+		return
+	}
+	tok, _ := procStartFn(childPID)
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
+	meta, rerr := readMeta(dir, jobID)
+	if rerr != nil || meta.Attempt != attempt {
+		return
+	}
+	meta.ChildPID, meta.ChildProcStart = childPID, tok
+	meta.ChildIdentityPending = false // identity now recorded — the Start window is closed
+	_ = writeMetaFn(dir, meta)
 }
 
 // MintQueuedLeaf records a leaf the workflow engine has admitted but not yet given a pool slot:
@@ -1396,7 +1500,7 @@ func ReleaseHeldLeafStopped(jobID, msg string) {
 	}
 	meta.Status = "stopped"
 	_ = writeMetaFn(dir, meta)
-	finalizeSyncJobLocked(jobID, fail(ErrCodeStopped, msg, meta.Provider, ""))
+	finalizeSyncJobLocked(jobID, fail(ErrCodeStopped, msg, meta.Provider, ""), false)
 }
 
 // NormalizeHeldLeaf clears a held pre-mark that lost its race: the directive landed
@@ -1447,6 +1551,11 @@ func RequeueLeaf(jobID string, attempt int) {
 	if err != nil {
 		return
 	}
+	// ChildPID/ChildProcStart are left untouched: the prior child is already reaped (reads dead), and
+	// registerSyncJob resets them to {ChildPID 0, pending} before the next attempt's cmd.Start. A refactor
+	// must never let a stale nonzero ChildPID coexist with a newly-started child — the reclaim guards veto
+	// on a recorded ChildPID, so preserving it across requeue, or starting the child before re-registering,
+	// would let a sweep delete a live worktree.
 	meta.Status = "queued"
 	meta.PID, meta.PGID = 0, 0
 	meta.Attempt = attempt
@@ -1502,28 +1611,37 @@ func normalizeStaleHold(dir, runID, jobID string) {
 	}
 	meta.Status = "stopped" // ahead of the finalize so the suppression branch can't fire
 	_ = writeMetaFn(dir, meta)
-	finalizeSyncJobLocked(jobID, fail(ErrCodeStopped, "run restarted while the leaf was held", meta.Provider, ""))
+	finalizeSyncJobLocked(jobID, fail(ErrCodeStopped, "run restarted while the leaf was held", meta.Provider, ""), false)
 }
 
-// finalizeSyncJob flips a sync job from running → done/failed by writing a
-// SANITIZED terminal result cache: status + provider/model/started + the SAFE
-// metrics (Usage / cost / turns / duration — claude's own metering, which the
-// board's Workflows view needs to show a done leaf's tokens + "done · N turns"
-// outcome) + canonical error fields, with the answer text (res.Result) and Raw
-// STRIPPED so no provider reply is ever persisted to disk for a sync run (the caller
-// already got it on stdout). A subsequent StatusFor/ListJobs serves this cache.
-// jobID=="" (register failed) is a no-op; it is called from a defer so it runs on
-// the normal return path that produced res. The read→suppress-or-write section runs
-// under jobMetaMu (a HoldLeaf landing between the meta read and the cache write
-// would otherwise strand a terminal cache under a hold); lifecycle paths already
-// holding the mutex call finalizeSyncJobLocked directly.
+// finalizeSyncJob is the SYNTHETIC-safe entry (childReaped=false): an external reclaimer that did NOT
+// run this attempt's runClaude cannot prove the child is dead, so it preserves a pending stamp (a
+// crashed engine's orphan may still be live). The in-process attempt path uses finalizeSyncJobReaped.
 func finalizeSyncJob(jobID string, res Result) {
 	jobMetaMu.Lock()
 	defer jobMetaMu.Unlock()
-	finalizeSyncJobLocked(jobID, res)
+	finalizeSyncJobLocked(jobID, res, false)
 }
 
-func finalizeSyncJobLocked(jobID string, res Result) {
+// finalizeSyncJobReaped is the in-process attempt path: runClaude RETURNED, so cmd.Wait reaped the
+// child (or cmd.Start never launched one) — the child is PROVABLY not running (childReaped=true), which
+// lets the terminal write clear a still-pending identity stamp.
+func finalizeSyncJobReaped(jobID string, res Result) {
+	jobMetaMu.Lock()
+	defer jobMetaMu.Unlock()
+	finalizeSyncJobLocked(jobID, res, true)
+}
+
+// finalizeSyncJobLocked flips a sync job from running → done/failed by writing a SANITIZED terminal
+// result cache: status + provider/model/started + the SAFE metrics (Usage / cost / turns / duration —
+// claude's own metering, which the board's Workflows view needs to show a done leaf's tokens +
+// "done · N turns" outcome) + canonical error fields, with the answer text (res.Result) and Raw STRIPPED
+// so no provider reply is ever persisted to disk for a sync run (the caller already got it on stdout). A
+// subsequent StatusFor/ListJobs serves this cache. jobID=="" (register failed) is a no-op. The
+// read→suppress-or-write section runs under jobMetaMu (a HoldLeaf landing between the meta read and the
+// cache write would otherwise strand a terminal cache under a hold); the public wrappers acquire it,
+// lifecycle paths already holding it call this directly.
+func finalizeSyncJobLocked(jobID string, res Result, childReaped bool) {
 	if jobID == "" {
 		return
 	}
@@ -1572,6 +1690,14 @@ func finalizeSyncJobLocked(jobID string, res Result) {
 	default:
 		cached.Status = "failed"
 	}
+	// A REAPED terminal finalize (childReaped: runClaude returned, so cmd.Wait reaped the child or
+	// cmd.Start never launched one) proves a still-PENDING leaf has NO live process. Clear the pending
+	// stamp AND the engine-proxy PID so the leaf reads process-free — else a cmd.Start failure (onStart
+	// never ran) strands a false-pending veto that force-keeps the meta and blocks the run's worktree
+	// reclamation forever. Pending survives ONLY paths that cannot verify the child: an engine SIGKILL
+	// never reaches finalize, a synthetic reclaim (childReaped=false) preserves it, and the held-stopped
+	// suppression below returns before this clears anything.
+	clearPending := childReaped && meta.ChildIdentityPending
 	// A held meta marks a leaf-stop directive in flight (HoldLeaf ran before the kill).
 	// The killed attempt's stopped-class finalize is SUPPRESSED — a terminal cache during
 	// a hold would hand GC an authoritative "finished" for a live frame. Any other
@@ -1579,9 +1705,23 @@ func finalizeSyncJobLocked(jobID string, res Result) {
 	// normalize the meta to match, so no stale held meta survives a settle.
 	if meta.Status == "held" {
 		if cached.Status == "stopped" {
+			// SUPPRESS the terminal cache (a cache under a hold hands GC a finished frame), but the
+			// in-process reap still PROVES the child isn't running — clear a false-pending stamp + the
+			// engine-proxy PID so it can't force-keep the row forever once the hold is released. The row
+			// stays held (queuedPlaceholder keeps it as the live frame it is).
+			if clearPending {
+				meta.ChildIdentityPending, meta.PID = false, 0
+				_ = writeMetaFn(dir, meta)
+			}
 			return
 		}
 		meta.Status = cached.Status
+		if clearPending {
+			meta.ChildIdentityPending, meta.PID = false, 0
+		}
+		_ = writeMetaFn(dir, meta)
+	} else if clearPending {
+		meta.ChildIdentityPending, meta.PID = false, 0
 		_ = writeMetaFn(dir, meta)
 	}
 	if data, merr := json.Marshal(cached); merr == nil {

--- a/internal/subagent/job.go
+++ b/internal/subagent/job.go
@@ -85,7 +85,7 @@ type jobMeta struct {
 	// cmd.Start→recordChildIdentity window: ChildPID is not stamped yet, but a crash in that ~ms window
 	// leaves a LIVE orphan whose identity was never recorded. It is the discriminator that lets automated
 	// cleanup (GC/PurgeJobs) keep such a meta as veto evidence WITHOUT keeping every identity-less legacy
-	// meta (which lacks this field → false, preserving the GC contract for pre-change jobs). recordChildIdentity clears
+	// meta (which lacks this field → false, preserving the GC contract for legacy jobs). recordChildIdentity clears
 	// it in the same write that stamps ChildPID; a REAPED terminal finalize (runClaude returned → child
 	// provably not running) also clears it — and zeroes the engine-proxy PID — so a cmd.Start failure
 	// can't strand a false pending veto that force-keeps the meta forever.

--- a/internal/subagent/leaf_liveness_test.go
+++ b/internal/subagent/leaf_liveness_test.go
@@ -1,0 +1,1021 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/pinned"
+)
+
+// writeLeafMeta seeds a member job meta, optionally with a cached terminal result (which the
+// identity-first predicate must IGNORE for a sync leaf with a recorded child).
+func writeLeafMeta(t *testing.T, m jobMeta, terminal bool) {
+	t.Helper()
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if m.Status == "" {
+		m.Status = "running"
+	}
+	if m.StartedAt == "" {
+		m.StartedAt = "2026-01-01T00:00:00Z"
+	}
+	if err := writeMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if terminal {
+		if err := os.WriteFile(filepath.Join(dir, m.JobID+".result.json"), []byte(`{"ok":false,"status":"failed"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestLeafProcessMayBeAlive: the per-leaf classifier, IDENTITY-first (it never reads the result cache,
+// so a synthesized failVanished can't fool it). meta.PID is the ENGINE for a sync leaf → its child
+// pid+token is the authority; a background leaf's meta.PID IS the child; a held-premark orphan is
+// decided by its recorded child, not the PID-0 fallback.
+func TestLeafProcessMayBeAlive(t *testing.T) {
+	self := os.Getpid()
+	const dead = 0x7ffffffe
+	origPS := procStartFn
+	origArgv := hasArgvIntrospection
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	hasArgvIntrospection = false // background cases: let processAlive degrade to pid+token (no argv marker)
+	t.Cleanup(func() { procStartFn = origPS; hasArgvIntrospection = origArgv })
+
+	engine := self // sync meta.PID is the engine
+	cases := []struct {
+		name string
+		meta jobMeta
+		want bool
+	}{
+		{"sync, live child", jobMeta{PID: engine, ChildPID: self, ChildProcStart: "tok"}, true},
+		{"held premark, live child (orphan window)", jobMeta{PID: 0, Status: "held", ChildPID: self, ChildProcStart: "tok"}, true},
+		{"held premark, dead child", jobMeta{PID: 0, Status: "held", ChildPID: dead}, false},
+		{"held premark, identity PENDING (no child)", jobMeta{PID: 0, Status: "held", ChildIdentityPending: true}, true}, // r25: PID 0 says nothing about the started child
+		{"held premark, NON-pending legacy (no child)", jobMeta{PID: 0, Status: "held"}, false},                          // legacy behavior unchanged
+		{"sync, dead child", jobMeta{PID: engine, ChildPID: dead}, false},
+		{"sync, recycled child (alive pid, token mismatch)", jobMeta{PID: engine, ChildPID: self, ChildProcStart: "stale"}, false},
+		{"sync, no child identity, execed", jobMeta{PID: engine}, true},
+		{"queued leaf (pid 0, no child)", jobMeta{PID: 0}, false},
+		{"background, live pid + matching token", jobMeta{PID: self, SettingsPath: "/p", ProcStart: "tok"}, true},
+		{"background, dead pid", jobMeta{PID: dead, SettingsPath: "/p", ProcStart: "tok"}, false},
+	}
+	for _, c := range cases {
+		if got := leafProcessMayBeAlive(c.meta); got != c.want {
+			t.Errorf("%s: leafProcessMayBeAlive = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestSegmentReclaimVerdicts: ownership is SEGMENT-level (ids.WorktreeSegment). A path-safe dead +
+// leaf-free owner is a Reclaimer; any owner — path-safe or a colliding non-path-safe twin — that is
+// alive/unverifiable or leaf-bearing VETOES; a lone non-path-safe dead owner reclaims nothing.
+func TestSegmentReclaimVerdicts(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	const dead = 0x7ffffffe
+
+	writeRunForTest(t, WorkflowRun{RunID: "solo", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: dead})  // dead path-safe, no leaf
+	writeRunForTest(t, WorkflowRun{RunID: "leafy", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: dead}) // dead but a live orphan
+	writeLeafMeta(t, jobMeta{JobID: "lj", RunID: "leafy", PID: self, ChildPID: self, ChildProcStart: "tok"}, false)
+	writeRunForTest(t, WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: dead}) // dead path-safe reclaimer of seg a-b
+	writeRunForTest(t, WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0})    // LIVE non-path-safe twin (seg a-b)
+	writeRunForTest(t, WorkflowRun{RunID: "x.y", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: dead}) // lone dead non-path-safe (seg x-y)
+
+	v, ok := SegmentReclaimVerdicts()
+	if !ok {
+		t.Fatal("SegmentReclaimVerdicts scan failed")
+	}
+	check := func(seg string, wantReclaimer, wantVetoed bool) {
+		if got := v[seg]; got.Reclaimer != wantReclaimer || got.Vetoed != wantVetoed {
+			t.Errorf("seg %q = %+v, want {Reclaimer:%v Vetoed:%v}", seg, got, wantReclaimer, wantVetoed)
+		}
+	}
+	check("solo", true, false)  // removable
+	check("leafy", false, true) // live leaf → vetoed
+	check("a-b", true, true)    // dead a-b (reclaimer) + LIVE a.b (veto) → NOT removable (the r13 fix)
+	check("x-y", false, false)  // lone non-path-safe dead → no path-safe reclaimer → leak-only
+}
+
+// TestRecordChildIdentity: the sync-leaf child recorder stamps ChildPID + ChildProcStart on a running
+// meta AND on a HELD one (the hold premark precedes the child kill — an orphan in that window needs the
+// identity), preserving Status/PID; and the attempt guard rejects a stale write across a restart.
+func TestRecordChildIdentity(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "child-tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// A running meta (attempt 1) → the child identity is stamped.
+	if err := writeMeta(dir, jobMeta{JobID: "j1", PID: os.Getpid(), RunID: "r", Status: "running", Attempt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	recordChildIdentity("j1", 4242, 1)
+	if m, _ := readMeta(dir, "j1"); m.ChildPID != 4242 || m.ChildProcStart != "child-tok" {
+		t.Errorf("recordChildIdentity must set ChildPID/ChildProcStart on a running meta, got %d/%q", m.ChildPID, m.ChildProcStart)
+	}
+
+	// A HELD meta (the premark window) → the identity IS written, preserving the held status + PID 0.
+	if err := writeMeta(dir, jobMeta{JobID: "j2", PID: 0, RunID: "r", Status: "held", Attempt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	recordChildIdentity("j2", 4242, 1)
+	if m, _ := readMeta(dir, "j2"); m.ChildPID != 4242 || m.Status != "held" || m.PID != 0 {
+		t.Errorf("recordChildIdentity must stamp a held meta (identity protects the orphan) while preserving Status/PID, got ChildPID=%d Status=%q PID=%d", m.ChildPID, m.Status, m.PID)
+	}
+
+	// A stale attempt: the meta is now attempt 2 (restarted) → an attempt-1 write is ignored.
+	if err := writeMeta(dir, jobMeta{JobID: "j3", PID: os.Getpid(), RunID: "r", Status: "running", Attempt: 2}); err != nil {
+		t.Fatal(err)
+	}
+	recordChildIdentity("j3", 4242, 1)
+	if m, _ := readMeta(dir, "j3"); m.ChildPID != 0 {
+		t.Error("recordChildIdentity must ignore a stale attempt-1 write on an attempt-2 (restarted) meta")
+	}
+}
+
+// TestPurgeRunRefusesUnderLiveLeaf: PurgeRun REFUSES (never half-deletes) while a member leaf's child
+// is alive — the record, member jobs, AND workdir all survive so the ownership + identity evidence
+// stays intact — with a retryable error; once the child dies a retried purge fully removes everything.
+// A held-premark orphan is refused the same way. No live leaf → it purges.
+func TestPurgeRunRefusesUnderLiveLeaf(t *testing.T) {
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	assertIntact := func(t *testing.T, runID, jobID, wtDir string) {
+		t.Helper()
+		if _, rerr := ReadRun(runID); rerr != nil {
+			t.Error("the run record must survive a refused purge")
+		}
+		if dir, derr := jobsDir(); derr == nil {
+			if _, merr := readMeta(dir, jobID); merr != nil {
+				t.Error("the member job meta must survive a refused purge")
+			}
+		}
+		if _, err := os.Stat(wtDir); err != nil {
+			t.Errorf("the workdir must survive a refused purge (err=%v)", err)
+		}
+	}
+
+	t.Run("live child → refused, nothing deleted; retried after death → fully purged", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "purge-live-leaf"
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+		writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: runID, PID: self, ChildPID: self, ChildProcStart: "tok"}, true) // live child + synthesized terminal
+
+		if err := PurgeRun(runID); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+			t.Errorf("PurgeRun under a live leaf must be refused with a retryable error, got %v", err)
+		}
+		assertIntact(t, runID, "leaf1", wtDir)
+
+		// The orphan exits → a retried purge fully removes record + workdir.
+		writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: runID, PID: self, ChildPID: 0x7ffffffe}, false) // dead child
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("retried PurgeRun after the child died: %v", err)
+		}
+		if _, rerr := ReadRun(runID); rerr == nil {
+			t.Error("the record must be gone after the retried purge")
+		}
+		if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+			t.Errorf("the workdir must be gone after the retried purge (err=%v)", err)
+		}
+	})
+
+	t.Run("held-premark orphan (live child) → refused, nothing deleted", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "purge-held-leaf"
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+		writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: runID, PID: 0, Status: "held", ChildPID: self, ChildProcStart: "tok"}, false) // {held, PID 0, live child}
+
+		if err := PurgeRun(runID); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+			t.Errorf("PurgeRun under a held-premark orphan must be refused, got %v", err)
+		}
+		assertIntact(t, runID, "leaf1", wtDir)
+	})
+
+	t.Run("no live leaf → purges", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "purge-dead-leaf"
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+		writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: runID, PID: self, ChildPID: 0x7ffffffe}, false) // dead child
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun: %v", err)
+		}
+		if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+			t.Errorf("PurgeRun must remove the worktree temp when no leaf is alive (err=%v)", err)
+		}
+	})
+}
+
+// TestPruneRunsContinuesPastLiveLeaf: PruneRuns tolerates a per-run PurgeRun refusal — a run with a
+// live orphan leaf is spared (PurgeRun refuses) while a plain dead run is reaped; the sweep never aborts.
+func TestPruneRunsContinuesPastLiveLeaf(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	seedWorktreeTemp(t, "live-leaf-run") // an isolation worktree the orphan could be using → refusal applies
+	writeRunForTest(t, WorkflowRun{RunID: "live-leaf-run", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+	writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: "live-leaf-run", PID: self, ChildPID: self, ChildProcStart: "tok"}, false) // live orphan
+	writeRunForTest(t, WorkflowRun{RunID: "plain-dead-run", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+
+	removed, err := PruneRuns()
+	if err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("PruneRuns removed = %d, want 1 (plain dead reaped; live-leaf run spared by refusal)", removed)
+	}
+	if _, rerr := ReadRun("live-leaf-run"); rerr != nil {
+		t.Error("PruneRuns must spare a run with a live orphan leaf (PurgeRun refused, loop continued)")
+	}
+	if _, rerr := ReadRun("plain-dead-run"); rerr == nil {
+		t.Error("PruneRuns must still reap a plain dead run")
+	}
+}
+
+// TestPurgeRunRefusesNonPathSafeLiveMember (codex r18): PurgeRun("a.b") is a valid NON-path-safe id
+// that bypasses the path-safe segment gate, so it must still refuse — id-shape-independent — on its OWN
+// live child-identified member, else it deletes the veto for segment a-b and a dead path-safe a-b
+// reclaimer deletes the live child's workdir. Kill the child → PurgeRun("a.b") succeeds + reclaimable.
+func TestPurgeRunRefusesNonPathSafeLiveMember(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	writeRunForTest(t, WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}) // non-path-safe own record
+	writeRunForTest(t, WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}) // dead path-safe reclaimer (seg a-b)
+	writeLeafMeta(t, jobMeta{JobID: "ablj", RunID: "a.b", PID: self, ChildPID: self, ChildProcStart: "tok"}, false)            // LIVE a.b member
+
+	if err := PurgeRun("a.b"); err == nil || !strings.Contains(err.Error(), "still running") {
+		t.Errorf("PurgeRun(a.b) must refuse while its member leaf is live, got %v", err)
+	}
+	dir, _ := jobsDir()
+	if _, merr := readMeta(dir, "ablj"); merr != nil {
+		t.Error("the live member meta must survive the refused purge (veto evidence)")
+	}
+	if _, rerr := ReadRun("a.b"); rerr != nil {
+		t.Error("the a.b record must survive the refused purge")
+	}
+	if v, ok := SegmentReclaimVerdicts(); !ok || !v["a-b"].Vetoed {
+		t.Errorf("segment a-b must still be vetoed by the live a.b member, got %+v ok=%v", v["a-b"], ok)
+	}
+
+	// The child dies → the segment is reclaimable and PurgeRun("a.b") succeeds.
+	writeLeafMeta(t, jobMeta{JobID: "ablj", RunID: "a.b", PID: self, ChildPID: 0x7ffffffe}, false)
+	if v, ok := SegmentReclaimVerdicts(); !ok || v["a-b"].Vetoed {
+		t.Errorf("once the a.b member is dead, segment a-b must not be vetoed, got %+v ok=%v", v["a-b"], ok)
+	}
+	if err := PurgeRun("a.b"); err != nil {
+		t.Fatalf("PurgeRun(a.b) after the child died: %v", err)
+	}
+	if _, rerr := ReadRun("a.b"); rerr == nil {
+		t.Error("PurgeRun(a.b) must remove the record once the member is dead")
+	}
+}
+
+// TestPurgeRunRefusesUnderCollidingSegment (the codex r13 scenario): a dead PATH-SAFE "a-b" shares
+// segment "a-b" with a LIVE non-path-safe twin "a.b". PurgeRun("a-b") must NOT RemoveAll the shared
+// segment (where a.b's workdirs live) — it refuses, consistent with the r12 refusal shape — until the
+// colliding owner exits, then it purges.
+func TestPurgeRunRefusesUnderCollidingSegment(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	wtDir := seedWorktreeTemp(t, "a-b")                                                                                        // the shared segment dir a-b's RemoveAll would delete
+	writeRunForTest(t, WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}) // dead path-safe
+	writeRunForTest(t, WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0})          // LIVE colliding twin
+
+	if err := PurgeRun("a-b"); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+		t.Errorf("PurgeRun(a-b) must be refused while the colliding a.b is live, got %v", err)
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("the shared segment must survive (a.b's live workdirs), err=%v", err)
+	}
+
+	// The colliding twin exits → the segment becomes reclaimable → a-b purges.
+	writeRunForTest(t, WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+	if err := PurgeRun("a-b"); err != nil {
+		t.Fatalf("PurgeRun(a-b) after a.b died: %v", err)
+	}
+	if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+		t.Errorf("the segment must be removed once no colliding owner is live, err=%v", err)
+	}
+}
+
+// TestCorruptMemberMetaFailsClosed (codex r15): an unreadable/partial member meta makes the run's
+// leaf state unknowable, so runLeafScan fails CLOSED — SegmentReclaimVerdicts returns !ok, PurgeRun
+// refuses, and the worktree survives (never deleted under a possibly-live orphan whose meta was torn).
+func TestCorruptMemberMetaFailsClosed(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRunForTest(t, WorkflowRun{RunID: "corrupt-run", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+	writeLeafMeta(t, jobMeta{JobID: "good", RunID: "corrupt-run", PID: self, ChildPID: self, ChildProcStart: "tok"}, false) // a valid live-child member
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte(`{"job_id":"bad","run_id":`), 0o600); err != nil {        // truncated
+		t.Fatal(err)
+	}
+
+	if _, ok := SegmentReclaimVerdicts(); ok {
+		t.Error("a corrupt member meta must make SegmentReclaimVerdicts fail closed (ok=false)")
+	}
+	wtDir := seedWorktreeTemp(t, "corrupt-run")
+	if err := PurgeRun("corrupt-run"); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+		t.Errorf("PurgeRun must refuse when the leaf scan can't be trusted, got %v", err)
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("the worktree must survive the refused purge, err=%v", err)
+	}
+}
+
+// TestWriteMetaAtomicNoTornReads (codex r15): the meta is load-bearing death evidence, so writeMeta
+// must be atomic (temp+rename) — a concurrent reader never sees a partial file. A large payload widens
+// the write window so a NON-atomic (plain truncate+write) meta would surface a torn (parse-error) read.
+func TestWriteMetaAtomicNoTornReads(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	base := jobMeta{JobID: "big", RunID: "r", Status: "running", Label: strings.Repeat("x", 64<<10)}
+	if err := writeMeta(dir, base); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = writeMeta(dir, base)
+		}
+	}()
+	var tornErr error
+	for i := 0; i < 600 && tornErr == nil; i++ {
+		if _, rerr := readMeta(dir, "big"); rerr != nil {
+			tornErr = rerr
+		}
+	}
+	close(stop)
+	wg.Wait()
+	if tornErr != nil {
+		t.Errorf("readMeta saw a TORN write — writeMeta is not atomic: %v", tornErr)
+	}
+}
+
+// TestPruneRunsSparesLiveDetached (codex r20 correction): PruneRuns is BULK cleanup and never
+// auto-stops — a verifiably-live detached run (DetachedLive) is SPARED (isLiveOrUnverifiable's tri-state
+// arm, behavior-preserving vs the old EngineAlive arm), while a plainly-dead one is reaped. Uses the
+// test's own pid — safe because a spared run is never PurgeRun'd, so nothing is reaped.
+func TestPruneRunsSparesLiveDetached(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origArgv := reuseGuardArgv
+	reuseGuardArgv = func(int) ([]string, bool) {
+		return []string{"cc-fleet", "workflow", "run", "--run-id", "live", "s.js"}, true // matches → DetachedLive
+	}
+	t.Cleanup(func() { reuseGuardArgv = origArgv })
+
+	if got := ClassifyDetachedEngine(WorkflowRun{RunID: "live", EnginePID: self}); got != DetachedLive {
+		t.Fatalf("setup: expected DetachedLive, got %v", got)
+	}
+	writeRunForTest(t, WorkflowRun{RunID: "live", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self})
+	writeRunForTest(t, WorkflowRun{RunID: "gone", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+
+	removed, err := PruneRuns()
+	if err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("PruneRuns removed=%d, want 1 (dead reaped; live spared)", removed)
+	}
+	if _, rerr := ReadRun("live"); rerr != nil {
+		t.Error("PruneRuns must spare a verifiably-live detached run (never auto-stops)")
+	}
+	if _, rerr := ReadRun("gone"); rerr == nil {
+		t.Error("PruneRuns must reap a plainly-dead detached run")
+	}
+}
+
+// TestGCReapsRunThroughPurgeRunNoStrand (codex r20): GC's aged-run removal routes through PurgeRun, so
+// a dead run + a dead-child member + a leaked workdir (all TTL-expired) is reaped with the workdir
+// removed WITH the manifest (PurgeRun's ordered, physical-snapshot cleanup) — NO unknown-present strand.
+// The job-meta pass reaping the dead member BEFORE the run's PurgeRun is immaterial (PurgeRun removes
+// the segment by physical snapshot, not by member metas), and the standalone-jobs pass is untouched.
+func TestGCReapsRunThroughPurgeRunNoStrand(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const old = "2000-01-01T00:00:00Z"
+	const runID = "gcrun"
+	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	t.Cleanup(func() { _ = os.RemoveAll(segDir) })
+	if err := os.MkdirAll(filepath.Join(segDir, "wt"), 0o700); err != nil { // the leaked workdir
+		t.Fatal(err)
+	}
+
+	writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: old, Status: "stopped", EnginePID: 0x7ffffffe}) // provably dead, aged
+	if err := writeMeta(dir, jobMeta{JobID: "m", RunID: runID, PID: os.Getpid(), ChildPID: 0x7ffffffe, Status: "running", StartedAt: old}); err != nil {
+		t.Fatal(err) // dead-child member
+	}
+	if err := os.WriteFile(filepath.Join(dir, "m.result.json"), []byte(`{"ok":false}`), 0o600); err != nil {
+		t.Fatal(err) // terminal cache → the job-meta pass reaps it (dead child, aged)
+	}
+	// A LIVE standalone job (RunID "") — the standalone-jobs pass is untouched, so it survives.
+	if err := writeMeta(dir, jobMeta{JobID: "solo", RunID: "", PID: os.Getpid(), Status: "running", StartedAt: old}); err != nil {
+		t.Fatal(err)
+	}
+
+	if res := GC(time.Hour); !res.OK {
+		t.Fatalf("GC: %+v", res)
+	}
+	if _, serr := os.Stat(segDir); !os.IsNotExist(serr) {
+		t.Errorf("GC must remove the leaked workdir WITH the manifest (no unknown-present strand), stat err=%v", serr)
+	}
+	if _, rerr := ReadRun(runID); rerr == nil {
+		t.Error("GC must remove the aged dead run's manifest")
+	}
+	if _, merr := readMeta(dir, "solo"); merr != nil {
+		t.Error("GC's standalone-jobs pass must be untouched — a live standalone job survives")
+	}
+}
+
+// TestPurgeJobsReapsRunThroughPurgeRunNoStrand (codex r21): PurgeJobs's aged-run removal (the
+// uninstall/purge sweep) routes through PurgeRun, so a dead run + a dead-child member + a leaked workdir
+// is reaped with the workdir removed WITH the manifest (no unknown-present strand), while a run with a
+// LIVE-orphan member is kept intact (member pass keeps it → runningRuns → manifest kept).
+func TestPurgeJobsReapsRunThroughPurgeRunNoStrand(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	// Run A: dead + dead-child member (terminal cache) + a leaked workdir → reaped, workdir gone with it.
+	segA := filepath.Join(os.TempDir(), "cc-fleet-worktrees", "runA")
+	t.Cleanup(func() { _ = os.RemoveAll(segA) })
+	if err := os.MkdirAll(filepath.Join(segA, "wt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRunForTest(t, WorkflowRun{RunID: "runA", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+	writeLeafMeta(t, jobMeta{JobID: "ma", RunID: "runA", PID: self, ChildPID: 0x7ffffffe}, true) // dead child + terminal cache
+
+	// Run B: a LIVE-orphan member → kept intact.
+	segB := filepath.Join(os.TempDir(), "cc-fleet-worktrees", "runB")
+	t.Cleanup(func() { _ = os.RemoveAll(segB) })
+	if err := os.MkdirAll(filepath.Join(segB, "wt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRunForTest(t, WorkflowRun{RunID: "runB", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+	writeLeafMeta(t, jobMeta{JobID: "mb", RunID: "runB", PID: self, ChildPID: self, ChildProcStart: "tok"}, false) // LIVE child
+
+	if _, _, _, err := PurgeJobs(); err != nil {
+		t.Fatal(err)
+	}
+	if _, serr := os.Stat(segA); !os.IsNotExist(serr) {
+		t.Errorf("runA's leaked workdir must be removed WITH the record (no strand), stat err=%v", serr)
+	}
+	if _, rerr := ReadRun("runA"); rerr == nil {
+		t.Error("runA's manifest must be removed")
+	}
+	if _, rerr := ReadRun("runB"); rerr != nil {
+		t.Error("runB (live-orphan) must be kept intact")
+	}
+	if _, serr := os.Stat(segB); serr != nil {
+		t.Errorf("runB's workdir must survive (live orphan), stat err=%v", serr)
+	}
+}
+
+// TestPurgeJobsKeepsDirWhenRunRefused (codex r22): PurgeJobs's final wholesale RemoveAll must not
+// override a PurgeRun refusal. A LIVE foreground run with NO member job (so `running` alone is empty)
+// is refused by PurgeRun → its manifest SURVIVES and the jobs dir is KEPT. Flip it dead → the refusal
+// clears and the full cleanup (incl. the dir removal) proceeds.
+func TestPurgeJobsKeepsDirWhenRunRefused(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "fg-tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A blind-stopped LIVE foreground run ({stopped, 0, FgAlive}), NO member jobs → PurgeRun refuses it.
+	if err := SaveRun(WorkflowRun{RunID: "fg-live", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: "fg-tok"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, running, perr := PurgeJobs(); perr != nil {
+		t.Fatal(perr)
+	} else if len(running) != 0 {
+		t.Errorf("the bug precondition: with no member JOB, running is empty, got %v", running)
+	}
+	if _, rerr := ReadRun("fg-live"); rerr != nil {
+		t.Error("a refused live-fg run's manifest must SURVIVE PurgeJobs")
+	}
+	if _, serr := os.Stat(dir); os.IsNotExist(serr) {
+		t.Error("PurgeJobs must KEEP the jobs dir when a run was refused (no wholesale RemoveAll)")
+	}
+
+	// Flip the fg identity DEAD (→ FgDead → provably dead) → the refusal clears, full cleanup proceeds.
+	if err := SaveRun(WorkflowRun{RunID: "fg-live", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, perr := PurgeJobs(); perr != nil {
+		t.Fatal(perr)
+	}
+	if _, rerr := ReadRun("fg-live"); rerr == nil {
+		t.Error("a now-dead run must be purged")
+	}
+	if _, serr := os.Stat(dir); !os.IsNotExist(serr) {
+		t.Error("with nothing surviving, PurgeJobs must remove the jobs dir (full cleanup)")
+	}
+}
+
+// TestUnverifiableDetachedEngineSparesSegment (codex r19): an alive-but-UNVERIFIABLE detached engine
+// (recorded token, but neither argv nor its start token readable — EPERM/hardened) must NOT read as
+// provably dead, so its worktree segment is spared (Vetoed, not Reclaimer). Once the token becomes
+// readable + MISMATCHED (recycled), it reads dead and the segment becomes reclaimable. Covers both the
+// detached-manifest path (RunEngineProvablyNotLive) and the verdict map (SegmentReclaimVerdicts).
+func TestUnverifiableDetachedEngineSparesSegment(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origArgv := reuseGuardArgv
+	origPS := procStartFn
+	reuseGuardArgv = func(int) ([]string, bool) { return nil, false } // argv unreadable
+	procStartFn = func(int) (string, bool) { return "", false }       // token unreadable
+	t.Cleanup(func() { reuseGuardArgv = origArgv; procStartFn = origPS })
+
+	run := WorkflowRun{RunID: "det", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self, EngineProcStart: "tok"}
+	writeRunForTest(t, run)
+
+	if RunEngineProvablyNotLive(run) {
+		t.Error("an unverifiable-alive detached engine must NOT be provably dead (was reclaiming under a live engine)")
+	}
+	if v, ok := SegmentReclaimVerdicts(); !ok || !v["det"].Vetoed || v["det"].Reclaimer {
+		t.Errorf("an unverifiable detached run must VETO its segment (never Reclaimer), got %+v ok=%v", v["det"], ok)
+	}
+
+	// The token becomes readable + MISMATCHED → recycled → provably dead → reclaimable.
+	procStartFn = func(int) (string, bool) { return "different", true }
+	if !RunEngineProvablyNotLive(run) {
+		t.Error("a recycled detached pid (readable token mismatch) must be provably dead")
+	}
+	if v, ok := SegmentReclaimVerdicts(); !ok || v["det"].Vetoed || !v["det"].Reclaimer {
+		t.Errorf("once recycled-dead, segment det must be reclaimable (Reclaimer, not Vetoed), got %+v ok=%v", v["det"], ok)
+	}
+}
+
+// TestUnverifiableDetachedRefusedByPurgeAndPrune (codex r20): a blind-stop collapse can leave
+// {stopped, retained pid alive, token} — an UNVERIFIABLE detached engine (DetachedUnknown). Because it
+// is not PROVABLY dead, PurgeRun refuses it (mirroring FgAlive), PruneRuns spares it, and — since the
+// same DetachedUnknown is what resumeBlockedReason refuses on (workflow) — resume is refused too. Once
+// the pid recycles (token readable + mismatch → DetachedDead) everything proceeds.
+func TestUnverifiableDetachedRefusedByPurgeAndPrune(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origArgv := reuseGuardArgv
+	origPS := procStartFn
+	reuseGuardArgv = func(int) ([]string, bool) { return nil, false } // argv unreadable
+	procStartFn = func(int) (string, bool) { return "", false }       // token unreadable
+	t.Cleanup(func() { reuseGuardArgv = origArgv; procStartFn = origPS })
+
+	run := WorkflowRun{RunID: "det", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: self, EngineProcStart: "tok"}
+	// The shape resumeBlockedReason (workflow) refuses on: an alive-but-unverifiable detached pid.
+	if got := ClassifyDetachedEngine(run); got != DetachedUnknown {
+		t.Fatalf("setup: expected DetachedUnknown (the resume-refused shape), got %v", got)
+	}
+	writeRunForTest(t, run)
+
+	// PruneRuns' spare decision (its outcome is doubly protected by PurgeRun's refusal, so assert it directly too).
+	if !isLiveOrUnverifiable(run) {
+		t.Error("isLiveOrUnverifiable must spare an unverifiable detached run")
+	}
+	if err := PurgeRun("det"); err == nil || !strings.Contains(err.Error(), "still running") {
+		t.Errorf("PurgeRun must refuse an unverifiable detached run, got %v", err)
+	}
+	if _, rerr := ReadRun("det"); rerr != nil {
+		t.Error("the refused run must survive PurgeRun")
+	}
+	if removed, err := PruneRuns(); err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	} else if removed != 0 {
+		t.Errorf("PruneRuns must spare an unverifiable detached run, removed=%d", removed)
+	}
+	if _, rerr := ReadRun("det"); rerr != nil {
+		t.Error("PruneRuns must spare (not delete) the unverifiable detached run")
+	}
+
+	// The pid recycles: token readable + MISMATCHED → DetachedDead → prune reaps it (via PurgeRun).
+	procStartFn = func(int) (string, bool) { return "different", true }
+	if removed, err := PruneRuns(); err != nil {
+		t.Fatalf("PruneRuns after recycle: %v", err)
+	} else if removed != 1 {
+		t.Errorf("PruneRuns must reap the run once its pid reads DetachedDead, removed=%d", removed)
+	}
+	if _, rerr := ReadRun("det"); rerr == nil {
+		t.Error("the recycled-dead run must be gone after PruneRuns")
+	}
+}
+
+// TestPendingIdentityKeptByAutomatedCleanup (codex r24): a sync member still in the
+// cmd.Start→recordChildIdentity window (ChildIdentityPending, no ChildPID) is a possibly-live orphan the
+// read-side fail-safe already vetoes — so AUTOMATED cleanup (GC/PurgeJobs) must KEEP it (else it reaps
+// the veto and the chokepoint deletes the workdir). A NORMAL dead-child member (pending cleared) is
+// still reaped (r17 contract). The EXPLICIT DeleteJob on the pending job PROCEEDS (record-only recovery).
+func TestPendingIdentityKeptByAutomatedCleanup(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const old = "2000-01-01T00:00:00Z"
+	seed := func(jobID, runID string, childPID int, pending bool) {
+		if err := writeMeta(dir, jobMeta{JobID: jobID, RunID: runID, PID: self, ChildPID: childPID, ChildIdentityPending: pending, Status: "running", StartedAt: old}); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, jobID+".result.json"), []byte(`{"ok":false}`), 0o600); err != nil {
+			t.Fatal(err) // synthesized terminal — must NOT let a pending member be reaped
+		}
+	}
+
+	// GC: a PENDING member survives; a NORMAL dead-child member is reaped (r17 unchanged).
+	seed("pend", "a-b", 0, true)
+	seed("norm", "c-d", 0x7ffffffe, false)
+	if res := GC(time.Hour); !res.OK {
+		t.Fatalf("GC: %+v", res)
+	}
+	if _, merr := readMeta(dir, "pend"); merr != nil {
+		t.Error("GC must PRESERVE a pending-identity member (Start-window veto evidence)")
+	}
+	if _, merr := readMeta(dir, "norm"); merr == nil {
+		t.Error("GC must still reap a normal dead-child member (r17 contract unchanged)")
+	}
+
+	// Point 3: the pending member vetoes its segment (read-side fail-safe → projection).
+	if v, ok := SegmentReclaimVerdicts(); !ok || !v["a-b"].Vetoed {
+		t.Errorf("a pending member must VETO its segment (read-side), got %+v ok=%v", v["a-b"], ok)
+	}
+
+	// PurgeJobs: the pending member is kept + reported running (which keeps its run's manifest too).
+	seed("pend2", "e-f", 0, true)
+	_, _, running, perr := PurgeJobs()
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	if _, merr := readMeta(dir, "pend2"); merr != nil {
+		t.Error("PurgeJobs must PRESERVE a pending-identity member")
+	}
+	pend2Running := false
+	for _, r := range running {
+		if r == "pend2" {
+			pend2Running = true
+		}
+	}
+	if !pend2Running {
+		t.Errorf("PurgeJobs must report the pending member as running, got %v", running)
+	}
+
+	// Point 4: an EXPLICIT DeleteJob on the pending job PROCEEDS (record-only recovery escape).
+	if err := DeleteJob("pend2"); err != nil {
+		t.Errorf("DeleteJob on a PENDING job must proceed (recovery escape), got %v", err)
+	}
+	if _, merr := readMeta(dir, "pend2"); merr == nil {
+		t.Error("DeleteJob must remove the pending member's meta")
+	}
+}
+
+// TestGCPreservesLiveOrphanVetoEvidence (codex r17): the recency GC must NOT delete a live orphan's
+// member meta — even TTL-expired, with a SYNTHESIZED terminal cache and a dead meta.PID (engine proxy)
+// — because it is the veto evidence its worktree segment relies on. Once the child reads dead, GC reaps
+// it and the segment becomes reclaimable.
+func TestGCPreservesLiveOrphanVetoEvidence(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const old = "2000-01-01T00:00:00Z" // far past the TTL
+	if err := writeMeta(dir, jobMeta{JobID: "orphan", RunID: "a.b", PID: self, ChildPID: self, ChildProcStart: "tok", Status: "running", StartedAt: old}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orphan.result.json"), []byte(`{"ok":false,"status":"failed"}`), 0o600); err != nil { // synthesized terminal
+		t.Fatal(err)
+	}
+
+	if res := GC(time.Hour); !res.OK {
+		t.Fatalf("GC: %+v", res)
+	}
+	if _, rerr := readMeta(dir, "orphan"); rerr != nil {
+		t.Error("GC must PRESERVE a live-orphan member meta despite TTL + synthesized terminal (veto evidence)")
+	}
+	if v, ok := SegmentReclaimVerdicts(); !ok || !v["a-b"].Vetoed {
+		t.Errorf("the preserved live-orphan meta must still veto segment a-b, got %+v ok=%v", v["a-b"], ok)
+	}
+
+	// The child dies → GC reaps the (now dead) member on the next pass.
+	if err := writeMeta(dir, jobMeta{JobID: "orphan", RunID: "a.b", PID: self, ChildPID: 0x7ffffffe, Status: "running", StartedAt: old}); err != nil {
+		t.Fatal(err)
+	}
+	if res := GC(time.Hour); !res.OK {
+		t.Fatalf("GC 2: %+v", res)
+	}
+	if _, rerr := readMeta(dir, "orphan"); rerr == nil {
+		t.Error("once the child is dead, GC must reap the member meta (TTL-expired + cached terminal)")
+	}
+}
+
+// TestPurgeJobsPreservesLiveOrphan (codex r17 audit): PurgeJobs keeps a live-orphan member (reported
+// running) despite a synthesized terminal cache — the same veto-evidence rule as GC.
+func TestPurgeJobsPreservesLiveOrphan(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMeta(dir, jobMeta{JobID: "orphan", RunID: "a.b", PID: self, ChildPID: self, ChildProcStart: "tok", Status: "running", StartedAt: "2026-01-01T00:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orphan.result.json"), []byte(`{"ok":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, running, perr := PurgeJobs()
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	if _, rerr := readMeta(dir, "orphan"); rerr != nil {
+		t.Error("PurgeJobs must PRESERVE a live-orphan member meta")
+	}
+	found := false
+	for _, id := range running {
+		if id == "orphan" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("PurgeJobs must report the preserved live orphan as running, got %v", running)
+	}
+}
+
+// TestDeleteJobRefusesLiveOrphan (codex r17 audit): the board's per-record delete refuses a live-orphan
+// member (retryable), mirroring PurgeRun; once the child dies it deletes.
+func TestDeleteJobRefusesLiveOrphan(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMeta(dir, jobMeta{JobID: "orphan", RunID: "a.b", PID: self, ChildPID: self, ChildProcStart: "tok", Status: "running", StartedAt: "2026-01-01T00:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteJob("orphan"); err == nil || !strings.Contains(err.Error(), "still running") {
+		t.Errorf("DeleteJob must refuse a live-orphan member, got %v", err)
+	}
+	if _, rerr := readMeta(dir, "orphan"); rerr != nil {
+		t.Error("the refused member meta must survive")
+	}
+	if err := writeMeta(dir, jobMeta{JobID: "orphan", RunID: "a.b", PID: self, ChildPID: 0x7ffffffe, Status: "running", StartedAt: "2026-01-01T00:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteJob("orphan"); err != nil {
+		t.Fatalf("DeleteJob after the child died: %v", err)
+	}
+}
+
+// TestCorruptManifestLiveLeafVetoes (codex r16): ListRuns silently skips a corrupt run manifest, but a
+// live member leaf's veto stands on its own (its RunID comes from the job meta, not the manifest). So a
+// live colliding owner (a.b whose runs/a.b.json is truncated) still vetoes segment a-b via the leaf
+// projection — a dead path-safe a-b can't reclaim under it. Kill the member → reclaimable again.
+func TestCorruptManifestLiveLeafVetoes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	writeRunForTest(t, WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}) // dead path-safe reclaimer, valid manifest
+	writeLeafMeta(t, jobMeta{JobID: "ablj", RunID: "a.b", PID: self, ChildPID: self, ChildProcStart: "tok"}, false)            // LIVE a.b member
+	rd, err := runsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rd, "a.b.json"), []byte(`{"run_id":"a.b","stat`), 0o600); err != nil { // truncated manifest
+		t.Fatal(err)
+	}
+
+	v, ok := SegmentReclaimVerdicts()
+	if !ok {
+		t.Fatal("scan should succeed — the corrupt file is a MANIFEST, not a member meta")
+	}
+	if !v["a-b"].Vetoed {
+		t.Error("a live colliding owner with a CORRUPT manifest must veto segment a-b via the leaf projection")
+	}
+	wtDir := seedWorktreeTemp(t, "a-b")
+	if err := PurgeRun("a-b"); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+		t.Errorf("PurgeRun(a-b) must refuse while the corrupt-manifest a.b is live, got %v", err)
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("the shared segment must survive the refused purge, err=%v", err)
+	}
+
+	// The a.b member dies → the segment is reclaimable again.
+	writeLeafMeta(t, jobMeta{JobID: "ablj", RunID: "a.b", PID: self, ChildPID: 0x7ffffffe}, false)
+	if v2, ok2 := SegmentReclaimVerdicts(); !ok2 || v2["a-b"].Vetoed {
+		t.Errorf("once a.b's member is dead, segment a-b must not be vetoed, got %+v ok=%v", v2["a-b"], ok2)
+	}
+	if err := PurgeRun("a-b"); err != nil {
+		t.Fatalf("PurgeRun(a-b) after the a.b member died: %v", err)
+	}
+}
+
+// TestPurgeRunSnapshotScopedRemoval (codex r14 TOCTOU): PurgeRun removes exactly the workdirs its
+// VERDICT-TIME segment snapshot listed, and os.Remove's the segment dir only if now empty — so a
+// colliding owner's post-snapshot fresh-uuid workdir (unlisted, via the segReadDir seam) SURVIVES,
+// while the snapshot-listed stale one is removed with the record.
+func TestPurgeRunSnapshotScopedRemoval(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	const runID = "snap-run"
+	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	t.Cleanup(func() { _ = os.RemoveAll(segDir) })
+	staleWt := filepath.Join(segDir, "stale-uuid")
+	freshWt := filepath.Join(segDir, "fresh-uuid") // simulates a colliding owner's POST-snapshot creation
+	for _, d := range []string{staleWt, freshWt} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe})
+
+	orig := segReadDir
+	segReadDir = func(d string) ([]os.DirEntry, error) { // the snapshot omits fresh-uuid ("appeared after")
+		es, err := os.ReadDir(d)
+		if err != nil {
+			return nil, err
+		}
+		kept := es[:0]
+		for _, e := range es {
+			if e.Name() != "fresh-uuid" {
+				kept = append(kept, e)
+			}
+		}
+		return kept, nil
+	}
+	t.Cleanup(func() { segReadDir = orig })
+
+	if err := PurgeRun(runID); err != nil {
+		t.Fatalf("PurgeRun: %v", err)
+	}
+	if _, err := os.Stat(staleWt); !os.IsNotExist(err) {
+		t.Error("the snapshot-listed stale workdir must be removed")
+	}
+	if _, err := os.Stat(freshWt); err != nil {
+		t.Errorf("a post-snapshot fresh workdir (unlisted) must SURVIVE, err=%v", err)
+	}
+	if _, err := os.Stat(segDir); err != nil {
+		t.Errorf("the segment dir must survive (not empty) — os.Remove is empty-only, err=%v", err)
+	}
+	if _, rerr := ReadRun(runID); rerr == nil {
+		t.Error("the record must still be deleted")
+	}
+}
+
+// TestClearFinishedThroughPurgeRun (codex r14): ClearFinished routes run deletion through
+// WithRunLock + PurgeRun, so a blind-stopped FgAlive run is REFUSED (skip-and-continue, survives) and
+// a terminal provably-dead run with a leaked worktree is cleared with its workdir removed WITH the
+// record — the unknown-present strand can no longer happen through this door.
+func TestClearFinishedThroughPurgeRun(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	const sess = "sess-1"
+
+	writeRunForTest(t, WorkflowRun{RunID: "fg-live", SessionID: sess, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: "tok"}) // blind-stopped FgAlive
+	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", "term-run")
+	t.Cleanup(func() { _ = os.RemoveAll(segDir) })
+	if err := os.MkdirAll(filepath.Join(segDir, "wt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRunForTest(t, WorkflowRun{RunID: "term-run", SessionID: sess, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}) // terminal + provably dead + leaked worktree
+
+	removed, err := ClearFinished(sess, pinned.Set{})
+	if err != nil {
+		t.Fatalf("ClearFinished: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1 (term-run cleared; fg-live refused)", removed)
+	}
+	if _, rerr := ReadRun("fg-live"); rerr != nil {
+		t.Error("a blind-stopped FgAlive run must survive ClearFinished (PurgeRun refused, loop continued)")
+	}
+	if _, rerr := ReadRun("term-run"); rerr == nil {
+		t.Error("a terminal provably-dead run must be cleared")
+	}
+	if _, err := os.Stat(segDir); !os.IsNotExist(err) {
+		t.Errorf("the cleared run's leaked worktree must be removed WITH the record (no strand), err=%v", err)
+	}
+}

--- a/internal/subagent/leaf_liveness_test.go
+++ b/internal/subagent/leaf_liveness_test.go
@@ -470,7 +470,7 @@ func TestGCReapsRunThroughPurgeRunNoStrand(t *testing.T) {
 	}
 	const old = "2000-01-01T00:00:00Z"
 	const runID = "gcrun"
-	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	segDir := filepath.Join(storeWorktreeDir(t), runID)
 	t.Cleanup(func() { _ = os.RemoveAll(segDir) })
 	if err := os.MkdirAll(filepath.Join(segDir, "wt"), 0o700); err != nil { // the leaked workdir
 		t.Fatal(err)
@@ -515,7 +515,7 @@ func TestPurgeJobsReapsRunThroughPurgeRunNoStrand(t *testing.T) {
 	t.Cleanup(func() { procStartFn = origPS })
 
 	// Run A: dead + dead-child member (terminal cache) + a leaked workdir → reaped, workdir gone with it.
-	segA := filepath.Join(os.TempDir(), "cc-fleet-worktrees", "runA")
+	segA := filepath.Join(storeWorktreeDir(t), "runA")
 	t.Cleanup(func() { _ = os.RemoveAll(segA) })
 	if err := os.MkdirAll(filepath.Join(segA, "wt"), 0o700); err != nil {
 		t.Fatal(err)
@@ -524,7 +524,7 @@ func TestPurgeJobsReapsRunThroughPurgeRunNoStrand(t *testing.T) {
 	writeLeafMeta(t, jobMeta{JobID: "ma", RunID: "runA", PID: self, ChildPID: 0x7ffffffe}, true) // dead child + terminal cache
 
 	// Run B: a LIVE-orphan member → kept intact.
-	segB := filepath.Join(os.TempDir(), "cc-fleet-worktrees", "runB")
+	segB := filepath.Join(storeWorktreeDir(t), "runB")
 	t.Cleanup(func() { _ = os.RemoveAll(segB) })
 	if err := os.MkdirAll(filepath.Join(segB, "wt"), 0o700); err != nil {
 		t.Fatal(err)
@@ -929,6 +929,41 @@ func TestCorruptManifestLiveLeafVetoes(t *testing.T) {
 	}
 }
 
+// TestUnreadableManifestVetoesSegment (codex r32): a colliding owner whose MANIFEST read persistently
+// faults (a sharing violation the retry can't outlast, or a real I/O error) AND that has no member leaf
+// yet — the createWorktree→registration window — must still veto its segment. listRunsForReclaim drops
+// such a manifest from the run set, so without the unreadable-manifest veto the dead path-safe twin
+// ("a-b") would become an UNVETOED reclaimer for the SHARED segment and delete the live owner's workdir
+// under it. The leaf projection can't cover this case: there is no leaf meta to read yet. Distinct from
+// the corrupt-manifest sibling above — a readable-but-corrupt manifest stays deletable; an UNREADABLE
+// one fails closed.
+func TestUnreadableManifestVetoesSegment(t *testing.T) {
+	newReadRetryEnv(t)
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	writeRunForTest(t, WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadEnginePID}) // dead path-safe reclaimer
+	writeRunForTest(t, WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: os.Getpid()})   // colliding owner, no leaf yet
+	injectManifestRead(t, "a.b", -1)                                                                                              // its manifest read persistently faults
+
+	v, ok := SegmentReclaimVerdicts()
+	if !ok {
+		t.Fatal("an unreadable MANIFEST must not fail the whole scan (that is the corrupt-META rule); it vetoes its own segment")
+	}
+	if !v["a-b"].Vetoed {
+		t.Error("a colliding owner with an UNREADABLE manifest and no leaf yet must VETO segment a-b")
+	}
+
+	wtDir := seedWorktreeTemp(t, "a-b")
+	if err := PurgeRun("a-b"); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+		t.Errorf("PurgeRun(a-b) must refuse while a.b's manifest is unreadable, got %v", err)
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("the shared segment must survive the refused purge, err=%v", err)
+	}
+}
+
 // TestPurgeRunSnapshotScopedRemoval (codex r14 TOCTOU): PurgeRun removes exactly the workdirs its
 // VERDICT-TIME segment snapshot listed, and os.Remove's the segment dir only if now empty — so a
 // colliding owner's post-snapshot fresh-uuid workdir (unlisted, via the segReadDir seam) SURVIVES,
@@ -937,7 +972,7 @@ func TestPurgeRunSnapshotScopedRemoval(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	const runID = "snap-run"
-	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	segDir := filepath.Join(storeWorktreeDir(t), runID)
 	t.Cleanup(func() { _ = os.RemoveAll(segDir) })
 	staleWt := filepath.Join(segDir, "stale-uuid")
 	freshWt := filepath.Join(segDir, "fresh-uuid") // simulates a colliding owner's POST-snapshot creation
@@ -995,7 +1030,7 @@ func TestClearFinishedThroughPurgeRun(t *testing.T) {
 	const sess = "sess-1"
 
 	writeRunForTest(t, WorkflowRun{RunID: "fg-live", SessionID: sess, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: self, FgEngineProcStart: "tok"}) // blind-stopped FgAlive
-	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", "term-run")
+	segDir := filepath.Join(storeWorktreeDir(t), "term-run")
 	t.Cleanup(func() { _ = os.RemoveAll(segDir) })
 	if err := os.MkdirAll(filepath.Join(segDir, "wt"), 0o700); err != nil {
 		t.Fatal(err)

--- a/internal/subagent/leaf_liveness_test.go
+++ b/internal/subagent/leaf_liveness_test.go
@@ -106,7 +106,7 @@ func TestSegmentReclaimVerdicts(t *testing.T) {
 	}
 	check("solo", true, false)  // removable
 	check("leafy", false, true) // live leaf → vetoed
-	check("a-b", true, true)    // dead a-b (reclaimer) + LIVE a.b (veto) → NOT removable (the r13 fix)
+	check("a-b", true, true)    // dead a-b (reclaimer) + LIVE a.b (veto) → NOT removable
 	check("x-y", false, false)  // lone non-path-safe dead → no path-safe reclaimer → leak-only
 }
 
@@ -267,7 +267,7 @@ func TestPruneRunsContinuesPastLiveLeaf(t *testing.T) {
 	}
 }
 
-// TestPurgeRunRefusesNonPathSafeLiveMember (codex r18): PurgeRun("a.b") is a valid NON-path-safe id
+// TestPurgeRunRefusesNonPathSafeLiveMember: PurgeRun("a.b") is a valid NON-path-safe id
 // that bypasses the path-safe segment gate, so it must still refuse — id-shape-independent — on its OWN
 // live child-identified member, else it deletes the veto for segment a-b and a dead path-safe a-b
 // reclaimer deletes the live child's workdir. Kill the child → PurgeRun("a.b") succeeds + reclaimable.
@@ -310,9 +310,9 @@ func TestPurgeRunRefusesNonPathSafeLiveMember(t *testing.T) {
 	}
 }
 
-// TestPurgeRunRefusesUnderCollidingSegment (the codex r13 scenario): a dead PATH-SAFE "a-b" shares
+// TestPurgeRunRefusesUnderCollidingSegment: a dead PATH-SAFE "a-b" shares
 // segment "a-b" with a LIVE non-path-safe twin "a.b". PurgeRun("a-b") must NOT RemoveAll the shared
-// segment (where a.b's workdirs live) — it refuses, consistent with the r12 refusal shape — until the
+// segment (where a.b's workdirs live) — it refuses — until the
 // colliding owner exits, then it purges.
 func TestPurgeRunRefusesUnderCollidingSegment(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -338,7 +338,7 @@ func TestPurgeRunRefusesUnderCollidingSegment(t *testing.T) {
 	}
 }
 
-// TestCorruptMemberMetaFailsClosed (codex r15): an unreadable/partial member meta makes the run's
+// TestCorruptMemberMetaFailsClosed: an unreadable/partial member meta makes the run's
 // leaf state unknowable, so runLeafScan fails CLOSED — SegmentReclaimVerdicts returns !ok, PurgeRun
 // refuses, and the worktree survives (never deleted under a possibly-live orphan whose meta was torn).
 func TestCorruptMemberMetaFailsClosed(t *testing.T) {
@@ -374,7 +374,7 @@ func TestCorruptMemberMetaFailsClosed(t *testing.T) {
 	}
 }
 
-// TestWriteMetaAtomicNoTornReads (codex r15): the meta is load-bearing death evidence, so writeMeta
+// TestWriteMetaAtomicNoTornReads: the meta is load-bearing death evidence, so writeMeta
 // must be atomic (temp+rename) — a concurrent reader never sees a partial file. A large payload widens
 // the write window so a NON-atomic (plain truncate+write) meta would surface a torn (parse-error) read.
 func TestWriteMetaAtomicNoTornReads(t *testing.T) {
@@ -418,7 +418,7 @@ func TestWriteMetaAtomicNoTornReads(t *testing.T) {
 	}
 }
 
-// TestPruneRunsSparesLiveDetached (codex r20 correction): PruneRuns is BULK cleanup and never
+// TestPruneRunsSparesLiveDetached: PruneRuns is BULK cleanup and never
 // auto-stops — a verifiably-live detached run (DetachedLive) is SPARED (isLiveOrUnverifiable's tri-state
 // arm, behavior-preserving vs the old EngineAlive arm), while a plainly-dead one is reaped. Uses the
 // test's own pid — safe because a spared run is never PurgeRun'd, so nothing is reaped.
@@ -453,7 +453,7 @@ func TestPruneRunsSparesLiveDetached(t *testing.T) {
 	}
 }
 
-// TestGCReapsRunThroughPurgeRunNoStrand (codex r20): GC's aged-run removal routes through PurgeRun, so
+// TestGCReapsRunThroughPurgeRunNoStrand: GC's aged-run removal routes through PurgeRun, so
 // a dead run + a dead-child member + a leaked workdir (all TTL-expired) is reaped with the workdir
 // removed WITH the manifest (PurgeRun's ordered, physical-snapshot cleanup) — NO unknown-present strand.
 // The job-meta pass reaping the dead member BEFORE the run's PurgeRun is immaterial (PurgeRun removes
@@ -502,7 +502,7 @@ func TestGCReapsRunThroughPurgeRunNoStrand(t *testing.T) {
 	}
 }
 
-// TestPurgeJobsReapsRunThroughPurgeRunNoStrand (codex r21): PurgeJobs's aged-run removal (the
+// TestPurgeJobsReapsRunThroughPurgeRunNoStrand: PurgeJobs's aged-run removal (the
 // uninstall/purge sweep) routes through PurgeRun, so a dead run + a dead-child member + a leaked workdir
 // is reaped with the workdir removed WITH the manifest (no unknown-present strand), while a run with a
 // LIVE-orphan member is kept intact (member pass keeps it → runningRuns → manifest kept).
@@ -549,7 +549,7 @@ func TestPurgeJobsReapsRunThroughPurgeRunNoStrand(t *testing.T) {
 	}
 }
 
-// TestPurgeJobsKeepsDirWhenRunRefused (codex r22): PurgeJobs's final wholesale RemoveAll must not
+// TestPurgeJobsKeepsDirWhenRunRefused: PurgeJobs's final wholesale RemoveAll must not
 // override a PurgeRun refusal. A LIVE foreground run with NO member job (so `running` alone is empty)
 // is refused by PurgeRun → its manifest SURVIVES and the jobs dir is KEPT. Flip it dead → the refusal
 // clears and the full cleanup (incl. the dir removal) proceeds.
@@ -596,7 +596,7 @@ func TestPurgeJobsKeepsDirWhenRunRefused(t *testing.T) {
 	}
 }
 
-// TestUnverifiableDetachedEngineSparesSegment (codex r19): an alive-but-UNVERIFIABLE detached engine
+// TestUnverifiableDetachedEngineSparesSegment: an alive-but-UNVERIFIABLE detached engine
 // (recorded token, but neither argv nor its start token readable — EPERM/hardened) must NOT read as
 // provably dead, so its worktree segment is spared (Vetoed, not Reclaimer). Once the token becomes
 // readable + MISMATCHED (recycled), it reads dead and the segment becomes reclaimable. Covers both the
@@ -631,7 +631,7 @@ func TestUnverifiableDetachedEngineSparesSegment(t *testing.T) {
 	}
 }
 
-// TestUnverifiableDetachedRefusedByPurgeAndPrune (codex r20): a blind-stop collapse can leave
+// TestUnverifiableDetachedRefusedByPurgeAndPrune: a blind-stop collapse can leave
 // {stopped, retained pid alive, token} — an UNVERIFIABLE detached engine (DetachedUnknown). Because it
 // is not PROVABLY dead, PurgeRun refuses it (mirroring FgAlive), PruneRuns spares it, and — since the
 // same DetachedUnknown is what resumeBlockedReason refuses on (workflow) — resume is refused too. Once
@@ -684,11 +684,11 @@ func TestUnverifiableDetachedRefusedByPurgeAndPrune(t *testing.T) {
 	}
 }
 
-// TestPendingIdentityKeptByAutomatedCleanup (codex r24): a sync member still in the
+// TestPendingIdentityKeptByAutomatedCleanup: a sync member still in the
 // cmd.Start→recordChildIdentity window (ChildIdentityPending, no ChildPID) is a possibly-live orphan the
 // read-side fail-safe already vetoes — so AUTOMATED cleanup (GC/PurgeJobs) must KEEP it (else it reaps
 // the veto and the chokepoint deletes the workdir). A NORMAL dead-child member (pending cleared) is
-// still reaped (r17 contract). The EXPLICIT DeleteJob on the pending job PROCEEDS (record-only recovery).
+// still reaped. The EXPLICIT DeleteJob on the pending job PROCEEDS (record-only recovery).
 func TestPendingIdentityKeptByAutomatedCleanup(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
@@ -713,7 +713,7 @@ func TestPendingIdentityKeptByAutomatedCleanup(t *testing.T) {
 		}
 	}
 
-	// GC: a PENDING member survives; a NORMAL dead-child member is reaped (r17 unchanged).
+	// GC: a PENDING member survives; a NORMAL dead-child member is reaped.
 	seed("pend", "a-b", 0, true)
 	seed("norm", "c-d", 0x7ffffffe, false)
 	if res := GC(time.Hour); !res.OK {
@@ -723,7 +723,7 @@ func TestPendingIdentityKeptByAutomatedCleanup(t *testing.T) {
 		t.Error("GC must PRESERVE a pending-identity member (Start-window veto evidence)")
 	}
 	if _, merr := readMeta(dir, "norm"); merr == nil {
-		t.Error("GC must still reap a normal dead-child member (r17 contract unchanged)")
+		t.Error("GC must still reap a normal dead-child member")
 	}
 
 	// Point 3: the pending member vetoes its segment (read-side fail-safe → projection).
@@ -759,7 +759,7 @@ func TestPendingIdentityKeptByAutomatedCleanup(t *testing.T) {
 	}
 }
 
-// TestGCPreservesLiveOrphanVetoEvidence (codex r17): the recency GC must NOT delete a live orphan's
+// TestGCPreservesLiveOrphanVetoEvidence: the recency GC must NOT delete a live orphan's
 // member meta — even TTL-expired, with a SYNTHESIZED terminal cache and a dead meta.PID (engine proxy)
 // — because it is the veto evidence its worktree segment relies on. Once the child reads dead, GC reaps
 // it and the segment becomes reclaimable.
@@ -807,7 +807,7 @@ func TestGCPreservesLiveOrphanVetoEvidence(t *testing.T) {
 	}
 }
 
-// TestPurgeJobsPreservesLiveOrphan (codex r17 audit): PurgeJobs keeps a live-orphan member (reported
+// TestPurgeJobsPreservesLiveOrphan: PurgeJobs keeps a live-orphan member (reported
 // running) despite a synthesized terminal cache — the same veto-evidence rule as GC.
 func TestPurgeJobsPreservesLiveOrphan(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -848,7 +848,7 @@ func TestPurgeJobsPreservesLiveOrphan(t *testing.T) {
 	}
 }
 
-// TestDeleteJobRefusesLiveOrphan (codex r17 audit): the board's per-record delete refuses a live-orphan
+// TestDeleteJobRefusesLiveOrphan: the board's per-record delete refuses a live-orphan
 // member (retryable), mirroring PurgeRun; once the child dies it deletes.
 func TestDeleteJobRefusesLiveOrphan(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -882,7 +882,7 @@ func TestDeleteJobRefusesLiveOrphan(t *testing.T) {
 	}
 }
 
-// TestCorruptManifestLiveLeafVetoes (codex r16): ListRuns silently skips a corrupt run manifest, but a
+// TestCorruptManifestLiveLeafVetoes: ListRuns silently skips a corrupt run manifest, but a
 // live member leaf's veto stands on its own (its RunID comes from the job meta, not the manifest). So a
 // live colliding owner (a.b whose runs/a.b.json is truncated) still vetoes segment a-b via the leaf
 // projection — a dead path-safe a-b can't reclaim under it. Kill the member → reclaimable again.
@@ -929,7 +929,7 @@ func TestCorruptManifestLiveLeafVetoes(t *testing.T) {
 	}
 }
 
-// TestUnreadableManifestVetoesSegment (codex r32): a colliding owner whose MANIFEST read persistently
+// TestUnreadableManifestVetoesSegment: a colliding owner whose MANIFEST read persistently
 // faults (a sharing violation the retry can't outlast, or a real I/O error) AND that has no member leaf
 // yet — the createWorktree→registration window — must still veto its segment. listRunsForReclaim drops
 // such a manifest from the run set, so without the unreadable-manifest veto the dead path-safe twin
@@ -964,7 +964,7 @@ func TestUnreadableManifestVetoesSegment(t *testing.T) {
 	}
 }
 
-// TestPurgeRunSnapshotScopedRemoval (codex r14 TOCTOU): PurgeRun removes exactly the workdirs its
+// TestPurgeRunSnapshotScopedRemoval: PurgeRun removes exactly the workdirs its
 // VERDICT-TIME segment snapshot listed, and os.Remove's the segment dir only if now empty — so a
 // colliding owner's post-snapshot fresh-uuid workdir (unlisted, via the segReadDir seam) SURVIVES,
 // while the snapshot-listed stale one is removed with the record.
@@ -1016,7 +1016,7 @@ func TestPurgeRunSnapshotScopedRemoval(t *testing.T) {
 	}
 }
 
-// TestClearFinishedThroughPurgeRun (codex r14): ClearFinished routes run deletion through
+// TestClearFinishedThroughPurgeRun: ClearFinished routes run deletion through
 // WithRunLock + PurgeRun, so a blind-stopped FgAlive run is REFUSED (skip-and-continue, survives) and
 // a terminal provably-dead run with a leaked worktree is cleared with its workdir removed WITH the
 // record — the unknown-present strand can no longer happen through this door.

--- a/internal/subagent/pending_finalize_test.go
+++ b/internal/subagent/pending_finalize_test.go
@@ -1,0 +1,149 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReapedFinalizeClearsPendingIdentity: a sync member whose cmd.Start FAILED (onStart never ran,
+// so ChildIdentityPending stays set with no ChildPID) finalizes through the REAPED path — runClaude
+// returned, so the child is provably not running. That terminal write must clear the pending stamp AND
+// the engine-proxy PID, so the leaf reads process-free and the keep-rule no longer force-keeps it. The
+// SYNTHETIC finalize (an external reclaimer that can't prove the child dead) must instead PRESERVE the
+// stamp — a crashed engine's orphan may still be live.
+func TestReapedFinalizeClearsPendingIdentity(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+	dir, err := jobsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The pending shape registerSyncJob leaves before recordChildIdentity: engine-proxy PID, RunID set,
+	// pending true, no ChildPID.
+	pending := func(jobID string) jobMeta {
+		return jobMeta{JobID: jobID, RunID: "r", PID: deadEnginePID, ChildIdentityPending: true}
+	}
+
+	t.Run("reaped finalize clears pending + PID", func(t *testing.T) {
+		writeLeafMeta(t, pending("reaped"), false)
+		finalizeSyncJobReaped("reaped", fail(ErrCodeFailed, "spawn failed", "glm", ""))
+
+		m, merr := readMeta(dir, "reaped")
+		if merr != nil {
+			t.Fatalf("readMeta: %v", merr)
+		}
+		if m.ChildIdentityPending {
+			t.Error("a reaped finalize must clear ChildIdentityPending (child provably not running)")
+		}
+		if m.PID != 0 {
+			t.Errorf("a reaped finalize must zero the engine-proxy PID, got %d", m.PID)
+		}
+		if _, serr := os.Stat(filepath.Join(dir, "reaped.result.json")); serr != nil {
+			t.Errorf("the terminal result cache must be written, err=%v", serr)
+		}
+		if leafProcessMayBeAlive(m) {
+			t.Error("a cleared cmd.Start-fails leaf must read process-free")
+		}
+		if isLiveOrPendingOrphanEvidence(m) {
+			t.Error("the keep-rule must no longer force-keep a cleared cmd.Start-fails leaf")
+		}
+	})
+
+	t.Run("synthetic finalize preserves pending (crash veto stands)", func(t *testing.T) {
+		writeLeafMeta(t, pending("synthetic"), false)
+		finalizeSyncJob("synthetic", fail(ErrCodeStopped, "run stopped before the leaf finished", "glm", ""))
+
+		m, merr := readMeta(dir, "synthetic")
+		if merr != nil {
+			t.Fatalf("readMeta: %v", merr)
+		}
+		if !m.ChildIdentityPending || m.PID != deadEnginePID {
+			t.Errorf("a synthetic finalize must preserve the pending stamp + PID, got pending=%v PID=%d", m.ChildIdentityPending, m.PID)
+		}
+		if !leafProcessMayBeAlive(m) || !isLiveOrPendingOrphanEvidence(m) {
+			t.Error("a synthetic-finalized pending member must keep its read-side veto and force-keep evidence")
+		}
+	})
+
+	// A HELD + pending member whose reaped finalize maps to `stopped` (the hold cancelled the attempt):
+	// the terminal cache is SUPPRESSED (no cache under a live hold), but the in-process reap still clears
+	// the false-pending stamp + PID so it can't force-keep the row forever once the hold is released.
+	t.Run("held+stopped reaped finalize clears pending, still suppresses cache", func(t *testing.T) {
+		m := pending("heldstop")
+		m.Status = "held"
+		m.PID = 0 // a hold premark clears PID
+		writeLeafMeta(t, m, false)
+		finalizeSyncJobReaped("heldstop", fail(ErrCodeStopped, "leaf held while the attempt was stopping", "glm", ""))
+
+		got, merr := readMeta(dir, "heldstop")
+		if merr != nil {
+			t.Fatalf("readMeta: %v", merr)
+		}
+		if got.ChildIdentityPending {
+			t.Error("a held+stopped reaped finalize must still clear the false-pending stamp")
+		}
+		if got.Status != "held" {
+			t.Errorf("the row must stay held (a live frame awaiting restart), got %q", got.Status)
+		}
+		if _, serr := os.Stat(filepath.Join(dir, "heldstop.result.json")); serr == nil {
+			t.Error("a hold must still SUPPRESS the terminal result cache")
+		}
+		if isLiveOrPendingOrphanEvidence(got) {
+			t.Error("the keep-rule must no longer force-keep the held row via the pending clause")
+		}
+	})
+}
+
+// TestReapedFinalizeUnblocksWorktreeReclaim: end-to-end, a dead-engine worktree run with a
+// cmd.Start-fails member strands until the member's veto is cleared. After the REAPED finalize the
+// member reads process-free → runLeafScan finds no live leaf → a path-safe PurgeRun proceeds and drops
+// the workdir. The genuine-crash shape (pending, never reaped-finalized) keeps its veto → PurgeRun
+// refuses. Disabling the finalize clear-site reverts the first case to a refusal (the bite check).
+func TestReapedFinalizeUnblocksWorktreeReclaim(t *testing.T) {
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	t.Run("reaped finalize → PurgeRun proceeds", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "pend-reaped-run" // path-safe
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadEnginePID})
+		writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: runID, PID: deadEnginePID, ChildIdentityPending: true}, false)
+
+		// The reaped finalize (cmd.Start failed) clears the stamp; the leaf now reads process-free.
+		finalizeSyncJobReaped("leaf1", fail(ErrCodeFailed, "spawn failed", "glm", ""))
+		if live, ok := runLeafScan(); !ok || live[runID] {
+			t.Fatalf("runLeafScan must report no live leaf after the reaped finalize, live=%v ok=%v", live, ok)
+		}
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun must proceed after the reaped finalize, got %v", err)
+		}
+		if _, serr := os.Stat(wtDir); !os.IsNotExist(serr) {
+			t.Errorf("the workdir must be removed once the cmd.Start-fails veto is cleared, err=%v", serr)
+		}
+	})
+
+	t.Run("genuine crash (never finalized) → PurgeRun refuses", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "pend-crash-run" // path-safe
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadEnginePID})
+		writeLeafMeta(t, jobMeta{JobID: "leaf1", RunID: runID, PID: deadEnginePID, ChildIdentityPending: true}, false)
+
+		if err := PurgeRun(runID); err == nil {
+			t.Error("PurgeRun must refuse while a genuine-crash pending member vetoes the segment")
+		}
+		if _, serr := os.Stat(wtDir); serr != nil {
+			t.Errorf("the refused PurgeRun must leave the workdir, err=%v", serr)
+		}
+	})
+}

--- a/internal/subagent/procstart_guard_test.go
+++ b/internal/subagent/procstart_guard_test.go
@@ -5,35 +5,6 @@ import (
 	"testing"
 )
 
-// TestEngineProcStartMatches covers the start-token engine identity used where
-// argv is unreadable: a matching token positively identifies the engine, a
-// mismatch (recycled pid) rejects it, and an empty token never matches (those
-// manifests keep the argv-only behavior).
-func TestEngineProcStartMatches(t *testing.T) {
-	orig := procStartFn
-	t.Cleanup(func() { procStartFn = orig })
-	self := os.Getpid()
-
-	procStartFn = func(int) (string, bool) { return "tok-1", true }
-	if !engineProcStartMatches(WorkflowRun{EnginePID: self, EngineProcStart: "tok-1"}) {
-		t.Error("a matching start token must identify the engine")
-	}
-	if engineProcStartMatches(WorkflowRun{EnginePID: self, EngineProcStart: "tok-0"}) {
-		t.Error("a mismatched start token (recycled pid) must not match")
-	}
-	if engineProcStartMatches(WorkflowRun{EnginePID: self, EngineProcStart: ""}) {
-		t.Error("an empty recorded token must never match")
-	}
-	if engineProcStartMatches(WorkflowRun{EnginePID: 0, EngineProcStart: "tok-1"}) {
-		t.Error("EnginePID<=0 must never match")
-	}
-
-	procStartFn = func(int) (string, bool) { return "", false }
-	if engineProcStartMatches(WorkflowRun{EnginePID: self, EngineProcStart: "tok-1"}) {
-		t.Error("an unreadable live token must not match")
-	}
-}
-
 // TestEngineAlive_StartToken covers the argv-unavailable branch: a recorded
 // token decides liveness (match → alive, mismatch → gone), and only a
 // token-less manifest keeps the legacy fail-soft-to-alive behavior.
@@ -133,34 +104,5 @@ func TestProcessAlive_GuardComposition(t *testing.T) {
 	procStartFn = func(int) (string, bool) { return "", false }
 	if !processAlive(self, "/p/minimax.json", "tok-1") {
 		t.Error("an unreadable token must fall back to the (matching) argv guard")
-	}
-}
-
-// TestEngineIdentityMatches pins StopRun's kill guard: readable argv alone
-// decides (a token match must not override an argv mismatch); the token decides
-// only where argv is unreadable.
-func TestEngineIdentityMatches(t *testing.T) {
-	origArgv, origStart := reuseGuardArgv, procStartFn
-	t.Cleanup(func() { reuseGuardArgv, procStartFn = origArgv, origStart })
-	self := os.Getpid()
-	run := WorkflowRun{RunID: "r1", EnginePID: self, EngineProcStart: "tok-1"}
-	engineArgv := []string{"cc-fleet", "workflow", "run", "--run-id", "r1", "s.js"}
-	procStartFn = func(int) (string, bool) { return "tok-1", true }
-
-	reuseGuardArgv = func(int) ([]string, bool) { return engineArgv, true }
-	if !engineIdentityMatches(run) {
-		t.Error("matching argv must identify the engine")
-	}
-	reuseGuardArgv = func(int) ([]string, bool) { return []string{"some", "other"}, true }
-	if engineIdentityMatches(run) {
-		t.Error("an argv mismatch must veto even a matching token")
-	}
-	reuseGuardArgv = func(int) ([]string, bool) { return nil, false }
-	if !engineIdentityMatches(run) {
-		t.Error("argv-unreadable must fall back to the (matching) token")
-	}
-	procStartFn = func(int) (string, bool) { return "tok-0", true }
-	if engineIdentityMatches(run) {
-		t.Error("argv-unreadable with a mismatched token must not identify")
 	}
 }

--- a/internal/subagent/purge_livedetached_test.go
+++ b/internal/subagent/purge_livedetached_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package subagent
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// TestPurgeRunStopsLiveDetachedEngine (codex r20 correction): PurgeRun's one-action
+// delete-a-running-run — a VERIFIABLY-live detached engine (DetachedLive) is stopped AND confirmed dead
+// (reap tree + WaitEngineStopped) before the run is deleted. Drives a REAL killable child in its own
+// process group as the "engine" pid, with a matching argv via the reuseGuardArgv seam, so the reap can
+// never touch the test process.
+func TestPurgeRunStopsLiveDetachedEngine(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	child := exec.Command("sleep", "120")
+	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // own group → reapEngineTree's -pid can't reach the test
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() { _ = child.Wait(); close(done) }() // reap the zombie promptly so pidAlive flips false after the kill
+	t.Cleanup(func() { _ = child.Process.Kill(); <-done })
+	pid := child.Process.Pid
+
+	origArgv := reuseGuardArgv
+	reuseGuardArgv = func(int) ([]string, bool) {
+		return []string{"cc-fleet", "workflow", "run", "--run-id", "live-det", "s.js"}, true // matches → DetachedLive
+	}
+	t.Cleanup(func() { reuseGuardArgv = origArgv })
+
+	run := WorkflowRun{RunID: "live-det", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: pid}
+	if got := ClassifyDetachedEngine(run); got != DetachedLive {
+		t.Fatalf("setup: expected DetachedLive, got %v", got)
+	}
+	if err := SaveRun(run); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PurgeRun("live-det"); err != nil {
+		t.Fatalf("PurgeRun must stop + delete a verifiably-live detached run, got %v", err)
+	}
+	if _, rerr := ReadRun("live-det"); rerr == nil {
+		t.Error("PurgeRun must remove the run after stopping its engine")
+	}
+	if pidAlive(pid) {
+		t.Error("PurgeRun must have reaped the live detached engine before deleting")
+	}
+}

--- a/internal/subagent/purge_livedetached_test.go
+++ b/internal/subagent/purge_livedetached_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// TestPurgeRunStopsLiveDetachedEngine (codex r20 correction): PurgeRun's one-action
+// TestPurgeRunStopsLiveDetachedEngine: PurgeRun's one-action
 // delete-a-running-run — a VERIFIABLY-live detached engine (DetachedLive) is stopped AND confirmed dead
 // (reap tree + WaitEngineStopped) before the run is deleted. Drives a REAL killable child in its own
 // process group as the "engine" pid, with a matching argv via the reuseGuardArgv seam, so the reap can

--- a/internal/subagent/purge_nonpathsafe_pending_test.go
+++ b/internal/subagent/purge_nonpathsafe_pending_test.go
@@ -1,0 +1,93 @@
+package subagent
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPurgeRunRefusesNonPathSafePendingMember (codex r29): a NON-path-safe run id ("a.b", segment
+// "a-b") skips PurgeRun's path-safe segment verdict, so its whole-run member walk is the ONLY segment
+// guard. A crash-window PENDING member (ChildIdentityPending, no ChildPID) is the sole veto for segment
+// "a-b"; PurgeRun must REFUSE rather than reap its meta, else a colliding dead path-safe "a-b" reclaimer
+// deletes the shared workdir under the possible orphan. The r24 recovery is unchanged: an explicit
+// DeleteJob on the pending job proceeds → the retried PurgeRun proceeds → the segment then reclaims.
+func TestPurgeRunRefusesNonPathSafePendingMember(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	// The shared isolation-worktree segment; a.b is non-path-safe (segment a-b), a-b the path-safe reclaimer.
+	wtAB := seedWorktreeTemp(t, "a-b")
+	writeRunForTest(t, WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadEnginePID})
+	writeRunForTest(t, WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadEnginePID})
+	// The crash-window PENDING member of a.b: registered but never past cmd.Start→identity (no ChildPID).
+	writeLeafMeta(t, jobMeta{JobID: "pm", RunID: "a.b", PID: deadEnginePID, ChildIdentityPending: true}, false)
+
+	// PurgeRun(a.b) — its member walk (the only guard for a non-path-safe id) refuses on the pending member.
+	if err := PurgeRun("a.b"); err == nil || !strings.Contains(err.Error(), "never identified") {
+		t.Fatalf("PurgeRun(a.b) must refuse on the pending member, got %v", err)
+	}
+	if _, rerr := ReadRun("a.b"); rerr != nil {
+		t.Error("the refused PurgeRun must leave the a.b manifest")
+	}
+	if dir, _ := jobsDir(); func() bool { _, merr := readMeta(dir, "pm"); return merr != nil }() {
+		t.Error("the refused PurgeRun must leave the pending member meta (the segment veto)")
+	}
+
+	// The colliding path-safe a-b reclaimer is vetoed by that same pending member (segment verdict) →
+	// PurgeRun(a-b) refuses, the shared workdir survives.
+	if err := PurgeRun("a-b"); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+		t.Errorf("PurgeRun(a-b) must be vetoed by a.b's pending member, got %v", err)
+	}
+	if _, serr := os.Stat(wtAB); serr != nil {
+		t.Errorf("the shared segment workdir must survive the vetoed reclaim, err=%v", serr)
+	}
+
+	// PruneRuns spares BOTH (each PurgeRun refuses) — the automatic path never erases the veto.
+	if removed, err := PruneRuns(); err != nil || removed != 0 {
+		t.Errorf("PruneRuns must spare both runs (both PurgeRun refuse), removed=%d err=%v", removed, err)
+	}
+	if _, rerr := ReadRun("a.b"); rerr != nil {
+		t.Error("PruneRuns must leave a.b")
+	}
+
+	// Recovery: an explicit DeleteJob on the pending job proceeds (record-only escape, narrower rule).
+	if derr := DeleteJob("pm"); derr != nil {
+		t.Fatalf("DeleteJob on the pending job must proceed (recovery escape), got %v", derr)
+	}
+	// With the veto resolved, PurgeRun(a.b) proceeds, and the path-safe a-b reclaimer then reclaims the
+	// shared workdir (adjudicated post-recovery semantics).
+	if err := PurgeRun("a.b"); err != nil {
+		t.Errorf("after recovery PurgeRun(a.b) must proceed, got %v", err)
+	}
+	if err := PurgeRun("a-b"); err != nil {
+		t.Errorf("after recovery the path-safe reclaimer must proceed, got %v", err)
+	}
+	if _, serr := os.Stat(wtAB); !os.IsNotExist(serr) {
+		t.Errorf("post-recovery the shared workdir is reclaimed, err=%v", serr)
+	}
+}
+
+// TestPurgeRunNonPathSafeDeadMembersStillPurge: a NON-path-safe run whose only members are DEAD
+// identified leaves (ChildPID>0, dead child) still purges as before — the widened member-walk predicate
+// keys on live-or-pending evidence, so a dead identified member never blocks.
+func TestPurgeRunNonPathSafeDeadMembersStillPurge(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	origPS := procStartFn
+	procStartFn = func(int) (string, bool) { return "tok", true }
+	t.Cleanup(func() { procStartFn = origPS })
+
+	writeRunForTest(t, WorkflowRun{RunID: "c.d", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadEnginePID})
+	writeLeafMeta(t, jobMeta{JobID: "dm", RunID: "c.d", PID: deadEnginePID, ChildPID: deadEnginePID}, true) // dead identified child + terminal
+
+	if err := PurgeRun("c.d"); err != nil {
+		t.Fatalf("a non-path-safe run with only dead identified members must purge, got %v", err)
+	}
+	if _, rerr := ReadRun("c.d"); rerr == nil {
+		t.Error("the c.d manifest must be gone after PurgeRun")
+	}
+}

--- a/internal/subagent/purge_nonpathsafe_pending_test.go
+++ b/internal/subagent/purge_nonpathsafe_pending_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-// TestPurgeRunRefusesNonPathSafePendingMember (codex r29): a NON-path-safe run id ("a.b", segment
+// TestPurgeRunRefusesNonPathSafePendingMember: a NON-path-safe run id ("a.b", segment
 // "a-b") skips PurgeRun's path-safe segment verdict, so its whole-run member walk is the ONLY segment
 // guard. A crash-window PENDING member (ChildIdentityPending, no ChildPID) is the sole veto for segment
 // "a-b"; PurgeRun must REFUSE rather than reap its meta, else a colliding dead path-safe "a-b" reclaimer
-// deletes the shared workdir under the possible orphan. The r24 recovery is unchanged: an explicit
+// deletes the shared workdir under the possible orphan. The recovery escape holds: an explicit
 // DeleteJob on the pending job proceeds → the retried PurgeRun proceeds → the segment then reclaims.
 func TestPurgeRunRefusesNonPathSafePendingMember(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/subagent/readretry.go
+++ b/internal/subagent/readretry.go
@@ -1,0 +1,38 @@
+package subagent
+
+import (
+	"os"
+	"time"
+)
+
+// metaReadAttempts / metaReadDelay bound the meta read's retry of a transient Windows
+// share/lock violation. AtomicWrite renames the meta into place (MoveFileEx replace); for
+// the instant the replace holds the target, a concurrent reader's open fails with
+// ERROR_SHARING_VIOLATION. ~5 tries over ~12ms outlast that window; past it the error is
+// returned unchanged.
+const (
+	metaReadAttempts = 5
+	metaReadDelay    = 3 * time.Millisecond
+)
+
+// readFileRetry is os.ReadFile hardened for the meta read path. On unix isSharingViolation
+// is always false, so it is exactly one os.ReadFile — no retry, no behavior change. On
+// windows it re-tries only the transient rename-window sharing violation. It never masks a
+// torn read: AtomicWrite renames whole files, so a reader observes whole-old or whole-new,
+// and a genuinely corrupt/partial meta still surfaces (as a non-transient error or an
+// unmarshal failure) for the caller to reject.
+func readFileRetry(path string) ([]byte, error) {
+	return retryTransientRead(func() ([]byte, error) { return os.ReadFile(path) }, isSharingViolation, metaReadAttempts, metaReadDelay)
+}
+
+// retryTransientRead calls read until it succeeds, fails non-transiently, or attempts is
+// spent, sleeping delay between tries. Split from readFileRetry so the retry loop is
+// exercisable off-platform with an injected read/predicate.
+func retryTransientRead(read func() ([]byte, error), transient func(error) bool, attempts int, delay time.Duration) ([]byte, error) {
+	data, err := read()
+	for i := 1; i < attempts && err != nil && transient(err); i++ {
+		time.Sleep(delay)
+		data, err = read()
+	}
+	return data, err
+}

--- a/internal/subagent/readretry.go
+++ b/internal/subagent/readretry.go
@@ -5,24 +5,32 @@ import (
 	"time"
 )
 
-// metaReadAttempts / metaReadDelay bound the meta read's retry of a transient Windows
-// share/lock violation. AtomicWrite renames the meta into place (MoveFileEx replace); for
-// the instant the replace holds the target, a concurrent reader's open fails with
-// ERROR_SHARING_VIOLATION. ~5 tries over ~12ms outlast that window; past it the error is
-// returned unchanged.
+// metaReadAttempts / metaReadDelay bound the retry of a transient Windows share/lock violation on a
+// meta OR run-manifest read. AtomicWrite renames the file into place (MoveFileEx replace); for the
+// instant the replace holds the target, a concurrent reader's open fails with ERROR_SHARING_VIOLATION.
+// ~5 tries over ~12ms outlast that window; past it the error is returned unchanged.
 const (
 	metaReadAttempts = 5
 	metaReadDelay    = 3 * time.Millisecond
 )
 
-// readFileRetry is os.ReadFile hardened for the meta read path. On unix isSharingViolation
-// is always false, so it is exactly one os.ReadFile — no retry, no behavior change. On
-// windows it re-tries only the transient rename-window sharing violation. It never masks a
-// torn read: AtomicWrite renames whole files, so a reader observes whole-old or whole-new,
-// and a genuinely corrupt/partial meta still surfaces (as a non-transient error or an
-// unmarshal failure) for the caller to reject.
+// osReadFile / transientRead are readFileRetry's read primitive and its transient-error predicate,
+// held as package vars only so a test can drive the retry loop off-platform: unix's isSharingViolation
+// is always false, so a Windows sharing violation can't otherwise be simulated on the meta/manifest
+// read path. Production never reassigns them.
+var (
+	osReadFile    = os.ReadFile
+	transientRead = isSharingViolation
+)
+
+// readFileRetry is os.ReadFile hardened for the meta + run-manifest read paths. On unix
+// isSharingViolation is always false, so it is exactly one os.ReadFile — no retry, no behavior
+// change. On windows it re-tries only the transient rename-window sharing violation. It never masks a
+// torn read: AtomicWrite renames whole files, so a reader observes whole-old or whole-new, and a
+// genuinely corrupt/partial file still surfaces (as a non-transient error or an unmarshal failure)
+// for the caller to reject.
 func readFileRetry(path string) ([]byte, error) {
-	return retryTransientRead(func() ([]byte, error) { return os.ReadFile(path) }, isSharingViolation, metaReadAttempts, metaReadDelay)
+	return retryTransientRead(func() ([]byte, error) { return osReadFile(path) }, transientRead, metaReadAttempts, metaReadDelay)
 }
 
 // retryTransientRead calls read until it succeeds, fails non-transiently, or attempts is

--- a/internal/subagent/readretry_test.go
+++ b/internal/subagent/readretry_test.go
@@ -1,0 +1,62 @@
+package subagent
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRetryTransientReadLoop exercises the retry core off-platform (unix's isSharingViolation
+// is always false, so the production wrapper never loops here): a transient error retries up to
+// the attempt bound, a non-transient error returns at once, and an exhausted retry returns the
+// last transient error — the shape the windows meta read relies on.
+func TestRetryTransientReadLoop(t *testing.T) {
+	transient := errors.New("sharing violation")
+	isTransient := func(err error) bool { return errors.Is(err, transient) }
+
+	t.Run("retries then succeeds", func(t *testing.T) {
+		calls := 0
+		data, err := retryTransientRead(func() ([]byte, error) {
+			calls++
+			if calls < 3 {
+				return nil, transient
+			}
+			return []byte("ok"), nil
+		}, isTransient, 5, time.Millisecond)
+		if err != nil || string(data) != "ok" {
+			t.Fatalf("data=%q err=%v, want ok/nil", data, err)
+		}
+		if calls != 3 {
+			t.Fatalf("calls=%d, want 3 (two retries)", calls)
+		}
+	})
+
+	t.Run("non-transient returns immediately", func(t *testing.T) {
+		hard := errors.New("not found")
+		calls := 0
+		_, err := retryTransientRead(func() ([]byte, error) {
+			calls++
+			return nil, hard
+		}, isTransient, 5, time.Millisecond)
+		if !errors.Is(err, hard) {
+			t.Fatalf("err=%v, want hard", err)
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want 1 (no retry on a non-transient error)", calls)
+		}
+	})
+
+	t.Run("gives up after the attempt bound", func(t *testing.T) {
+		calls := 0
+		_, err := retryTransientRead(func() ([]byte, error) {
+			calls++
+			return nil, transient
+		}, isTransient, 5, time.Millisecond)
+		if !errors.Is(err, transient) {
+			t.Fatalf("err=%v, want the last transient error", err)
+		}
+		if calls != 5 {
+			t.Fatalf("calls=%d, want 5 (the attempt bound)", calls)
+		}
+	})
+}

--- a/internal/subagent/readretry_unix.go
+++ b/internal/subagent/readretry_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package subagent
+
+// isSharingViolation is always false on unix: os.Rename is atomic on the inode, so a
+// concurrent reader never sees the transient replace-window contention Windows reports.
+// readFileRetry therefore collapses to a single os.ReadFile — no retry cost.
+func isSharingViolation(error) bool { return false }

--- a/internal/subagent/readretry_windows.go
+++ b/internal/subagent/readretry_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package subagent
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isSharingViolation reports the transient contention a concurrent AtomicWrite rename
+// (MoveFileEx replace) raises against a reader's open — SHARING for the file handle,
+// LOCK for a byte range. Both clear once the replace completes, so readFileRetry re-tries
+// them; every other error (including ErrNotExist) is returned immediately.
+func isSharingViolation(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/internal/subagent/reap_windows_test.go
+++ b/internal/subagent/reap_windows_test.go
@@ -68,7 +68,7 @@ func TestRunClaude_TimeoutKillsProcessTree(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	start := time.Now()
-	_, _, _, _ = runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil)
+	_, _, _, _ = runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil, nil)
 	if elapsed := time.Since(start); elapsed > 12*time.Second {
 		t.Fatalf("runClaude took %v with a sleeping grandchild; tree-kill model broken", elapsed)
 	}

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -251,6 +251,13 @@ func RunScriptPath(runID string) (string, error) { return runSidecarPath(runID, 
 // error instead of a JS parse failure.
 func LegacyRunScriptPath(runID string) (string, error) { return runSidecarPath(runID, ".star") }
 
+// errRunManifestUnreadable tags a non-ErrNotExist FAILURE TO READ a run manifest (a genuine I/O
+// fault, or a Windows sharing violation the read retry couldn't outlast) — distinct from a
+// genuinely-absent manifest (os.ErrNotExist) and from one read fine but corrupt (a JSON parse error).
+// Destructive/liveness callers fail CLOSED on it: a transient read failure must never be mistaken for
+// engine death and let them delete/finalize under a live run.
+var errRunManifestUnreadable = errors.New("subagent: run manifest unreadable")
+
 // ReadRun loads a manifest by id. runID is validated first because it becomes a
 // filesystem path component (guards against a "../" escape via the CLI/status path).
 func ReadRun(runID string) (WorkflowRun, error) {
@@ -261,15 +268,22 @@ func ReadRun(runID string) (WorkflowRun, error) {
 	if err != nil {
 		return WorkflowRun{}, err
 	}
-	data, err := os.ReadFile(filepath.Join(dir, runID+".json"))
+	// readFileRetry, not os.ReadFile: SaveRun renames the manifest into place (AtomicWrite), so on
+	// windows a concurrent reader can hit a transient ERROR_SHARING_VIOLATION for the instant the
+	// replace holds the target. The retry absorbs only that window; a persistent failure still surfaces.
+	data, err := readFileRetry(filepath.Join(dir, runID+".json"))
 	if err != nil {
-		// Canonical, path-free "not found" so an unknown-run id doesn't leak the
-		// config-dir layout into the CLI's JSON error envelope (a genuine I/O fault
-		// keeps its context for debugging).
 		if errors.Is(err, os.ErrNotExist) {
-			return WorkflowRun{}, fmt.Errorf("run %q not found", runID)
+			// Canonical, path-free "not found" so an unknown-run id doesn't leak the config-dir layout
+			// into the CLI's JSON error envelope. Wraps os.ErrNotExist so a destructive/liveness caller
+			// can tell a genuinely-absent manifest (safe to treat as gone) from an unreadable one.
+			return WorkflowRun{}, fmt.Errorf("run %q not found: %w", runID, os.ErrNotExist)
 		}
-		return WorkflowRun{}, err
+		// A non-ErrNotExist read failure — a genuine I/O fault, or a Windows sharing violation the retry
+		// couldn't outlast. Tag it errRunManifestUnreadable (keeping the raw context) so PurgeRun /
+		// WaitEngineStopped fail CLOSED rather than mistake a transient read for engine death. A manifest
+		// read fine but corrupt is NOT this class — it surfaces below as a parse error (deletable junk).
+		return WorkflowRun{}, fmt.Errorf("%w: run %q: %w", errRunManifestUnreadable, runID, err)
 	}
 	var run WorkflowRun
 	if err := json.Unmarshal(data, &run); err != nil {
@@ -299,7 +313,10 @@ func ListRuns() ([]WorkflowRun, error) {
 		if e.IsDir() || !strings.HasSuffix(name, ".json") {
 			continue
 		}
-		data, rerr := os.ReadFile(filepath.Join(dir, name))
+		// readFileRetry absorbs a transient Windows sharing violation so a LIVE run isn't dropped from
+		// the listing mid-write; a persistent read/parse error still skips that manifest. Skipping is
+		// fail-safe for the reclaim/prune consumers — a run that can't be listed is never reclaimed.
+		data, rerr := readFileRetry(filepath.Join(dir, name))
 		if rerr != nil {
 			continue
 		}
@@ -792,7 +809,15 @@ func PurgeRun(runID string) error {
 	if err := ids.ValidateJobID(runID); err != nil {
 		return err
 	}
-	if run, rerr := ReadRun(runID); rerr == nil {
+	run, rerr := ReadRun(runID)
+	if errors.Is(rerr, errRunManifestUnreadable) {
+		// The manifest exists but its read failed transiently/IO — we can tell neither a live engine
+		// from a gone one. Fail closed: delete nothing, so a transient Windows sharing violation can
+		// never drop a live run's record/jobs/worktrees. ErrNotExist (genuinely gone) and a parse error
+		// (corrupt junk) both fall through to the removal below — the accumulated junk this clears.
+		return rerr
+	}
+	if rerr == nil {
 		if run.EnginePID > 0 {
 			switch ClassifyDetachedEngine(run) {
 			case DetachedLive:
@@ -988,15 +1013,22 @@ func isLiveOrUnverifiable(run WorkflowRun) bool {
 }
 
 // WaitEngineStopped polls a run's engine liveness until it is gone or the deadline passes (true once
-// EngineAlive is false / the manifest is unreadable, false on timeout). EngineAlive fails SOFT (an
-// alive-but-UNVERIFIABLE pid — argv + token unreadable — reads as alive), so a stuck poll times out into
-// the caller's fail-closed path rather than declaring death and touching files under a still-live engine.
-// Shared by StopRun's reap, PurgeRun (delete), and workflow.Restart.
+// EngineAlive is false / the manifest is genuinely absent, false on timeout). Only os.ErrNotExist —
+// the manifest deleted out from under us — counts as stopped; a transient/other read error (a Windows
+// sharing violation, an I/O fault, a corrupt manifest) does NOT, so a read that can't confirm death
+// times out into the caller's fail-closed path rather than declaring the engine gone. EngineAlive
+// itself also fails SOFT (an alive-but-UNVERIFIABLE pid reads as alive). Shared by StopRun's reap,
+// PurgeRun (delete), and workflow.Restart.
 func WaitEngineStopped(runID string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for {
 		run, err := ReadRun(runID)
-		if err != nil || !EngineAlive(run) {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return true // the manifest is genuinely gone → engine stopped
+			}
+			// A read we can't trust (transient/IO/corrupt): keep polling; don't declare death.
+		} else if !EngineAlive(run) {
 			return true
 		}
 		if time.Now().After(deadline) {

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -63,6 +63,14 @@ type WorkflowRun struct {
 	// our engine. Empty (a pre-token manifest / capture failure) degrades to the
 	// argv-only behavior.
 	EngineProcStart string `json:"engine_proc_start,omitempty"`
+	// FgEnginePID / FgEngineProcStart are a FOREGROUND engine's own pid + kernel start token, stamped
+	// by an inline `workflow run --foreground` engine as liveness EVIDENCE only — deliberately SEPARATE
+	// from EnginePID, which a foreground run keeps at 0 so `workflow stop` never claims a kill on a
+	// terminal-attached process it can't reap. ClassifyFgEngine reads them to tell a dead (Ctrl-C'd or
+	// crashed) foreground run from a still-live one, so the sweep and the resume/restart guards can act
+	// on it. A detached engine leaves them zero; an old (pre-field) record has them zero too.
+	FgEnginePID       int    `json:"fg_engine_pid,omitempty"`
+	FgEngineProcStart string `json:"fg_engine_proc_start,omitempty"`
 	// Error is the failure cause, set when Status is "failed" — so a DETACHED run
 	// (whose stderr went to /dev/null) still records WHY it failed for `workflow
 	// status`. It is a canonical/script-level message (agent() failures carry
@@ -342,49 +350,64 @@ func removeRun(dir, runID string) {
 // means a recycled EnginePID can NEVER make this kill an unrelated process: the pid is
 // reaped only when its argv still proves it is this run's detached `workflow run …
 // --run-id <id>` engine, or — where argv is unreadable (Windows) — when its kernel start
-// token still equals the manifest's recorded one. An already-terminal run is returned
-// untouched (no clobbering a
-// real done/failed). Every other case — a foreground run (EnginePID deliberately 0), an
-// engine already gone (crashed), or a recycled pid whose argv no longer matches — is
-// reaped of nothing and simply flipped to stopped, clearing a stale "running"; the reuse
-// guard ensures such an unverifiable pid is never killed.
+// token still equals the manifest's recorded one. A recorded DETACHED engine is classified TRI-STATE
+// (ClassifyDetachedEngine): DetachedLive → reap + confirm dead + finalize ghosts; DetachedDead
+// (gone / recycled) → finalize ghost leaves then flip stopped; DetachedUnknown (a retained pid alive
+// but argv + start token both unreadable) → REFUSED with an error, status + journal left untouched —
+// flipping it stopped or finalizing under a possibly-live engine would report a false success and let a
+// caller act under it. A foreground run (EnginePID 0) has nothing to reap and simply flips stopped,
+// clearing a stale "running". An already-terminal run is normally returned untouched; the ONE exception
+// is a WEDGED terminal record still carrying a Live or Unknown detached pid (an old collapse, or a
+// race) — it falls through so Live is properly reaped (an escape hatch) and Unknown fails closed. The
+// reuse guard ensures an unverifiable pid is never killed.
 func StopRun(runID string) (WorkflowRun, error) {
 	run, err := ReadRun(runID)
 	if err != nil {
 		return WorkflowRun{}, err
 	}
 	if run.Status != "" && run.Status != "running" {
-		return run, nil // already terminal — don't clobber done/failed/stopped
-	}
-	switch {
-	case run.EnginePID > 0 && pidAlive(run.EnginePID) && engineIdentityMatches(run):
-		// Verifiably this run's live detached engine: reap it + confirm dead before finalizing its leaves.
-		reapEngineTree(run.EnginePID) // reaps the engine + its in-flight leaf children
-		if !WaitEngineStopped(runID, stopReapTimeout) {
-			// Won't die — do NOT flip stopped or clear the pid, or a caller (Restart / PurgeRun) would
-			// falsely read it as dead and act under a still-live engine. Fail closed.
-			return WorkflowRun{}, fmt.Errorf("subagent: run %s engine did not stop in time", runID)
+		// Already terminal → normally nothing live to reap. But a WEDGED terminal record can still carry a
+		// detached pid that classifies Live or Unknown (an old binary-collapse stop that flipped stopped
+		// under an unverifiable engine, or a race): don't no-op then — fall through so a Live engine is
+		// properly reaped + re-verified and an Unknown one fails closed. Terminal + a Dead/absent pid keeps
+		// the no-op (a normal done/failed/stopped record, whose engine exited, reads Dead here).
+		if run.EnginePID <= 0 || ClassifyDetachedEngine(run) == DetachedDead {
+			return run, nil
 		}
-		// Confirmed dead: finalize the engine's mid-flight leaves (left "running" because its
-		// finalizeSyncJob defer died with it) — never racing that defer, since the engine is gone.
-		finalizeRunLeaves(runID)
-	case EngineAlive(run):
-		// The engine MIGHT still be live but we cannot verify it is THIS run's (its argv is unreadable),
-		// so we must neither kill it (fail SAFE) nor flip the run stopped — a caller would then rewrite
-		// the journal / delete / launch under a possibly-live engine. Fail closed.
-		return WorkflowRun{}, fmt.Errorf("subagent: run %s engine (pid %d) is alive but unverifiable; cannot stop safely", runID, run.EnginePID)
-	case run.EnginePID > 0:
-		// A recorded detached pid that is DEFINITIVELY gone (dead, or recycled to a different process):
-		// its mid-flight leaves are ghosts — finalize them. (A foreground EnginePID==0 run has nothing to
-		// reap and no ghost leaves here; it just flips stopped below, clearing a stale "running".)
-		finalizeRunLeaves(runID)
 	}
+	if run.EnginePID > 0 {
+		switch ClassifyDetachedEngine(run) {
+		case DetachedLive:
+			// Verifiably this run's live detached engine: reap it + confirm dead before finalizing its leaves.
+			reapEngineTreeFn(run.EnginePID) // reaps the engine + its in-flight leaf children
+			if !WaitEngineStopped(runID, stopReapTimeout) {
+				// Won't die — do NOT flip stopped or clear the pid, or a caller (Restart / PurgeRun) would
+				// falsely read it as dead and act under a still-live engine. Fail closed.
+				return WorkflowRun{}, fmt.Errorf("subagent: run %s engine did not stop in time", runID)
+			}
+			// Confirmed dead: finalize the engine's mid-flight leaves (left "running" because its
+			// finalizeSyncJob defer died with it) — never racing that defer, since the engine is gone.
+			finalizeRunLeaves(runID)
+		case DetachedUnknown:
+			// A retained detached pid ALIVE but UNVERIFIABLE (argv + start token both unreadable): we can
+			// neither kill-verify nor death-verify it, so we must not flip the run stopped or finalize its
+			// journal under a possibly-live engine. Fail closed; self-clearing once the pid exits (→ Dead).
+			return WorkflowRun{}, fmt.Errorf("subagent: run %s engine (pid %d) is alive but unverifiable; stop it manually or retry once it exits", runID, run.EnginePID)
+		case DetachedDead:
+			// A recorded detached pid DEFINITIVELY gone (dead, or recycled to a different process): its
+			// mid-flight leaves are ghosts — finalize them, then flip stopped below.
+			finalizeRunLeaves(runID)
+		}
+	}
+	// EnginePID <= 0 (a foreground run, or the detached mint→stamp window) has nothing to reap: flip
+	// stopped, clearing a stale "running".
 	run.Status = "stopped"
 	run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	// Keep EnginePID + EngineProcStart: for a reaped DETACHED run they are the death evidence
-	// RunEngineProvablyNotLive relies on (a positively-dead recorded pid — the token also disproves
-	// a recycled pid). A foreground run recorded 0 and stays 0, so it correctly reads NOT provably
-	// dead — nothing was reaped and its engine may still be writing. A resume re-stamps both.
+	// Keep every identity field (EnginePID/EngineProcStart AND FgEnginePID/FgEngineProcStart): they are
+	// the death evidence RunEngineProvablyNotLive / ClassifyFgEngine rely on. For a reaped DETACHED run
+	// the retained pid+token positively read dead. A blind-flipped FOREGROUND run keeps EnginePID 0 but
+	// retains its fg identity, so once its terminal engine exits it reads dead (resumable + reclaimable)
+	// and while alive it reads alive (refused) — never cleared here, only re-stamped by a resume.
 	if serr := SaveRun(run); serr != nil {
 		return WorkflowRun{}, serr
 	}
@@ -393,7 +416,12 @@ func StopRun(runID string) (WorkflowRun, error) {
 
 // stopReapTimeout bounds how long StopRun waits for a reaped engine to actually die before
 // finalizing its leaves — long enough for a SIGTERM'd engine to exit, short enough to not wedge.
-const stopReapTimeout = 5 * time.Second
+// A var so a test can shorten the fail-closed did-not-stop path.
+var stopReapTimeout = 5 * time.Second
+
+// reapEngineTreeFn is StopRun's engine-tree reaper as a test seam (mirrors reapJobTree), so a test can
+// drive the DetachedLive reap path without killing a real process.
+var reapEngineTreeFn = reapEngineTree
 
 // finalizeRunLeaves writes a terminal failure Result for every leaf of runID that a now-dead engine
 // left without a result cache, so a stopped run shows no phantom "running" leaf. The caller invokes it
@@ -450,32 +478,6 @@ func engineCmdlineMatches(pid int, runID string) bool {
 	return argvIsRunEngine(argv, runID)
 }
 
-// engineIdentityMatches is StopRun's kill guard: where argv is readable it
-// alone decides (a token match must not override an argv mismatch — the darwin
-// token is seconds-coarse and a same-second recycle can collide); where argv is
-// unreadable (Windows) the recorded start token decides. Fail SAFE: with
-// neither, never kill.
-func engineIdentityMatches(run WorkflowRun) bool {
-	argv, ok := reuseGuardArgv(run.EnginePID)
-	if ok {
-		return argvIsRunEngine(argv, run.RunID)
-	}
-	return engineProcStartMatches(run)
-}
-
-// engineProcStartMatches reports whether run's recorded engine start token still
-// matches the live pid — the identity check where argv is unreadable (Windows).
-// A recycled pid carries a new start time, so equality positively identifies
-// the engine. An empty token (a pre-token manifest / capture failure) never
-// matches: those runs keep the argv-only behavior.
-func engineProcStartMatches(run WorkflowRun) bool {
-	if run.EngineProcStart == "" || run.EnginePID <= 0 {
-		return false
-	}
-	live, ok := procStartFn(run.EnginePID)
-	return ok && live == run.EngineProcStart
-}
-
 // argvIsRunEngine reports whether argv is this run's detached `workflow run … --run-id <id>`
 // engine — the argv-matching core shared by the StopRun kill-guard (engineCmdlineMatches) and the
 // EngineAlive liveness check. Requiring the "--run-id" flag (which only the detached child carries)
@@ -498,52 +500,288 @@ func argvIsRunEngine(argv []string, runID string) bool {
 	return hasWorkflow && hasRun && hasRunIDFlag && hasID
 }
 
-// EngineAlive reports whether run's DETACHED engine MIGHT still be running. It is a read-only
-// LIVENESS check (it kills nothing), used by a watcher to stop waiting on a stale "running"
-// manifest whose engine is gone. A foreground run (EnginePID 0) or a definitively-dead pid is
-// "not alive". When the pid IS alive, the answer depends on what identity we can read: where
-// argv is readable (unix), require it to still be THIS run's engine so a RECYCLED pid (now an
-// unrelated process) reads as gone — otherwise a SIGKILLed engine whose pid was reused would
-// hold the watcher open forever; where it isn't (Windows), the manifest's recorded start token
-// answers the same question; with neither (a pre-token manifest), trust pidAlive alone, since
-// a false "gone" for a live engine is worse than a rare missed recycled-pid detection. Unlike
-// StopRun (which must fail-SAFE to never-kill an unverifiable pid), this fails-SOFT to
-// keep-watching — neither can ever kill the wrong process.
+// EngineAlive reports whether run's DETACHED engine MIGHT still be running — a read-only LIVENESS check
+// (it kills nothing), used by the watchers to stop waiting on a stale "running" manifest AND by
+// WaitEngineStopped to poll a reaped engine to death. It delegates to the tri-state
+// ClassifyDetachedEngine and fails SOFT to alive: a foreground run (EnginePID 0) is "not alive", and a
+// recorded detached pid is alive unless PROVABLY dead (DetachedDead: pid gone, or a READABLE identity
+// mismatch = a recycled pid, which still reads dead). An alive-but-UNVERIFIABLE pid (argv + start token
+// both unreadable) reads ALIVE — never a false "gone" for a live engine, which a consumer that treats
+// !EngineAlive as death proof (WaitEngineStopped, the watch/wait engine-gone check) would otherwise act
+// on. Unknown requires pidAlive, so treating it as alive is truthful.
 func EngineAlive(run WorkflowRun) bool {
-	if run.EnginePID <= 0 || !pidAlive(run.EnginePID) {
-		return false
+	if run.EnginePID <= 0 {
+		return false // no recorded DETACHED engine (foreground / pre-stamp) — not this check's concern
 	}
-	argv, ok := reuseGuardArgv(run.EnginePID)
-	if !ok {
-		if run.EngineProcStart != "" {
-			return engineProcStartMatches(run)
+	return ClassifyDetachedEngine(run) != DetachedDead
+}
+
+// DetachedLiveness classifies a DETACHED engine's recorded identity as a TRI-STATE, the detached
+// counterpart of ClassifyFgEngine. EngineAlive collapses "recycled/dead" and "unverifiable" into one
+// false, which the reclaim path then reads as provably-dead — so an UNVERIFIABLE pid (alive but neither
+// argv nor its start token readable: EPERM / hardened kernel / container) would be reclaimed under a
+// still-running engine. This split keeps EngineAlive unchanged (StopRun's kill/refuse still consume it)
+// while giving RunEngineProvablyNotLive the third answer.
+type DetachedLiveness int
+
+const (
+	// DetachedUnknown: pid alive but its identity is unverifiable (argv unreadable AND its start token
+	// unreadable/unrecorded) — the fail-safe class, NOT proof of death.
+	DetachedUnknown DetachedLiveness = iota
+	// DetachedDead: the recorded pid is gone, OR a READABLE identity proves a different process (recycled).
+	DetachedDead
+	// DetachedLive: the pid is alive and a readable identity still matches THIS run's detached engine.
+	DetachedLive
+)
+
+// ClassifyDetachedEngine classifies run's DETACHED engine (EnginePID + argv/EngineProcStart). Rules:
+// no pid → Unknown; pid gone → Dead; pid alive with READABLE argv → argv decides (match=Live,
+// mismatch=Dead — a readable argv mismatch is decisive, a token match must never override it); pid
+// alive + argv unreadable + a READABLE recorded token → match=Live, mismatch=Dead; pid alive with
+// nothing readable → Unknown. Only Dead is proof the reclaim path may act on.
+func ClassifyDetachedEngine(run WorkflowRun) DetachedLiveness {
+	if run.EnginePID <= 0 {
+		return DetachedUnknown // not a detached run
+	}
+	if !pidAlive(run.EnginePID) {
+		return DetachedDead // the recorded pid is gone
+	}
+	if argv, ok := reuseGuardArgv(run.EnginePID); ok {
+		if argvIsRunEngine(argv, run.RunID) {
+			return DetachedLive
 		}
-		return true // no argv and no token → can't disprove it's our engine; trust pidAlive
+		return DetachedDead // readable argv proves a DIFFERENT process (recycled)
 	}
-	return argvIsRunEngine(argv, run.RunID)
+	if run.EngineProcStart != "" {
+		live, ok := procStartFn(run.EnginePID)
+		if !ok {
+			return DetachedUnknown // pid alive, token unreadable → prove neither ours-alive nor recycled-dead
+		}
+		if live == run.EngineProcStart {
+			return DetachedLive
+		}
+		return DetachedDead // recycled to a different process
+	}
+	return DetachedUnknown // pid alive, nothing readable (pre-token manifest) → not provably dead
+}
+
+// FgLiveness classifies a FOREGROUND run's recorded engine identity for the resume/restart guards
+// and RunEngineProvablyNotLive.
+type FgLiveness int
+
+const (
+	// FgUnknown: no fg identity recorded (a detached or pre-field run), or one whose liveness the
+	// platform can't verify — the fail-safe class, treated as possibly-live.
+	FgUnknown FgLiveness = iota
+	// FgDead: the recorded foreground engine has exited, or its pid was recycled to a different process.
+	FgDead
+	// FgAlive: the recorded foreground engine is still the running process.
+	FgAlive
+)
+
+// ClassifyFgEngine classifies run's FOREGROUND engine identity (FgEnginePID + FgEngineProcStart).
+// There is NO argv check, unlike the detached engine: the original `workflow run --foreground`
+// invocation's argv carries no run id (only the detached re-exec does), so pid + kernel start token
+// is the WHOLE proof on every platform. Rules: no fg pid → FgUnknown; the pid is gone → FgDead; the
+// pid is alive with a readable token that MATCHES → FgAlive; a readable MISMATCHED token → FgDead
+// (recycled); an unreadable (EPERM / unsupported) or unrecorded token → FgUnknown. A token match is
+// thus treated as ALIVE — the fail-safe direction (never resume under a possibly-live fg engine).
+func ClassifyFgEngine(run WorkflowRun) FgLiveness {
+	if run.FgEnginePID <= 0 {
+		return FgUnknown
+	}
+	if !pidAlive(run.FgEnginePID) {
+		return FgDead // the recorded pid is gone
+	}
+	live, ok := procStartFn(run.FgEnginePID)
+	if !ok || run.FgEngineProcStart == "" {
+		return FgUnknown // pid alive but unverifiable — can prove neither ours-alive nor recycled-dead
+	}
+	if live != run.FgEngineProcStart {
+		return FgDead // the pid was recycled to a different process
+	}
+	return FgAlive
 }
 
 // RunEngineProvablyNotLive reports whether run's engine is DEFINITIVELY gone, so an external
-// reclaimer (the worktree sweep / PurgeRun's temp-root drop) may safely reclaim what the engine
-// left. The ONLY death proof is a recorded detached engine identity that is positively dead: a
-// run carrying an EnginePID whose process is dead or has been recycled to a different one
-// (!EngineAlive). Terminal status ALONE is not proof — StopRun flips a live FOREGROUND run to
-// "stopped" while reaping nothing (EnginePID 0 matches none of its kill branches), leaving its
-// engine writing under a stopped manifest; and a foreground/pre-stamp run records EnginePID 0 yet
-// may still be live. StopRun retains a reaped engine's pid + start token precisely so this check
-// has that evidence. Mirrors StopRun's fail-SAFE guard: never reclaim under a pid we cannot
-// positively disprove.
+// reclaimer (the worktree sweep / PurgeRun's temp-root drop) may safely reclaim what the engine left.
+// BOTH the detached and foreground branches are tri-state and demand PROOF of death: a recorded
+// DETACHED engine (EnginePID>0) is dead only when ClassifyDetachedEngine==DetachedDead (pid gone or a
+// readable identity mismatch) — an UNVERIFIABLE alive pid (argv+token unreadable) is NOT proof and
+// fails-safe to not-dead, mirroring the fg branch. With no detached pid, a FOREGROUND engine is dead
+// only when ClassifyFgEngine==FgDead; an absent/unverifiable fg identity (a pre-field record, a
+// still-live engine) is NOT proof. StopRun retains a reaped engine's pid + tokens precisely so this
+// check has the evidence.
 func RunEngineProvablyNotLive(run WorkflowRun) bool {
-	return run.EnginePID > 0 && !EngineAlive(run)
+	if run.EnginePID > 0 {
+		return ClassifyDetachedEngine(run) == DetachedDead
+	}
+	return ClassifyFgEngine(run) == FgDead
 }
 
+// leafProcessMayBeAlive reports whether a member leaf job MIGHT still have a running process — the
+// orphan risk that engine death does NOT settle: a SIGKILLed engine's `claude -p` leaf children run
+// in their OWN process groups (Setpgid) with cwd = the isolation worktree, so they outlive it. The
+// check is IDENTITY-first, never trusting a cached result — a bare engine SIGKILL makes StatusFor
+// synthesize a terminal (failVanished) for a still-LIVE orphan, so the result cache is unreliable:
+//   - BACKGROUND leaf: meta.PID IS the claude child → processAlive decides;
+//   - SYNC leaf with a recorded CHILD identity → the child's own pid+token decides (alive → possibly
+//     alive; dead/recycled → dead) REGARDLESS of any cached result;
+//   - SYNC leaf WITHOUT a child identity (old meta, or a crash between Start and the record): no
+//     verifiable child and the terminal shortcut is unsound → fail-safe POSSIBLY ALIVE, except a
+//     queued/never-execed leaf (PID<=0: no child, no worktree).
+//
+// An orphaned claude leaf is one-shot: it finishes and exits on its own, after which its recorded
+// identity reads dead and the workdir becomes reclaimable — same-boot reclamation with a delay equal
+// to the orphan's remaining runtime.
+func leafProcessMayBeAlive(meta jobMeta) bool {
+	if meta.SettingsPath != "" {
+		return processAlive(meta.PID, meta.SettingsPath, meta.ProcStart) // background: PID is the child
+	}
+	if meta.ChildPID > 0 {
+		return processAlive(meta.ChildPID, "", meta.ChildProcStart) // sync: the recorded child decides
+	}
+	if meta.ChildIdentityPending && meta.ChildPID == 0 {
+		// A sync member (the pending stamp is member-only) still in the Start window: a child may have
+		// started whose identity was never recorded, and PID being 0 (a hold premark clears it) says
+		// nothing about that child. Possibly-alive — aligns the read-side veto with the keep-rule.
+		return true
+	}
+	return meta.PID > 0 // sync, no child identity: execed → fail-safe alive; queued (PID 0) → dead
+}
+
+// isLiveOrphanVetoEvidence reports whether meta is a MEMBER leaf whose recorded CHILD identity is
+// alive-or-unverifiable — the veto evidence a worktree segment relies on. Every job-meta removal path
+// (GC, PurgeJobs, DeleteJob) must PRESERVE such a meta: deleting it would strip the segment's veto and
+// let a colliding reclaimer delete the live child's workdir. Deliberately SCOPED to CHILD-IDENTIFIED
+// metas (RunID != "" && ChildPID > 0): a synthesized terminal cache and a dead meta.PID (the engine
+// proxy) don't matter — the child identity outranks them. An identity-less sync meta (a pre-change job,
+// or a crash before the identity write) is NOT preserved here: its protection is the fail-safe veto
+// WHILE it lives, and the GC TTL bounds the exposure (a one-shot claude leaf outliving the TTL is not a
+// realistic lifetime, and preserving identity-less metas forever would break the GC contract).
+func isLiveOrphanVetoEvidence(meta jobMeta) bool {
+	return meta.RunID != "" && meta.ChildPID > 0 && leafProcessMayBeAlive(meta)
+}
+
+// isLiveOrPendingOrphanEvidence widens isLiveOrphanVetoEvidence with the Start-window: a sync member
+// whose identity write is still PENDING (ChildIdentityPending, no ChildPID yet). A crash inside the
+// ~ms cmd.Start→recordChildIdentity window leaves a LIVE orphan whose child identity was never
+// recorded; the read-side fail-safe (leafProcessMayBeAlive: sync, no ChildPID, PID>0 → possibly-alive)
+// already vetoes its segment, so AUTOMATED cleanup (GC/PurgeJobs) must KEEP the meta to match — else it
+// reaps the veto evidence and the chokepoint then deletes the workdir under the orphan. Rare + bounded
+// (a crash in that tiny window). The automated keep-rules AND PurgeRun's whole-run member walk use this
+// wider form — the walk is a NON-path-safe id's only segment guard (it skips the path-safe segment
+// verdict, which vetoes pending via leafProcessMayBeAlive). Only the EXPLICIT DeleteJob refusal stays on
+// the narrower isLiveOrphanVetoEvidence, so a DeleteJob on the pending job is the record-only recovery
+// escape (see DeleteJob). A legacy meta lacks the field (false), so the GC contract for pre-change
+// jobs is unchanged.
+func isLiveOrPendingOrphanEvidence(meta jobMeta) bool {
+	return isLiveOrphanVetoEvidence(meta) || (meta.RunID != "" && meta.ChildIdentityPending && meta.ChildPID == 0)
+}
+
+// runLeafScan does ONE jobs-dir pass, returning the set of run-ids that have a possibly-alive member
+// leaf and whether the scan succeeded (a scan error → false; callers must then fail safe / spare).
+func runLeafScan() (map[string]bool, bool) {
+	live := map[string]bool{}
+	dir, err := jobsDir()
+	if err != nil {
+		return live, false
+	}
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		if errors.Is(rerr, os.ErrNotExist) {
+			return live, true // no jobs yet → no live leaves
+		}
+		return live, false
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
+			continue
+		}
+		jobID := strings.TrimSuffix(name, ".json")
+		meta, merr := readMeta(dir, jobID)
+		if merr != nil {
+			// FAIL CLOSED: an unreadable / partial-JSON member meta makes SOME run's leaf state
+			// unknowable, and the id itself is unreadable so it can't be attributed to one segment —
+			// so the whole scan is untrusted (ok=false). Every consumer then spares/refuses.
+			return nil, false
+		}
+		if meta.RunID == "" {
+			continue // a standalone job (no run) — not a workflow member leaf
+		}
+		if leafProcessMayBeAlive(meta) {
+			live[meta.RunID] = true
+		}
+	}
+	return live, true
+}
+
+// SegmentReclaim is a worktree SEGMENT's reclaimability, aggregated over ALL runs mapping to it
+// (ids.WorktreeSegment) — path-safe or not. Worktree ownership is keyed by SEGMENT, not exact id, so a
+// per-id check would let a live "a.b" (segment "a-b") lose its workdirs to a dead "a-b" being reclaimed.
+// Vetoed: some owner is alive/unverifiable OR has a possibly-live leaf, so the segment's PRESENT
+// workdirs must never be deleted. Reclaimer: some PATH-SAFE owner is provably engine-dead AND leaf-free
+// — identity reclaim stays path-safe-only, so a non-path-safe id never RECLAIMS (leak-only) and, while
+// alive, always VETOES its segment. A present workdir is removable iff Reclaimer && !Vetoed.
+type SegmentReclaim struct {
+	Vetoed    bool
+	Reclaimer bool
+}
+
+// SegmentReclaimVerdicts builds the per-segment reclaim verdict in ONE ListRuns pass + ONE leaf scan
+// (the perf shape the sweep needs — it checks many segments without rescanning). A scan/list failure
+// returns ok=false so callers spare every present workdir (fail-safe).
+func SegmentReclaimVerdicts() (map[string]SegmentReclaim, bool) {
+	live, ok := runLeafScan()
+	if !ok {
+		return nil, false
+	}
+	runs, err := ListRuns()
+	if err != nil {
+		return nil, false
+	}
+	out := map[string]SegmentReclaim{}
+	// Project the leaf-liveness evidence into segment vetoes FIRST — independent of ListRuns. A member
+	// job meta's RunID is authoritative on its own, so a live leaf vetoes its segment even when the run's
+	// MANIFEST is unreadable (ListRuns silently skips a corrupt runs/<id>.json). This closes the
+	// corrupt-manifest sibling of the corrupt-meta hole: a live colliding owner (a.b whose manifest is
+	// corrupt) still vetoes segment a-b, so a dead path-safe a-b can never delete a.b's live workdir. An
+	// unreadable manifest only costs the Reclaimer half (it can never CONFIRM a reclaimer) — which stays
+	// fail-closed via the unknown-segment spare.
+	for runID := range live {
+		seg := ids.WorktreeSegment(runID)
+		v := out[seg]
+		v.Vetoed = true
+		out[seg] = v
+	}
+	for _, r := range runs {
+		seg := ids.WorktreeSegment(r.RunID)
+		v := out[seg]
+		if RunEngineProvablyNotLive(r) && !live[r.RunID] {
+			if seg == r.RunID { // a PATH-SAFE dead + leaf-free owner → an identity reclaimer
+				v.Reclaimer = true
+			}
+		} else {
+			v.Vetoed = true // an alive/unverifiable engine or a possibly-live leaf protects the segment
+		}
+		out[seg] = v
+	}
+	return out, true
+}
+
+// segReadDir is a seam so a test can drive the verdict-time segment snapshot — a workdir the snapshot
+// omits (a colliding owner's post-snapshot fresh-uuid creation) must survive PurgeRun's removal.
+var segReadDir = os.ReadDir
+
 // PurgeRun deletes a run entirely — the board's manual "delete" (the board never auto-clears, so runs
-// accumulate). A VERIFIABLY-LIVE detached engine is stopped AND confirmed dead before any file is
-// removed: the engine is recreate-safe (it rewrites a dropped manifest on its next save), so deleting
-// under a live engine would not stick and could race its writes; if it can't be confirmed dead, the
-// delete is aborted. A "running" manifest whose engine is GONE — crashed, or finished without
-// finalizing — is exactly the accumulated junk this is for, so it is removed as-is. The id is
-// validated before it becomes any path component.
+// accumulate). A VERIFIABLY-live detached engine is stopped AND confirmed dead before any file is
+// removed (the one-action delete-a-running-run): the engine is recreate-safe (it rewrites a dropped
+// manifest on its next save), so deleting under it would not stick and could race its writes; if it
+// can't be confirmed dead the delete is aborted. A detached pid alive but UNVERIFIABLE, and a live
+// FOREGROUND engine, are instead REFUSED (stop it first) — neither can be verify-reaped. A "running"
+// manifest whose engine is GONE — crashed, or finished without finalizing — is exactly the accumulated
+// junk this is for, so it is removed as-is. The id is validated before it becomes any path component.
 //
 // When no engine pid is recorded but the run is genuinely still writing — a --foreground
 // run, or a detached run in the moment between mint and its child stamping EnginePID — reads as
@@ -554,12 +792,36 @@ func PurgeRun(runID string) error {
 	if err := ids.ValidateJobID(runID); err != nil {
 		return err
 	}
-	if run, rerr := ReadRun(runID); rerr == nil && EngineAlive(run) {
-		if _, serr := StopRun(runID); serr != nil {
-			return serr
-		}
-		if !WaitEngineStopped(runID, 5*time.Second) {
-			return fmt.Errorf("subagent: run %s engine did not stop in time; delete aborted", runID)
+	if run, rerr := ReadRun(runID); rerr == nil {
+		if run.EnginePID > 0 {
+			switch ClassifyDetachedEngine(run) {
+			case DetachedLive:
+				// A VERIFIABLY-live detached engine → stop it + confirm dead before deleting anything (a
+				// verified reap + wait is safe, and this is the board's one-action delete-a-running-run).
+				// The worktreePurgeable re-read below then sees the terminal state.
+				if _, serr := StopRun(runID); serr != nil {
+					return serr
+				}
+				if !WaitEngineStopped(runID, 5*time.Second) {
+					return fmt.Errorf("subagent: run %s engine did not stop in time; delete aborted", runID)
+				}
+			case DetachedUnknown:
+				// A detached pid alive but UNVERIFIABLE (argv+token unreadable, or a blind-stop collapse
+				// left {stopped, retained pid}): we can neither kill-verify nor death-verify it, so we
+				// refuse — mirroring the foreground stance. Self-clearing: once it exits it reads
+				// DetachedDead and the delete proceeds.
+				return fmt.Errorf("subagent: run %s is still running (pid %d); stop it first (workflow stop), then delete", runID, run.EnginePID)
+			}
+			// DetachedDead → the accumulated junk this removes; proceed.
+		} else if run.FgEnginePID > 0 && ClassifyFgEngine(run) != FgDead {
+			// A recorded FOREGROUND engine we can't reap (it runs in the user's terminal, EnginePID 0)
+			// whose pid is alive-and-not-provably-dead: deleting its record/jobs/worktrees under it would
+			// corrupt a running run. Both FgAlive (token matches) and FgUnknown-WITH-a-recorded-pid (token
+			// empty/unreadable — a live pid we cannot disprove, mirroring the detached DetachedUnknown
+			// stance) refuse; a token MISMATCH reads FgDead (recycled) and proceeds. Self-clearing: once
+			// the pid exits it reads FgDead and the delete proceeds. A FgUnknown with NO recorded pid
+			// (FgEnginePID<=0 — a legacy / pre-field record) is not caught here and stays deletable.
+			return fmt.Errorf("subagent: run %s is running in the foreground (pid %d); stop it in its terminal (Ctrl-C) first, then delete", runID, run.FgEnginePID)
 		}
 	}
 	// Decide the worktree-temp purge NOW, while the manifest still exists: the RemoveAll near
@@ -573,10 +835,43 @@ func PurgeRun(runID string) error {
 	if run, rerr := ReadRun(runID); rerr == nil {
 		worktreePurgeable = RunEngineProvablyNotLive(run)
 	}
+	// Snapshot the run's OWN isolation-worktree segment AT VERDICT TIME — a colliding owner's
+	// post-snapshot fresh-uuid workdir is then structurally out of reach of the removal below
+	// (createWorktree always mints a NEW uuid dir under the segment, and nothing reuses a workdir path,
+	// so a listed entry can never be a later, live creation). Only a PATH-SAFE (segment == id),
+	// provably-dead (worktreePurgeable) run reclaims its segment; a non-path-safe id leaves it to the
+	// sweep. Refuse (RETRYABLE) when the shared segment is still in use — a live/colliding owner or an
+	// own orphan leaf vetoes — or its verdict can't be read (fail-closed: scan failed OR a MISSING entry
+	// refuses). An unverifiable-foreground run (not worktreePurgeable) skips this and deletes its record.
+	var segSnapshot []os.DirEntry
+	segDir := ""
+	if worktreePurgeable && ids.WorktreeSegment(runID) == runID {
+		d := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+		if entries, rerr := segReadDir(d); rerr == nil {
+			verdicts, vok := SegmentReclaimVerdicts()
+			if v, present := verdicts[runID]; !vok || !present || v.Vetoed {
+				return fmt.Errorf("subagent: run %s shares a worktree segment with a still-running engine or leaf; retry the delete after it exits", runID)
+			}
+			segDir, segSnapshot = d, entries
+		}
+	}
 	dir, err := jobsDir()
 	if err != nil {
 		return err
 	}
+	// Collect this run's member jobs in ONE walk and REFUSE — id-shape-independent, BEFORE removing
+	// anything — if ANY member is a live orphan OR still identity-PENDING: deleting its meta would erase
+	// segment ids.WorktreeSegment(runID)'s veto and let a colliding reclaimer delete the shared workdir
+	// under the (possible) orphan. This is the evidence-based gate the path-safe segment check above
+	// misses — a valid NON-path-safe id ("a.b") whose segment ("a-b") a path-safe reclaimer owns bypasses
+	// that branch entirely, so this walk is its ONLY segment guard. Pending-aware (isLiveOrPendingOrphan-
+	// Evidence) to match the automated keep-rules: a crash-window member (ChildIdentityPending, no
+	// ChildPID) is the sole veto for its segment and reaping it here would strip it. Legacy metas stay
+	// deletable: both arms require a field they lack (ChildPID>0 OR ChildIdentityPending), so identity-less
+	// old/non-isolation runs never trigger it. A live-orphan refusal self-clears once the
+	// one-shot orphan exits; a pending refusal is resolved by the explicit DeleteJob recovery escape (an
+	// unidentified orphan never records identity, so it never self-clears). The same walk feeds the removal.
+	var members []string
 	if entries, rerr := os.ReadDir(dir); rerr == nil {
 		for _, e := range entries {
 			name := e.Name()
@@ -584,24 +879,33 @@ func PurgeRun(runID string) error {
 				continue
 			}
 			jobID := strings.TrimSuffix(name, ".json")
-			if meta, merr := readMeta(dir, jobID); merr == nil && meta.RunID == runID {
-				removeJob(dir, jobID)
-				_ = pinned.Unpin(pinned.Job, jobID) // explicit delete clears any leaf pin marker
+			meta, merr := readMeta(dir, jobID)
+			if merr != nil || meta.RunID != runID {
+				continue
 			}
+			if isLiveOrPendingOrphanEvidence(meta) {
+				if meta.ChildPID > 0 {
+					return fmt.Errorf("subagent: run %s has a member leaf still running; retry the delete after it exits", runID)
+				}
+				return fmt.Errorf("subagent: run %s has a member (%s) whose leaf may have started but was never identified; delete that job to confirm it is gone, then retry", runID, jobID)
+			}
+			members = append(members, jobID)
 		}
 	}
-	// Drop the run's isolation-worktree temp workdirs BEFORE removing the manifest — only for a
-	// provably-dead run (decided above) and only when the run id is a safe path segment. Removing the
-	// workdir first means a successful removal (or a crash right after it) leaves the workdir gone
-	// while the manifest still proves death, so the next same-repo sweep reclaims the git registration
-	// via its workdir-missing clause; deleting the manifest first would strand that registration if
-	// this RemoveAll then failed (unknown segment + present workdir = spared forever). Best-effort — a
-	// failed removal never fails the purge; the residual clears on reboot, after which it is
-	// reclaimable. ValidateJobID (top) already rejects separators, so of the worktree-root-remapped
-	// forms only a '.'/':' can reach here; a run id bearing one leaves its workdirs to the next
-	// same-repo engine's startup sweep.
-	if worktreePurgeable && !strings.ContainsAny(runID, `.:/\`) {
-		_ = os.RemoveAll(filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID))
+	for _, jobID := range members {
+		removeJob(dir, jobID)
+		_ = pinned.Unpin(pinned.Job, jobID) // explicit delete clears any leaf pin marker
+	}
+	// Remove exactly the workdirs the verdict-time snapshot listed — BEFORE the manifest — so a
+	// mid-removal crash leaves the workdir gone while the record still proves death (the sweep's
+	// workdir-missing clause then reclaims the git registration; deleting the manifest first would strand
+	// it unknown-present). Then remove the segment dir only if now EMPTY: a plain os.Remove tolerates
+	// ENOTEMPTY as a leak-not-delete residual, so a surviving post-snapshot colliding workdir keeps it.
+	if segDir != "" {
+		for _, e := range segSnapshot {
+			_ = os.RemoveAll(filepath.Join(segDir, e.Name()))
+		}
+		_ = os.Remove(segDir)
 	}
 	removeRun(filepath.Join(dir, runsDirName), runID)
 	_ = pinned.Unpin(pinned.Run, runID) // explicit delete is the sanctioned removal of a pinned run
@@ -611,8 +915,9 @@ func PurgeRun(runID string) error {
 // PruneRuns deletes every run whose engine is no longer alive — crashed/killed runs still stuck
 // "running", plus terminal ones — while sparing any run with a live engine. Each delete runs under the
 // per-run execution lock so it can't race a concurrent restart/resume, and the sweep is best-effort:
-// one run that won't delete (an unverifiable-live engine PurgeRun refuses) doesn't abort the rest.
-// Returns the number of runs removed.
+// a run PurgeRun refuses (an unverifiable-live engine, or one with a still-live orphan leaf) leaves
+// `removed` unincremented and the loop continues — it never aborts the rest, and the run is retried
+// next pass. Returns the number of runs removed.
 func PruneRuns() (int, error) {
 	runs, err := ListRuns()
 	if err != nil {
@@ -650,19 +955,43 @@ func PruneRuns() (int, error) {
 	return removed, nil
 }
 
-// isLiveOrUnverifiable reports whether a run might still be writing — a verifiably-live detached
-// engine, OR a still-"running" run with no reapable pid (a --foreground run, or a detached run in the
-// mint→stamp-pid window). PruneRuns spares both: deleting under either could yank files from a live
-// engine. Mirrors the fail-closed liveness guard the resume/restart paths use. A terminal run, or a
-// crashed detached run (recorded pid now dead), is not protected — exactly what prune reaps.
+// isLiveOrUnverifiable reports whether a run might still be writing, so PruneRuns spares it (deleting
+// its record/jobs under a live engine would yank files out from under it). A verifiably-live DETACHED
+// engine is protected; a detached pid that is dead/recycled is not. With no reapable detached pid
+// (EnginePID<=0) the FOREGROUND identity decides: FgAlive (a live foreground engine, including a
+// blind-stopped one) is protected; a recorded fg pid alive but token-unverifiable (FgUnknown WITH
+// FgEnginePID>0) is spared the same way — a live pid we can't disprove (mirrors PurgeRun's refusal);
+// FgDead (exited/crashed) is prunable — consistent with resume now allowing it; a FgUnknown with NO
+// recorded pid (pre-field / mint→stamp) keeps the prior status-based behavior (a still-"running" one
+// spared, a terminal one prunable) so a legacy record isn't stranded. Mirrors the fail-closed liveness
+// guard the resume/restart paths use.
 func isLiveOrUnverifiable(run WorkflowRun) bool {
-	return EngineAlive(run) || (run.Status == "running" && run.EnginePID <= 0)
+	if run.EnginePID > 0 {
+		// A detached engine is live-or-unverifiable unless PROVABLY dead: DetachedDead (pid gone or a
+		// readable identity mismatch) → prunable; DetachedLive, and DetachedUnknown (a retained pid alive
+		// but unverifiable — argv+token unreadable) → SPARED, so PruneRuns never deletes a run whose
+		// engine it can't prove dead. Self-clearing: once that pid exits it reads DetachedDead and normal
+		// pruning applies.
+		return ClassifyDetachedEngine(run) != DetachedDead
+	}
+	switch ClassifyFgEngine(run) {
+	case FgAlive:
+		return true
+	case FgDead:
+		return false
+	default: // FgUnknown
+		if run.FgEnginePID > 0 {
+			return true // a recorded fg pid we can't disprove — spare it (mirrors PurgeRun's refusal)
+		}
+		return run.Status == "running" // no recorded pid (pre-field / mint→stamp) — status-based, don't strand a legacy record
+	}
 }
 
 // WaitEngineStopped polls a run's engine liveness until it is gone or the deadline passes (true once
 // EngineAlive is false / the manifest is unreadable, false on timeout). EngineAlive fails SOFT (an
-// unreadable argv reads as alive), so a stuck poll times out into the caller's fail-closed path rather
-// than touching files under a still-live engine. Shared by PurgeRun (delete) and workflow.Restart.
+// alive-but-UNVERIFIABLE pid — argv + token unreadable — reads as alive), so a stuck poll times out into
+// the caller's fail-closed path rather than declaring death and touching files under a still-live engine.
+// Shared by StopRun's reap, PurgeRun (delete), and workflow.Restart.
 func WaitEngineStopped(runID string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for {

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -1,6 +1,8 @@
 package subagent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +19,46 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/pinned"
 )
+
+// WorktreeTempName is the shared root dir under os.TempDir() for isolation-worktree temp workdirs;
+// beneath it each config store gets its own WorktreeStoreID() subdir.
+const WorktreeTempName = "cc-fleet-worktrees"
+
+// WorktreeStoreID is a stable, filesystem-safe identifier for THIS config store — a short hash of
+// config.ConfigDir. The isolation-worktree temp root lives under os.TempDir(), which is NOT per-store,
+// so two config stores (different HOME/XDG_CONFIG_HOME) running in the same git repo could otherwise
+// collide on a worktree SEGMENT and have one store's reclaim delete the other's LIVE worktree — a
+// store-local reclaim verdict can't see a foreign store's runs, so it records no veto. Namespacing the
+// temp root by store id puts a foreign store's worktrees under a DIFFERENT prefix, so they never enter
+// this store's sweep/purge candidate set (structural, not a runtime ownership check).
+func WorktreeStoreID() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	// Absolutize (and clean) before hashing so the id reflects the ACTUAL physical store, not the raw
+	// config string: a relative XDG_CONFIG_HOME resolves against cwd, so two processes at different cwds
+	// are DIFFERENT stores that must not share a worktree namespace (else the cross-store reclaim hole
+	// reopens). filepath.Abs resolves relative-to-cwd and Cleans '..'/'.'/trailing slashes; a symlinked
+	// alias hashing differently only over-isolates (each store cleans its own), which is safe.
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(abs))
+	return hex.EncodeToString(sum[:8]), nil
+}
+
+// WorktreeStoreDir is this store's isolation-worktree temp root: os.TempDir()/cc-fleet-worktrees/<storeID>.
+// A run's own segment is WorktreeStoreDir()/<ids.WorktreeSegment(runID)>. The path is un-canonicalized
+// (os.TempDir() form) for creation/removal; a caller matching git porcelain paths canonicalizes itself.
+func WorktreeStoreDir() (string, error) {
+	id, err := WorktreeStoreID()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(os.TempDir(), WorktreeTempName, id), nil
+}
 
 // runsDirName holds run manifests under the jobs dir: ConfigDir/subagent-jobs/runs.
 // A manifest <runId>.json is the canonical phase sequencer for a workflow run; the
@@ -330,6 +372,51 @@ func ListRuns() ([]WorkflowRun, error) {
 		return runs[i].StartedAt > runs[j].StartedAt
 	})
 	return runs, nil
+}
+
+// listRunsForReclaim is ListRuns specialized for the worktree-reclaim verdict, with one difference that
+// matters for fail-closed safety: a manifest whose read FAILS transiently/IO (a non-ErrNotExist fault
+// the retry couldn't outlast) is NOT silently dropped — its run id (the filename stem) is returned in
+// unreadable so the verdict can VETO that segment. ListRuns' silent skip is right for a listing but
+// wrong here: a colliding live owner ("a.b", segment "a-b") whose manifest is momentarily unreadable
+// would vanish from the run set, letting a dead path-safe twin ("a-b") reclaim the shared workdir under
+// it. A readable-but-corrupt manifest stays a skip (AtomicWrite never tears a readable file, so it is
+// genuine junk that must stay reclaimable — matching the parse-error-stays-deletable rule); a file that
+// vanished between the dir scan and the read (ErrNotExist) is a skip too (genuinely gone).
+func listRunsForReclaim() (runs []WorkflowRun, unreadable []string, ok bool) {
+	dir, err := runsDir()
+	if err != nil {
+		return nil, nil, false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, true // nothing has run yet
+		}
+		return nil, nil, false
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		data, rerr := readFileRetry(filepath.Join(dir, name))
+		if rerr != nil {
+			if errors.Is(rerr, os.ErrNotExist) {
+				continue // vanished between the dir scan and the read — genuinely gone
+			}
+			// A persistent read/IO fault leaves the run behind this manifest unknowable → fail closed by
+			// flagging it so the verdict VETOes its segment. SaveRun writes <runID>.json, so the id is the stem.
+			unreadable = append(unreadable, strings.TrimSuffix(name, ".json"))
+			continue
+		}
+		var run WorkflowRun
+		if json.Unmarshal(data, &run) != nil {
+			continue // readable but corrupt → deletable junk
+		}
+		runs = append(runs, run)
+	}
+	return runs, unreadable, true
 }
 
 // runIsRecent reports whether a run's last activity — the LATER of StartedAt and the
@@ -746,7 +833,7 @@ type SegmentReclaim struct {
 	Reclaimer bool
 }
 
-// SegmentReclaimVerdicts builds the per-segment reclaim verdict in ONE ListRuns pass + ONE leaf scan
+// SegmentReclaimVerdicts builds the per-segment reclaim verdict in ONE runs-dir pass + ONE leaf scan
 // (the perf shape the sweep needs — it checks many segments without rescanning). A scan/list failure
 // returns ok=false so callers spare every present workdir (fail-safe).
 func SegmentReclaimVerdicts() (map[string]SegmentReclaim, bool) {
@@ -754,19 +841,30 @@ func SegmentReclaimVerdicts() (map[string]SegmentReclaim, bool) {
 	if !ok {
 		return nil, false
 	}
-	runs, err := ListRuns()
-	if err != nil {
+	runs, unreadable, ok := listRunsForReclaim()
+	if !ok {
 		return nil, false
 	}
 	out := map[string]SegmentReclaim{}
-	// Project the leaf-liveness evidence into segment vetoes FIRST — independent of ListRuns. A member
-	// job meta's RunID is authoritative on its own, so a live leaf vetoes its segment even when the run's
-	// MANIFEST is unreadable (ListRuns silently skips a corrupt runs/<id>.json). This closes the
-	// corrupt-manifest sibling of the corrupt-meta hole: a live colliding owner (a.b whose manifest is
-	// corrupt) still vetoes segment a-b, so a dead path-safe a-b can never delete a.b's live workdir. An
-	// unreadable manifest only costs the Reclaimer half (it can never CONFIRM a reclaimer) — which stays
-	// fail-closed via the unknown-segment spare.
+	// Two vetoes are applied BEFORE the run loop, each independent of a readable manifest:
+	//
+	// (1) leaf liveness. A member job meta's RunID is authoritative on its own, so a live leaf vetoes its
+	// segment even when the run's manifest is corrupt (readable but bad JSON — skipped by
+	// listRunsForReclaim). This closes the corrupt-manifest sibling of the corrupt-meta hole: a live
+	// colliding owner (a.b whose manifest is truncated) still vetoes segment a-b, so a dead path-safe a-b
+	// can never delete a.b's live workdir.
 	for runID := range live {
+		seg := ids.WorktreeSegment(runID)
+		v := out[seg]
+		v.Vetoed = true
+		out[seg] = v
+	}
+	// (2) unreadable manifest. A manifest whose read FAILED (a transient/IO fault, not absent, not
+	// corrupt) leaves its run's engine liveness unknowable — and, unlike (1), there may be NO leaf meta
+	// yet (the owner is still inside createWorktree→registration). Fail CLOSED: veto its segment so a dead
+	// path-safe twin mapping to the same segment can't reclaim the shared workdir under the possibly-live
+	// owner.
+	for _, runID := range unreadable {
 		seg := ids.WorktreeSegment(runID)
 		v := out[seg]
 		v.Vetoed = true
@@ -870,8 +968,9 @@ func PurgeRun(runID string) error {
 	// refuses). An unverifiable-foreground run (not worktreePurgeable) skips this and deletes its record.
 	var segSnapshot []os.DirEntry
 	segDir := ""
-	if worktreePurgeable && ids.WorktreeSegment(runID) == runID {
-		d := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	storeDir, storeErr := WorktreeStoreDir()
+	if storeErr == nil && worktreePurgeable && ids.WorktreeSegment(runID) == runID {
+		d := filepath.Join(storeDir, runID)
 		if entries, rerr := segReadDir(d); rerr == nil {
 			verdicts, vok := SegmentReclaimVerdicts()
 			if v, present := verdicts[runID]; !vok || !present || v.Vetoed {

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -381,8 +381,10 @@ func StopRun(runID string) (WorkflowRun, error) {
 	}
 	run.Status = "stopped"
 	run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	run.EnginePID = 0 // a stopped run has no engine; clear the stale pid
-	run.EngineProcStart = ""
+	// Keep EnginePID + EngineProcStart: for a reaped DETACHED run they are the death evidence
+	// RunEngineProvablyNotLive relies on (a positively-dead recorded pid — the token also disproves
+	// a recycled pid). A foreground run recorded 0 and stays 0, so it correctly reads NOT provably
+	// dead — nothing was reaped and its engine may still be writing. A resume re-stamps both.
 	if serr := SaveRun(run); serr != nil {
 		return WorkflowRun{}, serr
 	}
@@ -521,6 +523,20 @@ func EngineAlive(run WorkflowRun) bool {
 	return argvIsRunEngine(argv, run.RunID)
 }
 
+// RunEngineProvablyNotLive reports whether run's engine is DEFINITIVELY gone, so an external
+// reclaimer (the worktree sweep / PurgeRun's temp-root drop) may safely reclaim what the engine
+// left. The ONLY death proof is a recorded detached engine identity that is positively dead: a
+// run carrying an EnginePID whose process is dead or has been recycled to a different one
+// (!EngineAlive). Terminal status ALONE is not proof — StopRun flips a live FOREGROUND run to
+// "stopped" while reaping nothing (EnginePID 0 matches none of its kill branches), leaving its
+// engine writing under a stopped manifest; and a foreground/pre-stamp run records EnginePID 0 yet
+// may still be live. StopRun retains a reaped engine's pid + start token precisely so this check
+// has that evidence. Mirrors StopRun's fail-SAFE guard: never reclaim under a pid we cannot
+// positively disprove.
+func RunEngineProvablyNotLive(run WorkflowRun) bool {
+	return run.EnginePID > 0 && !EngineAlive(run)
+}
+
 // PurgeRun deletes a run entirely — the board's manual "delete" (the board never auto-clears, so runs
 // accumulate). A VERIFIABLY-LIVE detached engine is stopped AND confirmed dead before any file is
 // removed: the engine is recreate-safe (it rewrites a dropped manifest on its next save), so deleting
@@ -546,6 +562,17 @@ func PurgeRun(runID string) error {
 			return fmt.Errorf("subagent: run %s engine did not stop in time; delete aborted", runID)
 		}
 	}
+	// Decide the worktree-temp purge NOW, while the manifest still exists: the RemoveAll near
+	// the end deletes the run's isolation-worktree WORKDIRS, which — unlike the git registration
+	// a later sweep reclaims — are not recreate-safe, so they must never be dropped under a live
+	// engine's leaves. Purge only when the run is PROVABLY dead: a successful stop left a terminal
+	// status, and a crashed detached run reads dead; a running FOREGROUND run (EnginePID 0) is not
+	// provably dead, so its live leaves keep their cwd for their own cleanup or a later sweep. A
+	// re-read failure (record already gone) fails closed → skip.
+	worktreePurgeable := false
+	if run, rerr := ReadRun(runID); rerr == nil {
+		worktreePurgeable = RunEngineProvablyNotLive(run)
+	}
 	dir, err := jobsDir()
 	if err != nil {
 		return err
@@ -562,6 +589,19 @@ func PurgeRun(runID string) error {
 				_ = pinned.Unpin(pinned.Job, jobID) // explicit delete clears any leaf pin marker
 			}
 		}
+	}
+	// Drop the run's isolation-worktree temp workdirs BEFORE removing the manifest — only for a
+	// provably-dead run (decided above) and only when the run id is a safe path segment. Removing the
+	// workdir first means a successful removal (or a crash right after it) leaves the workdir gone
+	// while the manifest still proves death, so the next same-repo sweep reclaims the git registration
+	// via its workdir-missing clause; deleting the manifest first would strand that registration if
+	// this RemoveAll then failed (unknown segment + present workdir = spared forever). Best-effort — a
+	// failed removal never fails the purge; the residual clears on reboot, after which it is
+	// reclaimable. ValidateJobID (top) already rejects separators, so of the worktree-root-remapped
+	// forms only a '.'/':' can reach here; a run id bearing one leaves its workdirs to the next
+	// same-repo engine's startup sweep.
+	if worktreePurgeable && !strings.ContainsAny(runID, `.:/\`) {
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID))
 	}
 	removeRun(filepath.Join(dir, runsDirName), runID)
 	_ = pinned.Unpin(pinned.Run, runID) // explicit delete is the sanctioned removal of a pinned run

--- a/internal/subagent/run.go
+++ b/internal/subagent/run.go
@@ -759,8 +759,8 @@ func leafProcessMayBeAlive(meta jobMeta) bool {
 // (GC, PurgeJobs, DeleteJob) must PRESERVE such a meta: deleting it would strip the segment's veto and
 // let a colliding reclaimer delete the live child's workdir. Deliberately SCOPED to CHILD-IDENTIFIED
 // metas (RunID != "" && ChildPID > 0): a synthesized terminal cache and a dead meta.PID (the engine
-// proxy) don't matter — the child identity outranks them. An identity-less sync meta (a pre-change job,
-// or a crash before the identity write) is NOT preserved here: its protection is the fail-safe veto
+// proxy) don't matter — the child identity outranks them. An identity-less sync meta (a legacy job
+// predating the identity fields) is NOT preserved here: its protection is the fail-safe veto
 // WHILE it lives, and the GC TTL bounds the exposure (a one-shot claude leaf outliving the TTL is not a
 // realistic lifetime, and preserving identity-less metas forever would break the GC contract).
 func isLiveOrphanVetoEvidence(meta jobMeta) bool {
@@ -772,13 +772,13 @@ func isLiveOrphanVetoEvidence(meta jobMeta) bool {
 // ~ms cmd.Start→recordChildIdentity window leaves a LIVE orphan whose child identity was never
 // recorded; the read-side fail-safe (leafProcessMayBeAlive: sync, no ChildPID, PID>0 → possibly-alive)
 // already vetoes its segment, so AUTOMATED cleanup (GC/PurgeJobs) must KEEP the meta to match — else it
-// reaps the veto evidence and the chokepoint then deletes the workdir under the orphan. Rare + bounded
-// (a crash in that tiny window). The automated keep-rules AND PurgeRun's whole-run member walk use this
-// wider form — the walk is a NON-path-safe id's only segment guard (it skips the path-safe segment
-// verdict, which vetoes pending via leafProcessMayBeAlive). Only the EXPLICIT DeleteJob refusal stays on
-// the narrower isLiveOrphanVetoEvidence, so a DeleteJob on the pending job is the record-only recovery
-// escape (see DeleteJob). A legacy meta lacks the field (false), so the GC contract for pre-change
-// jobs is unchanged.
+// reaps the veto evidence and the chokepoint then deletes the workdir under the orphan. Rare (a crash
+// in that tiny window), and kept regardless of age until an explicit DeleteJob recovers it. The
+// automated keep-rules AND PurgeRun's whole-run member walk use this wider form — the walk is a
+// NON-path-safe id's only segment guard (it skips the path-safe segment verdict, which vetoes pending
+// via leafProcessMayBeAlive). Only the EXPLICIT DeleteJob refusal stays on the narrower
+// isLiveOrphanVetoEvidence, so a DeleteJob on the pending job is the record-only recovery escape (see
+// DeleteJob). A legacy meta lacks the field (false), so the GC contract for legacy jobs is unchanged.
 func isLiveOrPendingOrphanEvidence(meta jobMeta) bool {
 	return isLiveOrphanVetoEvidence(meta) || (meta.RunID != "" && meta.ChildIdentityPending && meta.ChildPID == 0)
 }

--- a/internal/subagent/run_purge_worktree_test.go
+++ b/internal/subagent/run_purge_worktree_test.go
@@ -1,0 +1,125 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// seedWorktreeTemp creates a cc-fleet-worktrees/<runID> temp tree (mirroring a run's
+// isolation-worktree workdir root), registers its cleanup, and returns its path.
+func seedWorktreeTemp(t *testing.T, runID string) string {
+	t.Helper()
+	wtDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	if err := os.MkdirAll(filepath.Join(wtDir, "x"), 0o700); err != nil {
+		t.Fatalf("mkdir worktree temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(wtDir) })
+	return wtDir
+}
+
+const deadEnginePID = 0x7ffffffe // never a live process in the test env → provably dead
+
+// TestPurgeRunWorktreeTempGating: PurgeRun drops a run's isolation-worktree temp workdirs ONLY
+// when the run is provably dead — a recorded detached pid that is dead. A crashed detached run,
+// and a detached run taken down via the real StopRun path (dead pid + start token retained as the
+// death evidence), are purged. A running FOREGROUND run, a FOREGROUND run blind-flipped to
+// "stopped" by StopRun (EnginePID 0 — nothing reaped, engine may still be live), and an ABSENT
+// record are all left intact — the workdir may be a live leaf's cwd, and it is not recreate-safe.
+func TestPurgeRunWorktreeTempGating(t *testing.T) {
+	t.Run("crashed detached (running, dead pid) → removed", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "run-purge-crashed"
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: deadEnginePID})
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun: %v", err)
+		}
+		if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+			t.Errorf("crashed-detached run's worktree temp dir should be gone (err=%v)", err)
+		}
+	})
+
+	t.Run("detached stopped via real StopRun → provably dead → removed", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "run-purge-stopped"
+		wtDir := seedWorktreeTemp(t, runID)
+		// A detached run whose engine pid is already dead: StopRun reaps nothing to kill, flips it
+		// to "stopped", and RETAINS the dead pid as the death evidence.
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: deadEnginePID})
+		stopped, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("StopRun: %v", err)
+		}
+		if stopped.EnginePID != deadEnginePID {
+			t.Errorf("StopRun must retain the dead detached pid as death evidence, got EnginePID=%d", stopped.EnginePID)
+		}
+		if !RunEngineProvablyNotLive(stopped) {
+			t.Error("a detached run stopped via StopRun must remain provably dead (pid retained + dead)")
+		}
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun: %v", err)
+		}
+		if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+			t.Errorf("stopped-detached run's worktree temp dir should be gone (err=%v)", err)
+		}
+	})
+
+	t.Run("foreground flipped to stopped via real StopRun → survives", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "run-purge-fg-stopped"
+		wtDir := seedWorktreeTemp(t, runID)
+		// A live FOREGROUND run records EnginePID 0. `workflow stop` blind-flips it to "stopped"
+		// while reaping nothing — the engine may still be writing, so it must NOT read as dead.
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0})
+		stopped, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("StopRun: %v", err)
+		}
+		if RunEngineProvablyNotLive(stopped) {
+			t.Error("a foreground run blind-flipped to stopped (EnginePID 0) must NOT read as provably dead")
+		}
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun: %v", err)
+		}
+		if _, err := os.Stat(wtDir); err != nil {
+			t.Errorf("foreground-stopped run's worktree temp dir must survive the purge (err=%v)", err)
+		}
+	})
+
+	t.Run("running foreground (EnginePID 0) → survives", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "run-purge-fg"
+		wtDir := seedWorktreeTemp(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0})
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun: %v", err)
+		}
+		if _, err := os.Stat(wtDir); err != nil {
+			t.Errorf("running-foreground run's worktree temp dir must survive the purge (err=%v)", err)
+		}
+	})
+
+	t.Run("absent record → survives (fail closed)", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "run-purge-absent"
+		wtDir := seedWorktreeTemp(t, runID)
+		// No manifest: PurgeRun's provable-death re-read fails → fail closed → temp left intact.
+
+		if err := PurgeRun(runID); err != nil {
+			t.Fatalf("PurgeRun: %v", err)
+		}
+		if _, err := os.Stat(wtDir); err != nil {
+			t.Errorf("absent-record run's worktree temp dir must survive the purge (err=%v)", err)
+		}
+	})
+}

--- a/internal/subagent/run_purge_worktree_test.go
+++ b/internal/subagent/run_purge_worktree_test.go
@@ -6,11 +6,59 @@ import (
 	"testing"
 )
 
-// seedWorktreeTemp creates a cc-fleet-worktrees/<runID> temp tree (mirroring a run's
-// isolation-worktree workdir root), registers its cleanup, and returns its path.
+// TestWorktreeStoreIDDistinctForRelativeConfig (codex r35): WorktreeStoreID must hash an ABSOLUTE config
+// path, so a relative XDG_CONFIG_HOME (which resolves against cwd) yields DISTINCT ids from different
+// cwds — two different physical stores must never share a worktree namespace (else the cross-store
+// reclaim hole reopens). No test in this package runs in parallel, so the process-global chdir is safe.
+func TestWorktreeStoreIDDistinctForRelativeConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", ".xdg") // relative → resolves against cwd
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	idRoot, err := WorktreeStoreID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(sub); err != nil {
+		t.Fatal(err)
+	}
+	idSub, err := WorktreeStoreID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idRoot == idSub {
+		t.Error("a relative XDG_CONFIG_HOME from different cwds must yield DISTINCT store ids (different physical stores)")
+	}
+}
+
+// storeWorktreeDir is this store's isolation-worktree temp root as production computes it
+// (WorktreeStoreDir), so a test seeds workdirs where createWorktree / PurgeRun look after the per-store
+// namespacing. Both read the same process env, so the store id always matches production in-test.
+func storeWorktreeDir(t *testing.T) string {
+	t.Helper()
+	d, err := WorktreeStoreDir()
+	if err != nil {
+		t.Fatalf("WorktreeStoreDir: %v", err)
+	}
+	return d
+}
+
+// seedWorktreeTemp creates a <store>/<runID> temp tree (mirroring a run's isolation-worktree workdir
+// root), registers its cleanup, and returns its path.
 func seedWorktreeTemp(t *testing.T, runID string) string {
 	t.Helper()
-	wtDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	wtDir := filepath.Join(storeWorktreeDir(t), runID)
 	if err := os.MkdirAll(filepath.Join(wtDir, "x"), 0o700); err != nil {
 		t.Fatalf("mkdir worktree temp: %v", err)
 	}

--- a/internal/subagent/run_purge_worktree_test.go
+++ b/internal/subagent/run_purge_worktree_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// TestWorktreeStoreIDDistinctForRelativeConfig (codex r35): WorktreeStoreID must hash an ABSOLUTE config
+// TestWorktreeStoreIDDistinctForRelativeConfig: WorktreeStoreID must hash an ABSOLUTE config
 // path, so a relative XDG_CONFIG_HOME (which resolves against cwd) yields DISTINCT ids from different
 // cwds — two different physical stores must never share a worktree namespace (else the cross-store
 // reclaim hole reopens). No test in this package runs in parallel, so the process-global chdir is safe.

--- a/internal/subagent/run_readretry_test.go
+++ b/internal/subagent/run_readretry_test.go
@@ -1,0 +1,140 @@
+package subagent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// injectManifestRead makes the run-manifest read for runID fail with a transient (sharing-violation-
+// shaped) error — persistently when failN < 0, or only the first failN reads then the real bytes —
+// while every other read is served normally. It wires the sentinel into transientRead so readFileRetry
+// treats it as the retryable class on unix, where the production isSharingViolation is always false.
+// Returns a pointer to the manifest read count. Both seams are restored on cleanup.
+func injectManifestRead(t *testing.T, runID string, failN int) *int {
+	t.Helper()
+	sentinel := errors.New("simulated ERROR_SHARING_VIOLATION")
+	target := filepath.Join(runsDirName, runID+".json")
+	realRead, realPred := osReadFile, transientRead
+	calls := 0
+	osReadFile = func(path string) ([]byte, error) {
+		if strings.HasSuffix(path, target) {
+			calls++
+			if failN < 0 || calls <= failN {
+				return nil, sentinel
+			}
+		}
+		return realRead(path)
+	}
+	transientRead = func(err error) bool { return errors.Is(err, sentinel) || realPred(err) }
+	t.Cleanup(func() { osReadFile, transientRead = realRead, realPred })
+	return &calls
+}
+
+func newReadRetryEnv(t *testing.T) {
+	t.Helper()
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(xdg, "cc-fleet", jobsDirName), 0o700); err != nil {
+		t.Fatalf("mkdir jobs: %v", err)
+	}
+}
+
+// TestReadRun_AbsorbsTransientSharingViolation: a transient-then-success manifest read is retried past
+// the sharing-violation window (a) and returns the parsed manifest, not an error.
+func TestReadRun_AbsorbsTransientSharingViolation(t *testing.T) {
+	newReadRetryEnv(t)
+	writeRunForTest(t, WorkflowRun{RunID: "run-transient", Name: "flaky", StartedAt: nowRFC3339(), Status: "running"})
+
+	calls := injectManifestRead(t, "run-transient", 2) // fail twice, then serve the real bytes
+
+	run, err := ReadRun("run-transient")
+	if err != nil {
+		t.Fatalf("ReadRun should absorb a transient sharing violation, got %v", err)
+	}
+	if run.RunID != "run-transient" || run.Name != "flaky" {
+		t.Fatalf("ReadRun returned the wrong manifest: %+v", run)
+	}
+	if *calls != 3 {
+		t.Fatalf("manifest read attempts = %d, want 3 (two retries then success)", *calls)
+	}
+}
+
+// TestReadRun_PersistentReadFailIsUnreadable: a persistent transient read surfaces as
+// errRunManifestUnreadable — NOT os.ErrNotExist — so destructive/liveness callers can fail closed.
+func TestReadRun_PersistentReadFailIsUnreadable(t *testing.T) {
+	newReadRetryEnv(t)
+	writeRunForTest(t, WorkflowRun{RunID: "run-io", StartedAt: nowRFC3339(), Status: "running"})
+	injectManifestRead(t, "run-io", -1)
+
+	_, err := ReadRun("run-io")
+	if !errors.Is(err, errRunManifestUnreadable) {
+		t.Fatalf("want errRunManifestUnreadable, got %v", err)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("a transient read failure must not read as ErrNotExist: %v", err)
+	}
+}
+
+// TestWaitEngineStopped_TransientReadNotStopped: a persistent transient manifest read does NOT report
+// the engine stopped (b) — it times out into the caller's fail-closed path instead of declaring death.
+func TestWaitEngineStopped_TransientReadNotStopped(t *testing.T) {
+	newReadRetryEnv(t)
+	writeRunForTest(t, WorkflowRun{RunID: "run-wait", StartedAt: nowRFC3339(), Status: "running", EnginePID: os.Getpid()})
+	injectManifestRead(t, "run-wait", -1)
+
+	if WaitEngineStopped("run-wait", 60*time.Millisecond) {
+		t.Fatal("WaitEngineStopped must NOT report stopped on a persistent transient read (fail closed)")
+	}
+}
+
+// TestWaitEngineStopped_MissingIsStopped: a genuinely-absent manifest (os.ErrNotExist) DOES report
+// stopped — the one read-error that means gone.
+func TestWaitEngineStopped_MissingIsStopped(t *testing.T) {
+	newReadRetryEnv(t)
+	if !WaitEngineStopped("run-gone", 60*time.Millisecond) {
+		t.Fatal("WaitEngineStopped should report stopped when the manifest is genuinely absent")
+	}
+}
+
+// TestPurgeRun_TransientReadFailsClosed: PurgeRun on a persistent transient manifest read deletes
+// NOTHING and returns the unreadable error (c); on a genuinely-absent manifest it proceeds (nil).
+func TestPurgeRun_TransientReadFailsClosed(t *testing.T) {
+	newReadRetryEnv(t)
+	writeRunForTest(t, WorkflowRun{RunID: "run-purge", StartedAt: nowRFC3339(), Status: "running", EnginePID: os.Getpid()})
+	injectManifestRead(t, "run-purge", -1)
+
+	if err := PurgeRun("run-purge"); !errors.Is(err, errRunManifestUnreadable) {
+		t.Fatalf("PurgeRun on a transient read must fail closed with errRunManifestUnreadable, got %v", err)
+	}
+	if !runManifestExists(t, "run-purge") {
+		t.Fatal("PurgeRun failed closed but still deleted the manifest")
+	}
+
+	// A genuinely-absent run proceeds (nothing to delete) — the accumulated-junk path stays open.
+	if err := PurgeRun("run-absent"); err != nil {
+		t.Fatalf("PurgeRun of an absent run should proceed (nil), got %v", err)
+	}
+}
+
+// TestGC_SparesRunWithUnreadableManifest: a reclaim scan spares a memberless run whose manifest read
+// persistently errors (d) — PurgeRun fails closed, so GC never reaps under a possibly-live engine.
+func TestGC_SparesRunWithUnreadableManifest(t *testing.T) {
+	newReadRetryEnv(t)
+	// An OLD, memberless manifest that, read successfully, would be pruned as an aged orphan.
+	writeRunForTest(t, WorkflowRun{RunID: "run-gc", StartedAt: "2000-01-01T00:00:00Z", Status: "running"})
+	injectManifestRead(t, "run-gc", -1)
+
+	if out := GC(0); !out.OK {
+		t.Fatalf("GC(0) failed: %s", out.ErrorMsg)
+	}
+	if !runManifestExists(t, "run-gc") {
+		t.Fatal("GC must spare a run whose manifest read persistently errors, not reclaim it")
+	}
+}
+
+func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/internal/subagent/run_test.go
+++ b/internal/subagent/run_test.go
@@ -168,7 +168,7 @@ func TestPurgeRun_RemovesRunAndJobs(t *testing.T) {
 		t.Fatalf("NewRun: %v", err)
 	}
 	jobID := regSyncJob(Request{Provider: "v", RunID: run.RunID, Phase: "p", Label: "a"}, "m")
-	finalizeSyncJob(jobID, Result{OK: true})
+	finalizeSyncJobReaped(jobID, Result{OK: true}) // a real finished leaf: the in-process reap clears the pending stamp
 	if got := StatusFor(jobID); got.RunID != run.RunID {
 		t.Fatalf("setup: job not tagged with the run, got %+v", got)
 	}

--- a/internal/subagent/runclaude_cap_test.go
+++ b/internal/subagent/runclaude_cap_test.go
@@ -28,7 +28,7 @@ func TestRunClaude_OutputCapKillsGroup(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	stdout, _, _, err := runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil)
+	stdout, _, _, err := runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil, nil)
 	elapsed := time.Since(start)
 
 	if !errors.Is(err, errOutputTooLarge) {
@@ -61,7 +61,7 @@ func TestRunClaude_OutputCapBothStreams(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	stdout, stderr, _, err := runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil)
+	stdout, stderr, _, err := runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil, nil)
 	if !errors.Is(err, errOutputTooLarge) {
 		t.Fatalf("err = %v, want errOutputTooLarge", err)
 	}

--- a/internal/subagent/stoprun_tristate_test.go
+++ b/internal/subagent/stoprun_tristate_test.go
@@ -1,0 +1,199 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStopRunTriState drives StopRun's DetachedLive / DetachedDead / DetachedUnknown ladder and the
+// wedged-terminal escape hatch via the classification seams (reuseGuardArgv / procStartFn) + the reap
+// seam (reapEngineTreeFn — a no-op so EnginePID==self is never actually killed). The key regression: a
+// retained detached pid ALIVE but unverifiable must be REFUSED (status + journal untouched), NOT
+// finalized-and-flipped-stopped under a possibly-live engine.
+func TestStopRunTriState(t *testing.T) {
+	self := os.Getpid()
+	engineArgv := func(runID string) []string {
+		return []string{"cc-fleet", "workflow", "run", "--run-id", runID, "s.js"}
+	}
+	otherArgv := []string{"some", "other", "proc"}
+
+	// resultCached reports whether a member leaf got a synthetic terminal (finalizeRunLeaves ran).
+	resultCached := func(t *testing.T, jobID string) bool {
+		t.Helper()
+		dir, _ := jobsDir()
+		_, err := os.Stat(filepath.Join(dir, jobID+".result.json"))
+		return err == nil
+	}
+
+	t.Run("running + live-unverifiable → refused, status+leaf untouched", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		origArgv, origPS, origReap := reuseGuardArgv, procStartFn, reapEngineTreeFn
+		reaped := false
+		reuseGuardArgv = func(int) ([]string, bool) { return nil, false } // argv unreadable
+		procStartFn = func(int) (string, bool) { return "", false }       // token unreadable → Unknown
+		reapEngineTreeFn = func(int) { reaped = true }
+		t.Cleanup(func() { reuseGuardArgv, procStartFn, reapEngineTreeFn = origArgv, origPS, origReap })
+
+		const runID = "st-unverif"
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self, EngineProcStart: "tok"})
+		writeLeafMeta(t, jobMeta{JobID: "lf", RunID: runID, PID: self, Status: "running"}, false)
+
+		_, err := StopRun(runID)
+		if err == nil || !strings.Contains(err.Error(), "unverifiable") {
+			t.Fatalf("StopRun on a live-unverifiable engine must refuse, got %v", err)
+		}
+		if reaped {
+			t.Error("an unverifiable pid must never be reaped")
+		}
+		if run, _ := ReadRun(runID); run.Status != "running" {
+			t.Errorf("status must be left untouched (not flipped stopped), got %q", run.Status)
+		}
+		if resultCached(t, "lf") {
+			t.Error("no leaf may be finalized under a possibly-live engine")
+		}
+	})
+
+	t.Run("running + dead detached → finalize ghosts + stop", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		origReap := reapEngineTreeFn
+		reaped := false
+		reapEngineTreeFn = func(int) { reaped = true }
+		t.Cleanup(func() { reapEngineTreeFn = origReap })
+
+		const runID = "st-dead"
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: deadEnginePID})
+		writeLeafMeta(t, jobMeta{JobID: "lf", RunID: runID, PID: deadEnginePID, Status: "running"}, false)
+
+		run, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("StopRun on a dead detached engine must succeed, got %v", err)
+		}
+		if run.Status != "stopped" {
+			t.Errorf("a dead detached run must flip stopped, got %q", run.Status)
+		}
+		if reaped {
+			t.Error("a dead pid must not be reaped")
+		}
+		if !resultCached(t, "lf") {
+			t.Error("a dead detached run's ghost leaf must be finalized")
+		}
+	})
+
+	t.Run("running foreground (EnginePID 0) → blind-flip stopped", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		origReap := reapEngineTreeFn
+		reaped := false
+		reapEngineTreeFn = func(int) { reaped = true }
+		t.Cleanup(func() { reapEngineTreeFn = origReap })
+
+		const runID = "st-fg"
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0})
+
+		run, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("StopRun on a foreground run must succeed, got %v", err)
+		}
+		if run.Status != "stopped" || reaped {
+			t.Errorf("a foreground run flips stopped with no reap, got status=%q reaped=%v", run.Status, reaped)
+		}
+	})
+
+	// The DetachedLive reap path (running + terminal escape hatch): reuseGuardArgv reads the engine argv
+	// as a MATCH before the reap and a MISMATCH after (via the reaped flag), so the pid is Live going in
+	// and reads Dead as WaitEngineStopped polls — deterministic, no real process killed.
+	liveThenDead := func(t *testing.T, runID string) *bool {
+		t.Helper()
+		origArgv, origReap := reuseGuardArgv, reapEngineTreeFn
+		reaped := false
+		reuseGuardArgv = func(int) ([]string, bool) {
+			if reaped {
+				return otherArgv, true // post-reap: readable mismatch → Dead
+			}
+			return engineArgv(runID), true // pre-reap: match → Live
+		}
+		reapEngineTreeFn = func(int) { reaped = true }
+		t.Cleanup(func() { reuseGuardArgv, reapEngineTreeFn = origArgv, origReap })
+		return &reaped
+	}
+
+	t.Run("running + verifiably-live → reap + confirm dead + stop", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "st-live"
+		reaped := liveThenDead(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: self})
+		writeLeafMeta(t, jobMeta{JobID: "lf", RunID: runID, PID: self, Status: "running"}, false)
+
+		run, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("StopRun on a verifiably-live engine must reap + stop, got %v", err)
+		}
+		if !*reaped || run.Status != "stopped" || !resultCached(t, "lf") {
+			t.Errorf("live engine must be reaped + run stopped + leaf finalized, got reaped=%v status=%q cached=%v", *reaped, run.Status, resultCached(t, "lf"))
+		}
+	})
+
+	t.Run("wedged terminal + Unknown pid → refused (not a no-op)", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		origArgv, origPS, origReap := reuseGuardArgv, procStartFn, reapEngineTreeFn
+		reaped := false
+		reuseGuardArgv = func(int) ([]string, bool) { return nil, false }
+		procStartFn = func(int) (string, bool) { return "", false }
+		reapEngineTreeFn = func(int) { reaped = true }
+		t.Cleanup(func() { reuseGuardArgv, procStartFn, reapEngineTreeFn = origArgv, origPS, origReap })
+
+		const runID = "st-wedge-unk"
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: self, EngineProcStart: "tok"})
+
+		_, err := StopRun(runID)
+		if err == nil || !strings.Contains(err.Error(), "unverifiable") {
+			t.Fatalf("a wedged terminal record with an Unknown live pid must fail closed, got %v", err)
+		}
+		if reaped {
+			t.Error("an unverifiable pid must never be reaped")
+		}
+	})
+
+	t.Run("wedged terminal + Live pid → reaps (escape hatch)", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		const runID = "st-wedge-live"
+		reaped := liveThenDead(t, runID)
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: self})
+
+		run, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("the escape hatch must reap a wedged-terminal live engine, got %v", err)
+		}
+		if !*reaped || run.Status != "stopped" {
+			t.Errorf("a wedged-terminal live engine must be reaped (not no-oped), got reaped=%v status=%q", *reaped, run.Status)
+		}
+	})
+
+	t.Run("terminal + dead pid → no-op", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		origReap := reapEngineTreeFn
+		reaped := false
+		reapEngineTreeFn = func(int) { reaped = true }
+		t.Cleanup(func() { reapEngineTreeFn = origReap })
+
+		const runID = "st-term-dead"
+		writeRunForTest(t, WorkflowRun{RunID: runID, StartedAt: "2026-01-01T00:00:00Z", Status: "done", EnginePID: deadEnginePID})
+		writeLeafMeta(t, jobMeta{JobID: "lf", RunID: runID, PID: deadEnginePID, Status: "running"}, false)
+
+		run, err := StopRun(runID)
+		if err != nil {
+			t.Fatalf("StopRun on a normal terminal record must no-op, got %v", err)
+		}
+		if run.Status != "done" || reaped || resultCached(t, "lf") {
+			t.Errorf("a terminal + dead-pid record must be returned untouched, got status=%q reaped=%v cached=%v", run.Status, reaped, resultCached(t, "lf"))
+		}
+	})
+}

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -376,7 +376,9 @@ func Run(parent context.Context, req Request) Result {
 	registered := reg == registerOK
 	var res Result
 	if registered {
-		defer func() { finalizeSyncJob(jobID, res) }()
+		// The REAPED finalize: this deferred call runs only after runClaude returns, so the child is
+		// provably reaped (or cmd.Start never launched one) — the evidence that clears a false-pending stamp.
+		defer func() { finalizeSyncJobReaped(jobID, res) }()
 	} else if slim.promptFile != "" {
 		defer func() { _ = os.Remove(slim.promptFile) }()
 	}
@@ -397,7 +399,16 @@ func Run(parent context.Context, req Request) Result {
 	}
 	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
-	stdout, stderr, exitCode, runErr := runClaude(ctx, fp.BinaryPath, argv, env, req.PromptReader, req.WorkingDir, act)
+	// Record the sync leaf's claude CHILD identity once it starts — meta.PID is the engine (a proxy a
+	// SIGKILL breaks), so the worktree reclaimers need the child's own pid+token to tell a live orphan
+	// from a dead leaf. Capture THIS spawn's attempt so a late write can't stamp a restarted row (the
+	// attempt guard). Only for a registered job (a held/failed registration has no meta to update).
+	var onStart func(int)
+	if registered && jobID != "" {
+		attempt := req.Attempt
+		onStart = func(childPID int) { recordChildIdentity(jobID, childPID, attempt) }
+	}
+	stdout, stderr, exitCode, runErr := runClaude(ctx, fp.BinaryPath, argv, env, req.PromptReader, req.WorkingDir, act, onStart)
 	timedOut := errors.Is(ctx.Err(), context.DeadlineExceeded)
 	dg.Logf("subagent: claude exited code %d (timeout=%v)", exitCode, timedOut)
 
@@ -538,7 +549,7 @@ type slimArgv struct {
 // standalone func so tests can drive it with a fake binary. It never streams to
 // the parent's stdio: stdout/stderr are captured to byte-capped buffers, and a
 // stream that overflows maxChildOutput kills the group and returns errOutputTooLarge.
-func runClaude(ctx context.Context, binaryPath string, argv, env []string, stdin io.Reader, workingDir string, act *activityWriter) (stdout, stderr []byte, exitCode int, err error) {
+func runClaude(ctx context.Context, binaryPath string, argv, env []string, stdin io.Reader, workingDir string, act *activityWriter, onStart func(childPID int)) (stdout, stderr []byte, exitCode int, err error) {
 	cmd := exec.CommandContext(ctx, binaryPath)
 	cmd.Args = argv // argv[0] == binaryPath by construction
 	cmd.Env = env
@@ -608,6 +619,9 @@ func runClaude(ctx context.Context, binaryPath string, argv, env []string, stdin
 	// the old cmd.Run() error path: exitCode -1, no escalation, empty captures.
 	if err = cmd.Start(); err == nil {
 		pg.afterStart(cmd)
+		if onStart != nil {
+			onStart(cmd.Process.Pid) // record the CHILD identity (sync leaf's orphan-liveness evidence)
+		}
 		err = cmd.Wait()
 	}
 

--- a/internal/subagent/subagent_unix_test.go
+++ b/internal/subagent/subagent_unix_test.go
@@ -19,7 +19,7 @@ func TestRunClaude_SuccessEnvelope(t *testing.T) {
 	bin := writeFakeBin(t, "#!/bin/sh\nprintf '%s' '"+smokeSuccessJSON+"'\nexit 0\n")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	stdout, stderr, code, err := runClaude(ctx, bin, []string{bin, "-p", "x"}, os.Environ(), nil, "", nil)
+	stdout, stderr, code, err := runClaude(ctx, bin, []string{bin, "-p", "x"}, os.Environ(), nil, "", nil, nil)
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
@@ -36,11 +36,32 @@ func TestRunClaude_SuccessEnvelope(t *testing.T) {
 	}
 }
 
+// TestRunClaude_OnStartReceivesLiveChildPID: runClaude invokes onStart right after Start with the
+// claude CHILD's pid — the hook that records a sync leaf's orphan-liveness evidence — and that pid is
+// alive at the moment onStart fires.
+func TestRunClaude_OnStartReceivesLiveChildPID(t *testing.T) {
+	bin := writeFakeBin(t, "#!/bin/sh\nsleep 0.2\nexit 0\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var gotPID int
+	var aliveAtStart bool
+	_, _, _, _ = runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil, func(pid int) {
+		gotPID = pid
+		aliveAtStart = pidAlive(pid)
+	})
+	if gotPID <= 0 {
+		t.Fatalf("onStart must receive the child pid, got %d", gotPID)
+	}
+	if !aliveAtStart {
+		t.Error("the child pid must be alive when onStart fires")
+	}
+}
+
 func TestRunClaude_ErrorEnvelopeExit1(t *testing.T) {
 	bin := writeFakeBin(t, "#!/bin/sh\nprintf '%s' '"+smoke429BalanceJSON+"'\nexit 1\n")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	stdout, _, code, err := runClaude(ctx, bin, []string{bin, "-p", "x"}, os.Environ(), nil, "", nil)
+	stdout, _, code, err := runClaude(ctx, bin, []string{bin, "-p", "x"}, os.Environ(), nil, "", nil, nil)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
@@ -60,7 +81,7 @@ func TestRunClaude_StdinPrompt(t *testing.T) {
 	bin := writeFakeBin(t, "#!/bin/sh\ncat\n")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	stdout, _, code, _ := runClaude(ctx, bin, []string{bin, "-p"}, os.Environ(), strings.NewReader("piped-prompt"), "", nil)
+	stdout, _, code, _ := runClaude(ctx, bin, []string{bin, "-p"}, os.Environ(), strings.NewReader("piped-prompt"), "", nil, nil)
 	if code != 0 || string(stdout) != "piped-prompt" {
 		t.Fatalf("stdin not piped: code=%d stdout=%q", code, stdout)
 	}
@@ -87,7 +108,7 @@ func TestRunClaude_TimeoutKillsProcessGroup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	start := time.Now()
-	_, _, _, _ = runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil)
+	_, _, _, _ = runClaude(ctx, bin, []string{bin}, os.Environ(), nil, "", nil, nil)
 	elapsed := time.Since(start)
 
 	// Should return within deadline + grace + slack, not hang on the pipe-holding

--- a/internal/workflow/budget.go
+++ b/internal/workflow/budget.go
@@ -56,7 +56,7 @@ func (e *engine) budgetCharge(usd float64, tok int64) {
 	// Persist the new running spend so an external `workflow status` reader sees a live run-level
 	// total mid-run (the manifest otherwise only restamps at phase/terminal transitions). Bounded
 	// by real leaf completions (cache hits never charge); loop-held, so it serializes with charging.
-	e.saveManifest("running", "")
+	_ = e.saveManifest("running", "")
 }
 
 // budgetExceededErr is the gate's refusal, naming only the active cap(s): USD (a list-price

--- a/internal/workflow/builtins.go
+++ b/internal/workflow/builtins.go
@@ -41,16 +41,18 @@ type engine struct {
 	// events is the run's live-event channel that `workflow watch` renders. Nil-safe.
 	// Emitted only on the loop — the seq counter needs no atomic and lines never
 	// interleave. One-way producer→watcher; never read back, never feeds journalKey.
-	events          *eventWriter
-	groupSeq        int    // monotonic id source for parallel/pipeline/workflow group brackets
-	persistIO       bool   // persist each leaf's prompt+answer for the board's inline detail (default on; --no-persist-io off)
-	enginePID       int    // os.Getpid() of the DETACHED engine — recorded so `workflow stop` can reap it
-	engineProcStart string // enginePID's start token — the stop identity where argv is unreadable (Windows)
-	metaModel       string // meta.model: default model for agents that omit model (applied before journalKey)
-	whenToUse       string // meta.whenToUse: display/board text
-	sessionID       string // parent Claude session (board grouping); seeded from the manifest, re-persisted every save
-	cwd             string // launching project dir (board run header); seeded from the manifest, re-persisted every save
-	argsJSON        string // --args-json, re-persisted so a restart resumes with the SAME args (else leaf keys shift)
+	events            *eventWriter
+	groupSeq          int    // monotonic id source for parallel/pipeline/workflow group brackets
+	persistIO         bool   // persist each leaf's prompt+answer for the board's inline detail (default on; --no-persist-io off)
+	enginePID         int    // os.Getpid() of the DETACHED engine — recorded so `workflow stop` can reap it
+	engineProcStart   string // enginePID's start token — the stop identity where argv is unreadable (Windows)
+	fgEnginePID       int    // os.Getpid() of a FOREGROUND engine — liveness EVIDENCE only, NOT stop-reapable (EnginePID stays 0)
+	fgEngineProcStart string // fgEnginePID's start token — the fg liveness identity (no argv, so pid+token is the whole proof)
+	metaModel         string // meta.model: default model for agents that omit model (applied before journalKey)
+	whenToUse         string // meta.whenToUse: display/board text
+	sessionID         string // parent Claude session (board grouping); seeded from the manifest, re-persisted every save
+	cwd               string // launching project dir (board run header); seeded from the manifest, re-persisted every save
+	argsJSON          string // --args-json, re-persisted so a restart resumes with the SAME args (else leaf keys shift)
 	// The run's default-provider resolution, fixed at mint and seeded from the manifest
 	// (re-persisted every save so the whole-manifest overwrite can't wipe it). A
 	// provider-less agent() resolves to defaultProvider; when it is empty, agent() throws
@@ -773,7 +775,7 @@ func (e *engine) jsPhase(call goja.FunctionCall) goja.Value {
 	if !found {
 		e.phases = append(e.phases, subagent.RunPhase{Title: title, Detail: detail})
 	}
-	e.saveManifest("running", "")
+	_ = e.saveManifest("running", "")
 	e.events.emit(EventRecord{Kind: "phase", Phase: title, Msg: detail})
 	return goja.Undefined()
 }
@@ -828,19 +830,28 @@ func (e *engine) emitGroupClose(gid string) {
 // state (errText is recorded only on a failed finalize). Best-effort: a write hiccup
 // never fails the run. Loop-held callers only (plus Execute's pre-run stamp + deferred
 // finalize, when the loop is not running) — manifest writes never race.
-func (e *engine) saveManifest(status, errText string) {
-	_ = subagent.SaveRun(subagent.WorkflowRun{
-		RunID:           e.runID,
-		Name:            e.name,
-		Description:     e.description,
-		WhenToUse:       e.whenToUse,
-		StartedAt:       e.startedAt,
-		UpdatedAt:       time.Now().UTC().Format(time.RFC3339),
-		Phases:          e.phases,
-		Status:          status,
-		Error:           errText,
-		EnginePID:       e.enginePID,
-		EngineProcStart: e.engineProcStart,
+// saveRunFn is a seam so a test can fail a manifest write (disk full / EPERM) — production is
+// subagent.SaveRun.
+var saveRunFn = subagent.SaveRun
+
+// saveManifest persists the whole run manifest and RETURNS the write error. Most callers are
+// best-effort (`_ = e.saveManifest(...)`); Execute's FIRST stamp is fatal (the engine that cannot
+// record its own identity must not run).
+func (e *engine) saveManifest(status, errText string) error {
+	return saveRunFn(subagent.WorkflowRun{
+		RunID:             e.runID,
+		Name:              e.name,
+		Description:       e.description,
+		WhenToUse:         e.whenToUse,
+		StartedAt:         e.startedAt,
+		UpdatedAt:         time.Now().UTC().Format(time.RFC3339),
+		Phases:            e.phases,
+		Status:            status,
+		Error:             errText,
+		EnginePID:         e.enginePID,
+		EngineProcStart:   e.engineProcStart,
+		FgEnginePID:       e.fgEnginePID,
+		FgEngineProcStart: e.fgEngineProcStart,
 		// Carried in engine state so every whole-file overwrite preserves them (the board
 		// groups by SessionID; a restart resumes with the same args/persistIO/budget).
 		SessionID:    e.sessionID,

--- a/internal/workflow/canonpath.go
+++ b/internal/workflow/canonpath.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package workflow
+
+import "path/filepath"
+
+// canonPath resolves p to the form `git worktree list --porcelain` / `git rev-parse --show-toplevel`
+// emit, so a prefix comparison against git output holds on every platform. On unix/darwin git reports
+// the symlink-resolved path (notably macOS, where os.TempDir() is /var/folders/… but git canonicalizes
+// the /var symlink to /private/var/folders/…), so we EvalSymlinks. A resolve error — e.g. p does not
+// exist — falls back to p: a later prefix miss then simply skips, never deletes (fail-safe).
+func canonPath(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return p
+}

--- a/internal/workflow/canonpath_windows.go
+++ b/internal/workflow/canonpath_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package workflow
+
+import (
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// canonPath resolves p to the form `git worktree list --porcelain` / `git rev-parse --show-toplevel`
+// emit, so a prefix comparison against git output holds on every platform. On Windows git reports the
+// LONG path while os.TempDir() may be the 8.3 short form (C:\Users\RUNNER~1\… vs the long
+// C:\Users\runneradmin\…); GetLongPathName bridges them (normPath's slash+case fold cannot). A
+// resolve error — e.g. p does not exist — falls back to p: a later prefix miss then simply skips,
+// never deletes (fail-safe).
+func canonPath(p string) string {
+	if long, err := longPathName(p); err == nil {
+		return long
+	}
+	return p
+}
+
+// longPathName expands p's 8.3 short components to their long form via GetLongPathName, growing the
+// buffer on the documented too-small return (required size, incl. NUL, > buflen).
+func longPathName(p string) (string, error) {
+	u16, err := windows.UTF16PtrFromString(p)
+	if err != nil {
+		return "", err
+	}
+	n := uint32(len(p) + 16)
+	for {
+		buf := make([]uint16, n)
+		got, gerr := windows.GetLongPathName(u16, &buf[0], n)
+		if gerr != nil {
+			return "", gerr
+		}
+		if got <= n {
+			return filepath.Clean(windows.UTF16ToString(buf[:got])), nil
+		}
+		n = got
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -191,6 +191,8 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 		persistIO:          !opts.NoPersistIO, // the board's inline prompt/answer detail is default-on
 		enginePID:          detachedEnginePID(opts),
 		engineProcStart:    detachedEngineProcStart(opts),
+		fgEnginePID:        fgEnginePID(opts),
+		fgEngineProcStart:  fgEngineProcStart(opts),
 		metaModel:          meta.Model, // default model for agents that omit model
 		whenToUse:          meta.WhenToUse,
 		budgetTotal:        opts.BudgetUSD,
@@ -235,10 +237,16 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 	if ctlErr == nil {
 		_ = os.Remove(ctlPath)
 	}
-	// Stamp the manifest once up front: records EnginePID (so `workflow stop` can reap
-	// this process), flips a resumed run to "running", and refreshes UpdatedAt from the
-	// start (GC recency) — before the first leaf, closing the mint→first-leaf window.
-	eng.saveManifest("running", "")
+	// Stamp the manifest once up front: records EnginePID (so `workflow stop` can reap this process),
+	// flips a resumed run to "running", and refreshes UpdatedAt from the start (GC recency) — before the
+	// first leaf, closing the mint→first-leaf window. FATAL: if this identity stamp cannot persist, the
+	// engine must not run — it returns BEFORE the startup sweep and any leaf/worktree work. This upholds
+	// the launcher's invariant that a manifest still reading EnginePID 0 means the child created NO
+	// worktrees (finalizeFailedDetach relies on it): a best-effort stamp that silently failed would let
+	// the child sweep + create worktrees under an EnginePID-0 manifest, stranding them on a later abort.
+	if serr := eng.saveManifest("running", ""); serr != nil {
+		return fmt.Errorf("workflow: record engine identity for run %s: %w", runID, serr)
+	}
 	if ctlErr == nil {
 		eng.startCtlPoller(ctlPath)
 	}
@@ -264,7 +272,7 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 		case err != nil:
 			status, errText = "failed", err.Error()
 		}
-		eng.saveManifest(status, errText)
+		_ = eng.saveManifest(status, errText)
 	}()
 
 	_, execErr := eng.run(scriptPath, normalized, opts)
@@ -287,6 +295,32 @@ func detachedEnginePID(opts Options) int {
 // (Windows). Empty for a foreground run or when the platform can't read it.
 func detachedEngineProcStart(opts Options) string {
 	if opts.RunID == "" {
+		return ""
+	}
+	start, _ := procintrospect.ProcStart(os.Getpid())
+	return start
+}
+
+// fgEnginePID is os.Getpid() for a FOREGROUND engine (the inline `workflow run --foreground` path,
+// opts.RunID empty) and 0 for the detached child. It is the inverse of detachedEnginePID: recorded as
+// liveness EVIDENCE separate from EnginePID (which stays 0 for foreground), so a resumer can tell a
+// dead foreground run from a live one WITHOUT letting `workflow stop` claim a kill on a terminal-
+// attached process.
+func fgEnginePID(opts Options) int {
+	if opts.RunID == "" {
+		return os.Getpid()
+	}
+	return 0
+}
+
+// fgEngineProcStart is the FOREGROUND engine's own start token, stamped next to fgEnginePID as its
+// liveness identity. Empty for the detached child or when the platform can't read it — and an empty
+// token is deliberately still stamped alongside the (always-recorded) pid: a recorded pid without a
+// token proves more than nothing (it degrades the fg evidence to FgUnknown, which the reclaim guards
+// refuse rather than delete under a possibly-live engine — it names the process to wait out), whereas
+// skipping the stamp would collapse to the legacy proof-less shape those guards treat as deletable.
+func fgEngineProcStart(opts Options) string {
+	if opts.RunID != "" {
 		return ""
 	}
 	start, _ := procintrospect.ProcStart(os.Getpid())
@@ -393,6 +427,11 @@ func resolveRunDefault() (provider, errCode string) {
 	return name, ""
 }
 
+// executeFn is a seam for Launch's FOREGROUND inline run so a test can drive the resume preflight
+// (which stamps the launcher's own fg identity) and observe the manifest WITHOUT running the engine —
+// production is Execute.
+var executeFn = Execute
+
 func Launch(ctx context.Context, scriptPath string, opts Options, foreground bool) (string, error) {
 	abs, err := filepath.Abs(scriptPath)
 	if err != nil {
@@ -404,6 +443,7 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 	// Resume reuses an existing run id (validated + confirmed to exist) so the engine
 	// replays its journal; a fresh run mints a new manifest from the script's meta.
 	var run subagent.WorkflowRun
+	var priorRecord *subagent.WorkflowRun // resume only: the pre-rewrite snapshot, to restore its death proof if the detached launch fails
 	if opts.Resume != "" {
 		if verr := subagent.ValidateRunID(opts.Resume); verr != nil {
 			return "", fmt.Errorf("workflow: invalid resume id: %w", verr)
@@ -425,6 +465,8 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 				return fmt.Errorf("workflow: cannot resume: %w", rerr)
 			}
 			run = existing
+			snap := existing // the PRIOR record (its death proof), before the rewrite below erases it
+			priorRecord = &snap
 			// Inherit the recorded default-resolution (do NOT re-resolve — a mid-run change of
 			// default_provider must never re-key an omitted-provider leaf). A PRE-feature manifest
 			// carries neither field; resolve+stamp once here so a provider-less script resumed on an
@@ -432,17 +474,17 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 			if run.DefaultProvider == "" && run.DefaultProviderError == "" {
 				run.DefaultProvider, run.DefaultProviderError = resolveRunDefault()
 			}
-			// One engine per run: refuse to resume a run that still has a LIVE engine — a verifiably-live
-			// detached one, or a foreground/unreapable run (EnginePID<=0) still claiming to run. The board
-			// Restart path stops the old engine first; a crashed/killed detached run (recorded pid now
+			// One engine per run: refuse to resume a run with a verifiably-live DETACHED engine (a second
+			// engine would run on one journal). A foreground/unreapable run (EnginePID<=0) is decided by
+			// resumeBlockedReason below from its recorded fg identity; a crashed detached run (pid now
 			// dead) falls through and resumes as-is. Under the lock this also rejects a SECOND resumer:
-			// the winner has already flipped the manifest to running. (Mirrors restart.go's fail-closed
-			// liveness check.)
-			if run.Status == "running" && (subagent.EngineAlive(run) || run.EnginePID <= 0) {
+			// the winner flipped the manifest to running (fg identity cleared → FgUnknown → refused).
+			if run.Status == "running" && subagent.EngineAlive(run) {
 				return fmt.Errorf("workflow: run %s already has a live engine; stop it first", opts.Resume)
 			}
-			// Refuse the ambiguous {stopped, EnginePID 0} state (a live blind-stopped foreground engine is
-			// indistinguishable from a dead Ctrl-C'd one) — resumeBlockedReason carries the full rationale.
+			// Vet the FOREGROUND cases (EnginePID<=0): a provably-dead fg engine (Ctrl-C'd/crashed) is
+			// resumable; a live one is refused; an absent/unverifiable identity keeps the conservative
+			// refusal — resumeBlockedReason carries the full rationale (shared with restart).
 			if reason := resumeBlockedReason(run); reason != nil {
 				return reason
 			}
@@ -489,6 +531,17 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 			run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 			run.EnginePID = 0 // clear the prior engine's pid; the new child re-stamps, and WaitEngineStarted waits for exactly that
 			run.EngineProcStart = ""
+			// On the FOREGROUND lane the launcher IS the engine process, so stamp its OWN fg identity in
+			// this same save: a crash before Execute's first save then still leaves a proof-bearing record
+			// (FgAlive now, FgDead once this pid exits), never a proof-less {running,0,no-fg} that resume
+			// would refuse forever. On the DETACHED lane the child stamps EnginePID, so clear the fg fields.
+			if foreground {
+				run.FgEnginePID = os.Getpid()
+				run.FgEngineProcStart, _ = procintrospect.ProcStart(os.Getpid())
+			} else {
+				run.FgEnginePID = 0
+				run.FgEngineProcStart = ""
+			}
 			if serr := subagent.SaveRun(run); serr != nil {
 				return fmt.Errorf("workflow: stamp resume liveness: %w", serr)
 			}
@@ -540,12 +593,11 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		}
 	}
 	if foreground {
-		return run.RunID, Execute(ctx, abs, run.RunID, opts)
+		return run.RunID, executeFn(ctx, abs, run.RunID, opts)
 	}
-	pid, reaper, lerr := launchDetached(abs, run.RunID, opts)
+	pid, reaper, lerr := launchDetachedFn(abs, run.RunID, opts)
 	if lerr != nil {
-		run.Status = "failed"
-		_ = subagent.SaveRun(run)
+		finalizeFailedDetach(run.RunID, run, priorRecord, "")
 		return "", lerr
 	}
 	if !WaitEngineStarted(run.RunID, pid) {
@@ -554,8 +606,7 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		// overwrite the failed manifest and run on as a second engine.
 		reaper.kill()
 		_ = reaper.wait()
-		run.Status, run.Error, run.EnginePID = "failed", "workflow: engine did not register within the startup budget", 0
-		_ = subagent.SaveRun(run)
+		finalizeFailedDetach(run.RunID, run, priorRecord, "workflow: engine did not register within the startup budget")
 		return "", fmt.Errorf("workflow: engine failed to start")
 	}
 	// Registered: reap the child asynchronously so it never lingers as a zombie under a
@@ -563,6 +614,41 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 	// goroutine completes; init then adopts and reaps the orphan.
 	go func() { _ = reaper.wait() }()
 	return run.RunID, nil
+}
+
+// launchDetachedFn is a seam so a test can fail the detached spawn without a real re-exec — production
+// is launchDetached.
+var launchDetachedFn = launchDetached
+
+// finalizeFailedDetach writes the manifest after a FAILED detached launch/resume without destroying a
+// death proof. Runs under the caller's per-run lock (the detached lane holds it across launchDetached +
+// WaitEngineStarted), re-reading the manifest to decide:
+//   - the child self-STAMPED its pid (EnginePID != 0): it may have created isolation worktrees (those
+//     follow the stamp) and its pid is the death evidence; the caller already killed+reaped it, so cur
+//     reads a DEAD detached pid → provably dead / reclaimable. Mark it failed KEEPING that pid.
+//   - else this was a RESUME (prior != nil): the child never stamped, so it created NO worktrees — the
+//     failed attempt must NOT erase the prior death proof (a {failed,0,no-fg} record reads
+//     not-provably-dead, stranding the run's leaked worktrees forever). Restore the PRIOR record.
+//   - else a FRESH launch (or an unreadable manifest): mark the minted run failed.
+func finalizeFailedDetach(runID string, minted subagent.WorkflowRun, prior *subagent.WorkflowRun, failMsg string) {
+	if cur, rerr := subagent.ReadRun(runID); rerr == nil && cur.EnginePID != 0 {
+		cur.Status = "failed"
+		if failMsg != "" {
+			cur.Error = failMsg
+		}
+		_ = subagent.SaveRun(cur)
+		return
+	}
+	if prior != nil {
+		_ = subagent.SaveRun(*prior)
+		return
+	}
+	minted.Status = "failed"
+	if failMsg != "" {
+		minted.Error = failMsg
+	}
+	minted.EnginePID = 0
+	_ = subagent.SaveRun(minted)
 }
 
 // engineStartupBudget bounds how long a launcher waits — under the per-run execution lock —

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -242,6 +242,16 @@ func Execute(ctx context.Context, scriptPath, runID string, opts Options) (err e
 	if ctlErr == nil {
 		eng.startCtlPoller(ctlPath)
 	}
+	// Reclaim OTHER runs' stale isolation-worktree registrations left in the user's repo by
+	// crashed/SIGKILLed engines — provably-dead known runs, plus any whose workdir has vanished.
+	// This run's OWN segment is never reclaimed here (it could belong to a still-live blind-stopped
+	// twin); own-segment cleanup happens in the resume launcher, under a death proof. A non-git cwd
+	// never created any worktree, so skip silently.
+	if cwd, cerr := os.Getwd(); cerr == nil {
+		if root, gerr := gitTopLevel(cwd); gerr == nil {
+			sweepRunWorktreesFn(root)
+		}
+	}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -398,62 +408,100 @@ func Launch(ctx context.Context, scriptPath string, opts Options, foreground boo
 		if verr := subagent.ValidateRunID(opts.Resume); verr != nil {
 			return "", fmt.Errorf("workflow: invalid resume id: %w", verr)
 		}
-		existing, rerr := subagent.ReadRun(opts.Resume)
-		if rerr != nil {
-			return "", fmt.Errorf("workflow: cannot resume: %w", rerr)
+		// The resume preflight — read prior → refuse-guard → death-proof own-segment sweep → inherit
+		// options → rewrite the manifest to "running" — must be ATOMIC against a concurrent resume of
+		// the same id: two resumers reading the SAME provably-dead prior would both sweep, and the
+		// loser's stale proof would delete the winner's live worktrees. A DETACHED resume already runs
+		// under the caller's per-run lock (the CLI wraps Launch; Restart wraps stop+drop+Launch), which
+		// additionally spans launchDetached + WaitEngineStarted — so it must NOT re-lock (that would
+		// deadlock Restart; the flock is not reentrant). A FOREGROUND resume reaches Launch with no
+		// lock held (the CLI leaves it unwrapped precisely so the lock is never held around the inline
+		// Execute below), so it self-serializes just this preflight and releases before Execute. Once
+		// the preflight has flipped the manifest to "running" (EnginePID 0), any later resumer is
+		// rejected by the refuse-guard.
+		preflight := func() error {
+			existing, rerr := subagent.ReadRun(opts.Resume)
+			if rerr != nil {
+				return fmt.Errorf("workflow: cannot resume: %w", rerr)
+			}
+			run = existing
+			// Inherit the recorded default-resolution (do NOT re-resolve — a mid-run change of
+			// default_provider must never re-key an omitted-provider leaf). A PRE-feature manifest
+			// carries neither field; resolve+stamp once here so a provider-less script resumed on an
+			// old run still has a default.
+			if run.DefaultProvider == "" && run.DefaultProviderError == "" {
+				run.DefaultProvider, run.DefaultProviderError = resolveRunDefault()
+			}
+			// One engine per run: refuse to resume a run that still has a LIVE engine — a verifiably-live
+			// detached one, or a foreground/unreapable run (EnginePID<=0) still claiming to run. The board
+			// Restart path stops the old engine first; a crashed/killed detached run (recorded pid now
+			// dead) falls through and resumes as-is. Under the lock this also rejects a SECOND resumer:
+			// the winner has already flipped the manifest to running. (Mirrors restart.go's fail-closed
+			// liveness check.)
+			if run.Status == "running" && (subagent.EngineAlive(run) || run.EnginePID <= 0) {
+				return fmt.Errorf("workflow: run %s already has a live engine; stop it first", opts.Resume)
+			}
+			// Refuse the ambiguous {stopped, EnginePID 0} state (a live blind-stopped foreground engine is
+			// indistinguishable from a dead Ctrl-C'd one) — resumeBlockedReason carries the full rationale.
+			if reason := resumeBlockedReason(run); reason != nil {
+				return reason
+			}
+			// Reclaim THIS run's own stale isolation worktrees while the prior record still proves
+			// death: the rewrite below (EnginePID cleared, status flipped) erases that evidence, and the
+			// Execute-time sweep never touches its own segment (a blind-stopped-but-live foreground twin
+			// shares this id). Only a provably-dead prior is reclaimed; a not-provably-dead prior (a live
+			// foreground run flipped to "stopped") is spared so its twin's worktrees survive. Atomic
+			// under the lock above, so no concurrent resumer acts on a stale copy of this proof.
+			if subagent.RunEngineProvablyNotLive(existing) {
+				if cwd, cerr := os.Getwd(); cerr == nil {
+					if root, gerr := gitTopLevel(cwd); gerr == nil {
+						sweepOwnSegmentFn(root, existing.RunID)
+					}
+				}
+			}
+			// Replay the run's original launch options on resume so a leaf's content key — and thus its
+			// journal-cache validity — doesn't shift. A non-zero/non-empty opts value overrides; a
+			// zero/empty one inherits the manifest. --no-budget arrives as a -1 sentinel: non-zero so it
+			// skips the inherit, then normalizes to 0 (uncapped) below — so a capped run CAN be resumed
+			// uncapped. (Args/persistIO have no such sentinel.)
+			if opts.ArgsJSON == "" {
+				opts.ArgsJSON = existing.ArgsJSON
+			}
+			if !opts.NoPersistIO {
+				opts.NoPersistIO = existing.NoPersistIO
+			}
+			if opts.BudgetUSD == 0 {
+				opts.BudgetUSD = existing.BudgetUSD
+			}
+			if opts.BudgetTokens == 0 {
+				opts.BudgetTokens = existing.BudgetTokens
+			}
+			// Normalize the -1 uncap sentinel to 0 AFTER the inherit decision (so -1 never inherits),
+			// then re-stamp the budgets so an uncap is durable from resume time.
+			normalizeBudgetSentinels(&opts)
+			run.BudgetUSD = opts.BudgetUSD
+			run.BudgetTokens = opts.BudgetTokens
+			// Restamp liveness + flip to running BEFORE detaching/executing, so a concurrent GC can't
+			// prune this (possibly old) run's manifest + journal before the resumed engine's first
+			// heartbeat (GC recency keys on the later of StartedAt/UpdatedAt). A stamp failure means the
+			// manifest is unwritable — fail the resume rather than launch blind.
+			run.Status = "running"
+			run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			run.EnginePID = 0 // clear the prior engine's pid; the new child re-stamps, and WaitEngineStarted waits for exactly that
+			run.EngineProcStart = ""
+			if serr := subagent.SaveRun(run); serr != nil {
+				return fmt.Errorf("workflow: stamp resume liveness: %w", serr)
+			}
+			return nil
 		}
-		run = existing
-		// Inherit the recorded default-resolution (do NOT re-resolve — a mid-run
-		// change of default_provider must never re-key an omitted-provider leaf). A
-		// PRE-feature manifest carries neither field; resolve+stamp once here so a
-		// provider-less script resumed on an old run still has a default.
-		if run.DefaultProvider == "" && run.DefaultProviderError == "" {
-			run.DefaultProvider, run.DefaultProviderError = resolveRunDefault()
+		var perr error
+		if foreground {
+			perr = subagent.WithRunLock(opts.Resume, preflight) // no caller lock on this lane — self-serialize
+		} else {
+			perr = preflight() // already under the caller's per-run lock (CLI / Restart)
 		}
-		// One engine per run: refuse to resume a run that still has a LIVE engine — a verifiably-live
-		// detached one, or a foreground/unreapable run (EnginePID<=0) still claiming to run. The board
-		// Restart path stops the old engine first (so the status is no longer running when it reaches
-		// here); a crashed/killed detached run (recorded pid now dead) falls through and resumes as-is.
-		// This guards the public `workflow run --resume` entry, which would otherwise launch a second
-		// concurrent engine. (Mirrors restart.go's fail-closed liveness check.)
-		if run.Status == "running" && (subagent.EngineAlive(run) || run.EnginePID <= 0) {
-			return "", fmt.Errorf("workflow: run %s already has a live engine; stop it first", opts.Resume)
-		}
-		// Replay the run's original launch options on resume so a leaf's content key — and thus
-		// its journal-cache validity — doesn't shift. A non-zero/non-empty opts value overrides
-		// (e.g. resuming with a larger --budget-usd); a zero/empty one reads as "not set" and
-		// inherits the manifest. The one way to override TO uncapped is --no-budget, which arrives
-		// as a -1 sentinel: it is non-zero so it skips the inherit, then normalizes to 0 (uncapped)
-		// below — so a capped run CAN be resumed uncapped. (Args/persistIO have no such sentinel.)
-		if opts.ArgsJSON == "" {
-			opts.ArgsJSON = existing.ArgsJSON
-		}
-		if !opts.NoPersistIO {
-			opts.NoPersistIO = existing.NoPersistIO
-		}
-		if opts.BudgetUSD == 0 {
-			opts.BudgetUSD = existing.BudgetUSD
-		}
-		if opts.BudgetTokens == 0 {
-			opts.BudgetTokens = existing.BudgetTokens
-		}
-		// Normalize the -1 uncap sentinel to 0 AFTER the inherit decision (so -1 never inherits),
-		// then re-stamp the budgets onto the manifest so an uncap is durable from resume time — the
-		// engine never persists -1, and never re-caps a run the user just uncapped.
-		normalizeBudgetSentinels(&opts)
-		run.BudgetUSD = opts.BudgetUSD
-		run.BudgetTokens = opts.BudgetTokens
-		// Restamp liveness + flip to running BEFORE detaching, so a concurrent GC can't
-		// prune this (possibly old) run's manifest + journal in the window before the
-		// resumed engine writes its first heartbeat (GC recency keys on the later of
-		// StartedAt / UpdatedAt). A stamp failure means the manifest is unwritable — the
-		// run can't be tracked or protected, so fail the resume rather than launch blind.
-		run.Status = "running"
-		run.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		run.EnginePID = 0 // clear the prior engine's pid; the new child re-stamps, and WaitEngineStarted waits for exactly that
-		run.EngineProcStart = ""
-		if serr := subagent.SaveRun(run); serr != nil {
-			return "", fmt.Errorf("workflow: stamp resume liveness: %w", serr)
+		if perr != nil {
+			return "", perr
 		}
 	} else {
 		minted, perr := Prepare(abs)

--- a/internal/workflow/engine_faildetach_test.go
+++ b/internal/workflow/engine_faildetach_test.go
@@ -1,0 +1,124 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// TestExecuteFatalFirstStamp (codex r21): Execute's FIRST identity stamp is fatal — if it can't persist
+// (disk full / EPERM), Execute returns the error BEFORE the startup sweep and any leaf/worktree work.
+// This upholds the invariant finalizeFailedDetach relies on: a manifest still reading EnginePID 0 means
+// the child created NO worktrees (so restoring the prior death proof strands nothing).
+func TestExecuteFatalFirstStamp(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	origSave := saveRunFn
+	saveRunFn = func(subagent.WorkflowRun) error { return fmt.Errorf("disk full") } // fail the manifest write
+	origSweep := sweepRunWorktreesFn
+	origLeaf := runLeaf
+	swept, ranLeaf := false, false
+	sweepRunWorktreesFn = func(string) { swept = true }
+	runLeaf = func(context.Context, subagent.Request) subagent.Result {
+		ranLeaf = true
+		return subagent.Result{OK: true}
+	}
+	t.Cleanup(func() { saveRunFn = origSave; sweepRunWorktreesFn = origSweep; runLeaf = origLeaf })
+
+	script := filepath.Join(t.TempDir(), "s.js")
+	if err := os.WriteFile(script, []byte(`const meta = {name:"n",description:"d",phases:[{title:"p"}]};
+phase("p");
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Execute(context.Background(), script, "fatal-run", Options{RunID: "fatal-run"})
+	if err == nil {
+		t.Error("Execute must FAIL when the first identity stamp cannot persist")
+	}
+	if swept {
+		t.Error("Execute must NOT run the startup sweep when the first stamp failed")
+	}
+	if ranLeaf {
+		t.Error("Execute must NOT run any leaf (create worktrees) when the first stamp failed")
+	}
+}
+
+// TestFinalizeFailedDetach (codex r20): a failed detached launch must not destroy a death proof.
+// (a) child self-stamped (EnginePID != 0) → mark failed, KEEP the pid (death evidence, already reaped);
+// (b) RESUME whose child never stamped (EnginePID 0) → restore the PRIOR record's death proof;
+// (c) FRESH launch (no prior) → mark the minted run failed.
+func TestFinalizeFailedDetach(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	const ts = "2026-01-01T00:00:00Z"
+
+	// (a) child stamped → failed + pid kept.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "stamped", StartedAt: ts, Status: "running", EnginePID: 4242}); err != nil {
+		t.Fatal(err)
+	}
+	finalizeFailedDetach("stamped", subagent.WorkflowRun{RunID: "stamped"}, nil, "boom")
+	if got, _ := subagent.ReadRun("stamped"); got.Status != "failed" || got.EnginePID != 4242 {
+		t.Errorf("child-stamped: want {failed, pid 4242}, got {%s, %d}", got.Status, got.EnginePID)
+	}
+
+	// (b) resume, child never stamped → prior death proof restored.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "resume", StartedAt: ts, Status: "running", EnginePID: 0}); err != nil { // the preflight's write
+		t.Fatal(err)
+	}
+	prior := subagent.WorkflowRun{RunID: "resume", StartedAt: ts, Status: "stopped", EnginePID: 0x7ffffffe, EngineProcStart: "tok"}
+	finalizeFailedDetach("resume", subagent.WorkflowRun{RunID: "resume"}, &prior, "boom")
+	if got, _ := subagent.ReadRun("resume"); got.EnginePID != 0x7ffffffe || got.EngineProcStart != "tok" {
+		t.Errorf("resume-no-stamp: want the prior death proof restored, got {pid %d, tok %q}", got.EnginePID, got.EngineProcStart)
+	}
+
+	// (c) fresh, no prior → minted marked failed.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "fresh", StartedAt: ts, Status: "running", EnginePID: 0}); err != nil {
+		t.Fatal(err)
+	}
+	finalizeFailedDetach("fresh", subagent.WorkflowRun{RunID: "fresh", StartedAt: ts, Status: "running"}, nil, "boom")
+	if got, _ := subagent.ReadRun("fresh"); got.Status != "failed" {
+		t.Errorf("fresh: want failed, got %s", got.Status)
+	}
+}
+
+// TestFailedDetachedResumeRestoresPriorDeathProof (codex r20): end-to-end via the launchDetachedFn
+// seam — a detached RESUME whose spawn fails must restore the PRIOR record so its death proof survives
+// (the manifest reads provably dead again → the sweep can still reclaim its worktrees), not a
+// {failed,0,no-fg} that would strand them forever.
+func TestFailedDetachedResumeRestoresPriorDeathProof(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	script := writeFgTrivialScript(t) // stubs runLeaf + both sweep fns
+	const id = "resume-fail"
+	const deadPID = 0x7ffffffe
+	prior := subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: deadPID, EngineProcStart: "tok"}
+	if err := subagent.SaveRun(prior); err != nil {
+		t.Fatal(err)
+	}
+
+	origLaunch := launchDetachedFn
+	launchDetachedFn = func(string, string, Options) (int, *detachedReaper, error) {
+		return 0, nil, fmt.Errorf("boom: spawn failed")
+	}
+	t.Cleanup(func() { launchDetachedFn = origLaunch })
+
+	if _, err := Launch(context.Background(), script, Options{Resume: id}, false); err == nil {
+		t.Fatal("Launch must fail when the detached spawn fails")
+	}
+	got, rerr := subagent.ReadRun(id)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if got.EnginePID != deadPID || got.EngineProcStart != "tok" {
+		t.Errorf("failed detached resume must RESTORE the prior death proof, got EnginePID=%d token=%q status=%q", got.EnginePID, got.EngineProcStart, got.Status)
+	}
+	if !subagent.RunEngineProvablyNotLive(got) {
+		t.Error("the restored record must read provably dead so the sweep can still reclaim its worktrees")
+	}
+}

--- a/internal/workflow/engine_faildetach_test.go
+++ b/internal/workflow/engine_faildetach_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
-// TestExecuteFatalFirstStamp (codex r21): Execute's FIRST identity stamp is fatal — if it can't persist
+// TestExecuteFatalFirstStamp: Execute's FIRST identity stamp is fatal — if it can't persist
 // (disk full / EPERM), Execute returns the error BEFORE the startup sweep and any leaf/worktree work.
 // This upholds the invariant finalizeFailedDetach relies on: a manifest still reading EnginePID 0 means
 // the child created NO worktrees (so restoring the prior death proof strands nothing).
@@ -49,7 +49,7 @@ phase("p");
 	}
 }
 
-// TestFinalizeFailedDetach (codex r20): a failed detached launch must not destroy a death proof.
+// TestFinalizeFailedDetach: a failed detached launch must not destroy a death proof.
 // (a) child self-stamped (EnginePID != 0) → mark failed, KEEP the pid (death evidence, already reaped);
 // (b) RESUME whose child never stamped (EnginePID 0) → restore the PRIOR record's death proof;
 // (c) FRESH launch (no prior) → mark the minted run failed.
@@ -87,7 +87,7 @@ func TestFinalizeFailedDetach(t *testing.T) {
 	}
 }
 
-// TestFailedDetachedResumeRestoresPriorDeathProof (codex r20): end-to-end via the launchDetachedFn
+// TestFailedDetachedResumeRestoresPriorDeathProof: end-to-end via the launchDetachedFn
 // seam — a detached RESUME whose spawn fails must restore the PRIOR record so its death proof survives
 // (the manifest reads provably dead again → the sweep can still reclaim its worktrees), not a
 // {failed,0,no-fg} that would strand them forever.

--- a/internal/workflow/fg_resume_test.go
+++ b/internal/workflow/fg_resume_test.go
@@ -127,7 +127,7 @@ func TestSweepReclaimsByFgIdentity(t *testing.T) {
 			repo := initSweepRepo(t)
 			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 			t.Setenv("HOME", t.TempDir())
-			tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+			tempBase := storeWorktreeBase(t)
 			const id = "fg-sweep" // path-safe
 			t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 			if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: c.status, EnginePID: 0, FgEnginePID: c.fgPID, FgEngineProcStart: c.fgTok}); err != nil {

--- a/internal/workflow/fg_resume_test.go
+++ b/internal/workflow/fg_resume_test.go
@@ -1,0 +1,220 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/procintrospect"
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// writeFgTrivialScript stubs runLeaf + silences the Execute-time sweep, and returns a no-leaf script
+// path — the shared setup for driving a real foreground Launch.
+func writeFgTrivialScript(t *testing.T) string {
+	t.Helper()
+	old := runLeaf
+	oldAll := sweepRunWorktreesFn
+	oldOwn := sweepOwnSegmentFn
+	runLeaf = func(context.Context, subagent.Request) subagent.Result {
+		return subagent.Result{OK: true, Result: "ok"}
+	}
+	sweepRunWorktreesFn = func(string) {}
+	sweepOwnSegmentFn = func(string, string) {}
+	t.Cleanup(func() { runLeaf = old; sweepRunWorktreesFn = oldAll; sweepOwnSegmentFn = oldOwn })
+	script := filepath.Join(t.TempDir(), "s.js")
+	if err := os.WriteFile(script, []byte(`const meta = {name: "n", description: "d", phases: [{title: "plan"}]};
+phase("plan");
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+// TestForegroundExecuteStampsFgIdentity: a real inline `workflow run --foreground` engine records its
+// own pid + start token in the FOREGROUND identity fields while leaving EnginePID 0 (never
+// stop-reapable) — the liveness evidence the resume guards and sweep read.
+func TestForegroundExecuteStampsFgIdentity(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	script := writeFgTrivialScript(t)
+
+	id, err := Launch(context.Background(), script, Options{}, true) // fresh foreground run to completion
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	run, err := subagent.ReadRun(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.EnginePID != 0 {
+		t.Errorf("a foreground run must keep EnginePID 0 (not stop-reapable), got %d", run.EnginePID)
+	}
+	if run.FgEnginePID != os.Getpid() {
+		t.Errorf("a foreground run must stamp FgEnginePID = os.Getpid() (%d), got %d", os.Getpid(), run.FgEnginePID)
+	}
+	if want, _ := procintrospect.ProcStart(os.Getpid()); run.FgEngineProcStart != want {
+		t.Errorf("FgEngineProcStart = %q, want the process's own token %q", run.FgEngineProcStart, want)
+	}
+}
+
+// fgIDCase is one recorded foreground identity + its expected resume/sweep verdicts.
+type fgIDCase struct {
+	name         string
+	status       string
+	fgPID        int
+	fgTok        string
+	resumeOK     bool   // resume/restart allowed (fg provably dead) vs refused
+	errSub       string // expected error substring when refused
+	provablyDead bool   // RunEngineProvablyNotLive → sweep reclaims vs spares
+}
+
+// fgIDCases enumerates the foreground-liveness verdicts, seeded with the TEST process's own live
+// identity for the "alive" shapes (no procStartFn mock needed — ClassifyFgEngine reads the real token).
+func fgIDCases(t *testing.T) []fgIDCase {
+	t.Helper()
+	self := os.Getpid()
+	liveTok, ok := procintrospect.ProcStart(self)
+	if !ok {
+		t.Skip("procintrospect.ProcStart unavailable on this platform")
+	}
+	const deadPID = 0x7ffffffe
+	return []fgIDCase{
+		{"ctrl-c'd fg (stopped, fg pid dead)", "stopped", deadPID, "", true, "", true},
+		{"crashed fg (running, fg pid dead)", "running", deadPID, "", true, "", true},
+		{"recycled fg pid (alive, token mismatch)", "stopped", self, "stale-token", true, "", true},
+		{"blind-stopped LIVE fg (alive, token match)", "stopped", self, liveTok, false, "still running in the foreground", false},
+		{"unverifiable fg (alive, no token)", "stopped", self, "", false, "cannot be verified", false},
+		{"absent fg identity (old record)", "stopped", 0, "", false, "cannot be verified", false},
+	}
+}
+
+// TestResumeGuardByFgIdentity: a FOREGROUND resume is allowed when the recorded fg engine is provably
+// dead (Ctrl-C'd / crashed / recycled) and refused otherwise (live → sharp error; unverifiable/absent
+// → the conservative refusal).
+func TestResumeGuardByFgIdentity(t *testing.T) {
+	for _, c := range fgIDCases(t) {
+		t.Run(c.name, func(t *testing.T) {
+			repo := initSweepRepo(t)
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("HOME", t.TempDir())
+			script := writeFgTrivialScript(t)
+			const id = "fg-resume"
+			if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: c.status, EnginePID: 0, FgEnginePID: c.fgPID, FgEngineProcStart: c.fgTok}); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(repo)
+			_, err := Launch(context.Background(), script, Options{Resume: id}, true)
+			if c.resumeOK {
+				if err != nil {
+					t.Errorf("resume must be allowed for a provably-dead fg engine, got %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), c.errSub) {
+				t.Errorf("resume must be refused (%q), got %v", c.errSub, err)
+			}
+		})
+	}
+}
+
+// TestSweepReclaimsByFgIdentity: the sweep (via RunEngineProvablyNotLive) reclaims a provably-dead
+// FOREGROUND run's leaked worktree and spares a live/unverifiable one — no direct sweep change, the
+// fg identity flows through RunEngineProvablyNotLive.
+func TestSweepReclaimsByFgIdentity(t *testing.T) {
+	for _, c := range fgIDCases(t) {
+		t.Run(c.name, func(t *testing.T) {
+			repo := initSweepRepo(t)
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("HOME", t.TempDir())
+			tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+			const id = "fg-sweep" // path-safe
+			t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+			if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: c.status, EnginePID: 0, FgEnginePID: c.fgPID, FgEngineProcStart: c.fgTok}); err != nil {
+				t.Fatal(err)
+			}
+			wt := filepath.Join(tempBase, id, "wt")
+			addWorktree(t, repo, wt)
+
+			sweepRunWorktrees(repo)
+
+			if c.provablyDead && worktreeListed(t, repo, wt) {
+				t.Error("a provably-dead fg run's leaked worktree must be reclaimed")
+			}
+			if !c.provablyDead && !worktreeListed(t, repo, wt) {
+				t.Error("a live/unverifiable fg run's worktree must be spared")
+			}
+		})
+	}
+}
+
+// TestResumeLauncherClearsFgIdentity: resuming a run clears the PRIOR fg identity before the resumed
+// engine stamps its own, so a stale identity never survives into the new engine — a foreground resume
+// of a run seeded with a dead fg pid ends up carrying the RESUMED engine's own pid, not the seed.
+func TestResumeLauncherClearsFgIdentity(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	script := writeFgTrivialScript(t)
+	const id = "fg-clear"
+	const stalePID = 0x7ffffffd // a DEAD pid distinct from the test process
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: stalePID, FgEngineProcStart: "stale"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+	if _, err := Launch(context.Background(), script, Options{Resume: id}, true); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	run, err := subagent.ReadRun(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.FgEnginePID == stalePID {
+		t.Error("the resumed run must not carry the PRIOR fg identity — the launcher clears it before re-stamp")
+	}
+	if run.FgEnginePID != os.Getpid() {
+		t.Errorf("the resumed foreground engine must stamp its OWN fg pid (%d), got %d", os.Getpid(), run.FgEnginePID)
+	}
+}
+
+// TestForegroundPreflightStampsSelfIdentity: the foreground resume preflight stamps the launcher's
+// OWN fg identity in the same save that flips the run running, so the crash window (a crash after the
+// preflight write, before the engine's first save) never leaves a proof-less {running, 0, no-fg}
+// record that resume would refuse forever. Execute is skipped (executeFn seam) to observe exactly the
+// preflight write: it classifies FgAlive while this process lives (never FgUnknown).
+func TestForegroundPreflightStampsSelfIdentity(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	oldExec := executeFn
+	oldAll := sweepRunWorktreesFn
+	oldOwn := sweepOwnSegmentFn
+	executeFn = func(context.Context, string, string, Options) error { return nil } // skip the engine
+	sweepRunWorktreesFn = func(string) {}
+	sweepOwnSegmentFn = func(string, string) {}
+	t.Cleanup(func() { executeFn = oldExec; sweepRunWorktreesFn = oldAll; sweepOwnSegmentFn = oldOwn })
+
+	script := filepath.Join(t.TempDir(), "s.js")
+	if err := os.WriteFile(script, []byte(`const meta = {name: "n", description: "d"};`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const id = "fg-preflight"
+	// A resumable (Ctrl-C'd fg, provably-dead) prior so the preflight proceeds to the rewrite.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0, FgEnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+	if _, err := Launch(context.Background(), script, Options{Resume: id}, true); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	run, err := subagent.ReadRun(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.FgEnginePID != os.Getpid() {
+		t.Errorf("the preflight must stamp the launcher's own fg pid (%d), got %d", os.Getpid(), run.FgEnginePID)
+	}
+	if got := subagent.ClassifyFgEngine(run); got != subagent.FgAlive {
+		t.Errorf("the crash-window record must classify FgAlive (never FgUnknown), got %v", got)
+	}
+}

--- a/internal/workflow/leaf_liveness_test.go
+++ b/internal/workflow/leaf_liveness_test.go
@@ -1,0 +1,337 @@
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/procintrospect"
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// seedLeafMeta writes a member job meta for runID into the jobs dir (derived from a run sidecar path,
+// since writeMeta is subagent-internal). status "running" seeds the normal sync shape (meta.PID = the
+// ENGINE); status "held" seeds the hold-premark shape (Status held, PID 0). childPID + childTok are the
+// recorded claude-child identity the reclaimers check. terminal writes a (possibly synthesized) cached
+// result the identity-first predicate must ignore.
+func seedLeafMeta(t *testing.T, runID, jobID, status string, childPID int, childTok string, terminal bool) {
+	t.Helper()
+	jp, err := subagent.RunJournalPath(runID) // .../subagent-jobs/runs/<id>.journal
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := filepath.Dir(filepath.Dir(jp)) // .../subagent-jobs
+	if err := os.MkdirAll(jobsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pid := os.Getpid() // sync leaf's meta.PID is the engine
+	if status == "held" {
+		pid = 0 // the hold premark clears PID; only the child identity can protect an orphan here
+	}
+	meta := fmt.Sprintf(`{"job_id":%q,"pid":%d,"status":%q,"run_id":%q,"child_pid":%d,"child_proc_start":%q}`,
+		jobID, pid, status, runID, childPID, childTok)
+	if err := os.WriteFile(filepath.Join(jobsDir, jobID+".json"), []byte(meta), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if terminal {
+		if err := os.WriteFile(filepath.Join(jobsDir, jobID+".result.json"), []byte(`{"ok":false,"status":"failed"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestSweepHonorsLiveLeafWorkdir: engine death does not prove leaf death, and identity outranks the
+// result cache. The Execute-time sweep SPARES a provably-dead run's PRESENT workdir while the member
+// leaf's CHILD is alive — EVEN with a synthesized terminal cached (the side door) — reclaims it once
+// the child reads dead, and reclaims a MISSING workdir regardless (clause b needs no leaf check).
+func TestSweepHonorsLiveLeafWorkdir(t *testing.T) {
+	liveTok, ok := procintrospect.ProcStart(os.Getpid())
+	if !ok {
+		t.Skip("procintrospect.ProcStart unavailable on this platform")
+	}
+	seedDeadRunWithWorktree := func(t *testing.T, id string) (repo, wt string) {
+		repo = initSweepRepo(t)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+		if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+			t.Fatal(err)
+		}
+		wt = filepath.Join(tempBase, id, "wt")
+		addWorktree(t, repo, wt)
+		return repo, wt
+	}
+
+	t.Run("present workdir spared while the child is alive (synthesized terminal ignored)", func(t *testing.T) {
+		repo, wt := seedDeadRunWithWorktree(t, "leaf-present")
+		seedLeafMeta(t, "leaf-present", "leaf1", "running", os.Getpid(), liveTok, true) // live child + cached terminal
+		sweepRunWorktrees(repo)
+		if !worktreeListed(t, repo, wt) {
+			t.Error("a present workdir must be spared while the member leaf's child is alive, cache notwithstanding")
+		}
+	})
+
+	t.Run("present workdir reclaimed once the child is dead", func(t *testing.T) {
+		repo, wt := seedDeadRunWithWorktree(t, "leaf-dead")
+		seedLeafMeta(t, "leaf-dead", "leaf1", "running", 0x7ffffffe, "", false) // dead child, no cache
+		sweepRunWorktrees(repo)
+		if worktreeListed(t, repo, wt) {
+			t.Error("a present workdir must be reclaimed once the member leaf's child reads dead")
+		}
+	})
+
+	t.Run("missing workdir reclaimed regardless of a live child", func(t *testing.T) {
+		repo, wt := seedDeadRunWithWorktree(t, "leaf-gone")
+		seedLeafMeta(t, "leaf-gone", "leaf1", "running", os.Getpid(), liveTok, false) // a live child...
+		if err := os.RemoveAll(wt); err != nil {                                      // ...but the workdir is gone
+			t.Fatal(err)
+		}
+		sweepRunWorktrees(repo)
+		if worktreeListed(t, repo, wt) {
+			t.Error("a missing workdir must be reclaimed regardless of the leaves (clause b needs no leaf check)")
+		}
+	})
+}
+
+// seedDeadRunWorktree seeds a provably-dead run (stopped + dead detached pid) with one registered
+// worktree, returning the repo + the worktree path.
+func seedDeadRunWorktree(t *testing.T, id string) (repo, wt string) {
+	t.Helper()
+	repo = initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	wt = filepath.Join(tempBase, id, "wt")
+	addWorktree(t, repo, wt)
+	return repo, wt
+}
+
+// TestReclaimSparesHeldPremarkOrphan: the hold protocol premarks {held, PID 0} BEFORE killing the
+// child, so an engine crash in that window leaves a live orphan whose ONLY protection is its recorded
+// child identity (the PID-0 fallback would read dead). Both the Execute-time sweep AND the launcher
+// own-segment sweep must spare a held-premark row with a live child, and reclaim once the child dies.
+func TestReclaimSparesHeldPremarkOrphan(t *testing.T) {
+	liveTok, ok := procintrospect.ProcStart(os.Getpid())
+	if !ok {
+		t.Skip("procintrospect.ProcStart unavailable on this platform")
+	}
+
+	t.Run("sweep spares a held-premark orphan (live child)", func(t *testing.T) {
+		repo, wt := seedDeadRunWorktree(t, "held-sweep")
+		seedLeafMeta(t, "held-sweep", "leaf1", "held", os.Getpid(), liveTok, false) // {held, PID 0, live child}
+		sweepRunWorktrees(repo)
+		if !worktreeListed(t, repo, wt) {
+			t.Error("the Execute-time sweep must spare a held-premark orphan's workdir (child alive)")
+		}
+	})
+
+	t.Run("sweepOwnSegment spares a held-premark orphan (live child)", func(t *testing.T) {
+		repo, wt := seedDeadRunWorktree(t, "held-own")
+		seedLeafMeta(t, "held-own", "leaf1", "held", os.Getpid(), liveTok, false)
+		sweepOwnSegment(repo, "held-own")
+		if !worktreeListed(t, repo, wt) {
+			t.Error("the launcher own-segment sweep must spare a held-premark orphan's workdir (child alive)")
+		}
+	})
+
+	t.Run("reclaimed once the held orphan's child is dead", func(t *testing.T) {
+		repo, wt := seedDeadRunWorktree(t, "held-dead")
+		seedLeafMeta(t, "held-dead", "leaf1", "held", 0x7ffffffe, "", false) // {held, PID 0, DEAD child}
+		sweepRunWorktrees(repo)
+		if worktreeListed(t, repo, wt) {
+			t.Error("a held row whose child is dead must be reclaimed")
+		}
+	})
+}
+
+// TestSweepSparesCollidingSegment (the codex r13 scenario): ownership is SEGMENT-level, so a LIVE
+// non-path-safe "a.b" and a dead path-safe "a-b" share segment "a-b". BOTH the Execute-time sweep and
+// the launcher own-segment sweep must SPARE the shared workdir (a.b may be using it); once a.b dies it
+// becomes reclaimable.
+func TestSweepSparesCollidingSegment(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, "a-b")) })
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0}); err != nil {
+		t.Fatal(err) // LIVE non-path-safe twin over segment a-b
+	}
+	wt := filepath.Join(tempBase, "a-b", "wt")
+	addWorktree(t, repo, wt)
+
+	sweepRunWorktrees(repo)
+	if !worktreeListed(t, repo, wt) {
+		t.Error("the Execute-time sweep must spare a segment a colliding live twin (a.b) uses")
+	}
+	sweepOwnSegment(repo, "a-b")
+	if !worktreeListed(t, repo, wt) {
+		t.Error("the launcher own-segment sweep must spare a segment a colliding live twin (a.b) uses")
+	}
+
+	// a.b dies → the segment (path-safe reclaimer a-b, no veto) becomes reclaimable.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	sweepRunWorktrees(repo)
+	if worktreeListed(t, repo, wt) {
+		t.Error("once the colliding twin dies, the shared segment is reclaimable")
+	}
+}
+
+// TestSweepOwnSegmentSnapshotScoped (codex r14 TOCTOU): sweepOwnSegment removes only the git-registered
+// (porcelain-snapshot) worktrees and os.Remove's the segment dir only if empty — so a workdir NOT in
+// the snapshot (here an unregistered dir, standing in for a post-snapshot fresh-uuid creation) SURVIVES.
+func TestSweepOwnSegmentSnapshotScoped(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	const id = "own-snap"
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	regWt := filepath.Join(tempBase, id, "reg-uuid") // git-registered → in the porcelain snapshot
+	addWorktree(t, repo, regWt)
+	unregWt := filepath.Join(tempBase, id, "fresh-uuid") // NOT registered → not in the snapshot
+	if err := os.MkdirAll(unregWt, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepOwnSegment(repo, id)
+
+	if worktreeListed(t, repo, regWt) {
+		t.Error("the porcelain-listed registration must be reclaimed")
+	}
+	if _, err := os.Stat(unregWt); err != nil {
+		t.Errorf("an unlisted (post-snapshot) workdir must SURVIVE, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tempBase, id)); err != nil {
+		t.Errorf("the segment dir must survive (not empty) — os.Remove is empty-only, err=%v", err)
+	}
+}
+
+// TestSweepSparesCorruptManifestCollision (codex r16): a corrupt run manifest is silently skipped by
+// ListRuns, but the live member leaf's veto stands on its own (the leaf projection), so a live colliding
+// a.b (with a truncated runs/a.b.json) still vetoes segment a-b. Both the sweep and the own-segment sweep
+// spare the shared workdir; once a.b's member dies it's reclaimable.
+func TestSweepSparesCorruptManifestCollision(t *testing.T) {
+	liveTok, ok := procintrospect.ProcStart(os.Getpid())
+	if !ok {
+		t.Skip("procintrospect.ProcStart unavailable on this platform")
+	}
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, "a-b")) })
+
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err) // dead path-safe reclaimer, valid manifest
+	}
+	seedLeafMeta(t, "a.b", "ablj", "running", os.Getpid(), liveTok, false) // LIVE a.b member
+	jp, err := subagent.RunJournalPath("x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(jp), "a.b.json"), []byte(`{"run_id":"a.b","stat`), 0o600); err != nil {
+		t.Fatal(err) // truncated a.b manifest
+	}
+	wt := filepath.Join(tempBase, "a-b", "wt")
+	addWorktree(t, repo, wt)
+
+	sweepRunWorktrees(repo)
+	if !worktreeListed(t, repo, wt) {
+		t.Error("the sweep must spare segment a-b — a.b's live member vetoes it despite the corrupt manifest")
+	}
+	sweepOwnSegment(repo, "a-b")
+	if !worktreeListed(t, repo, wt) {
+		t.Error("the own-segment sweep must skip segment a-b (colliding live a.b)")
+	}
+
+	seedLeafMeta(t, "a.b", "ablj", "running", 0x7ffffffe, "", false) // a.b's member dies
+	sweepRunWorktrees(repo)
+	if worktreeListed(t, repo, wt) {
+		t.Error("once a.b's member is dead, the shared segment is reclaimable")
+	}
+}
+
+// TestLegacyFgRunWorktreeUntouched (codex r23 rebuttal, executable): a {stopped, EnginePID 0, NO fg
+// identity} legacy run is NOT provably dead (FgUnknown), so every cleanup path may remove its RECORD
+// (today's adjudicated behavior) but NEVER touches its WORKDIR or git registration — worktreePurgeable
+// is false so PurgeRun skips the snapshot removal on direct rm / PruneRuns / PurgeJobs (its wholesale
+// RemoveAll only reaches the jobs-dir records, not the os.TempDir worktree tree nor the repo's .git),
+// and a subsequent sweep SPARES the now-unknown present segment.
+func TestLegacyFgRunWorktreeUntouched(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	const id = "legacy-fg" // path-safe
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	wt := filepath.Join(tempBase, id, "wt")
+	addWorktree(t, repo, wt) // registration + workdir, added ONCE — must survive every path below
+
+	legacy := subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0} // no fg identity
+	assertWorktreeUntouched := func(label string) {
+		if _, serr := os.Stat(wt); serr != nil {
+			t.Errorf("%s: the legacy fg run's workdir must SURVIVE (worktreePurgeable=false), err=%v", label, serr)
+		}
+		if !worktreeListed(t, repo, wt) {
+			t.Errorf("%s: the git registration must SURVIVE", label)
+		}
+	}
+
+	// Sanity: the adjudicated FgUnknown shape — NOT provably dead.
+	if err := subagent.SaveRun(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := subagent.ReadRun(id); subagent.RunEngineProvablyNotLive(r) {
+		t.Fatal("setup: {stopped,0,no-fg} must NOT be provably dead (FgUnknown)")
+	}
+
+	// Each path removes the RECORD (assert it does) but never the workdir/registration.
+	if err := subagent.PurgeRun(id); err != nil {
+		t.Fatalf("PurgeRun: %v", err)
+	}
+	if _, rerr := subagent.ReadRun(id); rerr == nil {
+		t.Error("PurgeRun removes the legacy fg record (adjudicated behavior)")
+	}
+	assertWorktreeUntouched("PurgeRun")
+
+	if err := subagent.SaveRun(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := subagent.PruneRuns(); err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	}
+	if _, rerr := subagent.ReadRun(id); rerr == nil {
+		t.Error("PruneRuns removes the legacy fg record")
+	}
+	assertWorktreeUntouched("PruneRuns")
+
+	if err := subagent.SaveRun(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := subagent.PurgeJobs(); err != nil {
+		t.Fatalf("PurgeJobs: %v", err)
+	}
+	if _, rerr := subagent.ReadRun(id); rerr == nil {
+		t.Error("PurgeJobs removes the legacy fg record")
+	}
+	assertWorktreeUntouched("PurgeJobs (incl. its wholesale jobs-dir RemoveAll)")
+
+	// The record is now gone → the segment is UNKNOWN; the sweep must SPARE the present workdir.
+	sweepRunWorktrees(repo)
+	assertWorktreeUntouched("sweepRunWorktrees (unknown present segment)")
+}

--- a/internal/workflow/leaf_liveness_test.go
+++ b/internal/workflow/leaf_liveness_test.go
@@ -54,7 +54,7 @@ func TestSweepHonorsLiveLeafWorkdir(t *testing.T) {
 		repo = initSweepRepo(t)
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		t.Setenv("HOME", t.TempDir())
-		tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+		tempBase := storeWorktreeBase(t)
 		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 		if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
 			t.Fatal(err)
@@ -102,7 +102,7 @@ func seedDeadRunWorktree(t *testing.T, id string) (repo, wt string) {
 	repo = initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
 		t.Fatal(err)
@@ -158,7 +158,7 @@ func TestSweepSparesCollidingSegment(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, "a-b")) })
 	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
 		t.Fatal(err)
@@ -195,7 +195,7 @@ func TestSweepOwnSegmentSnapshotScoped(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	const id = "own-snap"
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
@@ -233,7 +233,7 @@ func TestSweepSparesCorruptManifestCollision(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, "a-b")) })
 
 	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
@@ -276,7 +276,7 @@ func TestLegacyFgRunWorktreeUntouched(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	const id = "legacy-fg" // path-safe
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 	wt := filepath.Join(tempBase, id, "wt")

--- a/internal/workflow/leaf_liveness_test.go
+++ b/internal/workflow/leaf_liveness_test.go
@@ -150,7 +150,7 @@ func TestReclaimSparesHeldPremarkOrphan(t *testing.T) {
 	})
 }
 
-// TestSweepSparesCollidingSegment (the codex r13 scenario): ownership is SEGMENT-level, so a LIVE
+// TestSweepSparesCollidingSegment: ownership is SEGMENT-level, so a LIVE
 // non-path-safe "a.b" and a dead path-safe "a-b" share segment "a-b". BOTH the Execute-time sweep and
 // the launcher own-segment sweep must SPARE the shared workdir (a.b may be using it); once a.b dies it
 // becomes reclaimable.
@@ -188,7 +188,7 @@ func TestSweepSparesCollidingSegment(t *testing.T) {
 	}
 }
 
-// TestSweepOwnSegmentSnapshotScoped (codex r14 TOCTOU): sweepOwnSegment removes only the git-registered
+// TestSweepOwnSegmentSnapshotScoped: sweepOwnSegment removes only the git-registered
 // (porcelain-snapshot) worktrees and os.Remove's the segment dir only if empty — so a workdir NOT in
 // the snapshot (here an unregistered dir, standing in for a post-snapshot fresh-uuid creation) SURVIVES.
 func TestSweepOwnSegmentSnapshotScoped(t *testing.T) {
@@ -221,7 +221,7 @@ func TestSweepOwnSegmentSnapshotScoped(t *testing.T) {
 	}
 }
 
-// TestSweepSparesCorruptManifestCollision (codex r16): a corrupt run manifest is silently skipped by
+// TestSweepSparesCorruptManifestCollision: a corrupt run manifest is silently skipped by
 // ListRuns, but the live member leaf's veto stands on its own (the leaf projection), so a live colliding
 // a.b (with a truncated runs/a.b.json) still vetoes segment a-b. Both the sweep and the own-segment sweep
 // spare the shared workdir; once a.b's member dies it's reclaimable.
@@ -266,7 +266,7 @@ func TestSweepSparesCorruptManifestCollision(t *testing.T) {
 	}
 }
 
-// TestLegacyFgRunWorktreeUntouched (codex r23 rebuttal, executable): a {stopped, EnginePID 0, NO fg
+// TestLegacyFgRunWorktreeUntouched: a {stopped, EnginePID 0, NO fg
 // identity} legacy run is NOT provably dead (FgUnknown), so every cleanup path may remove its RECORD
 // (today's adjudicated behavior) but NEVER touches its WORKDIR or git registration — worktreePurgeable
 // is false so PurgeRun skips the snapshot removal on direct rm / PruneRuns / PurgeJobs (its wholesale

--- a/internal/workflow/pending_identity_test.go
+++ b/internal/workflow/pending_identity_test.go
@@ -19,7 +19,7 @@ func TestPendingIdentityWorktreeProtected(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	const id = "pend-run" // path-safe
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 	wt := filepath.Join(tempBase, id, "wt")
@@ -87,7 +87,7 @@ func TestPendingHeldMemberVetoesSegment(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	tempBase := storeWorktreeBase(t)
 	const id = "held-pend" // path-safe
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
 	wt := filepath.Join(tempBase, id, "wt")

--- a/internal/workflow/pending_identity_test.go
+++ b/internal/workflow/pending_identity_test.go
@@ -1,0 +1,127 @@
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// TestPendingIdentityWorktreeProtected (codex r24): a DETACHED dead-engine run with a PENDING
+// identity-less member (Start-window crash) + a present workdir. The pending member's read-side veto
+// protects the workdir: PurgeJobs keeps it (its run stays), the sweep spares it (segment vetoed), and a
+// path-safe PurgeRun refuses. The explicit DeleteJob on the pending job is the record-only recovery
+// escape; after it the run's rm is unblocked. Post-recovery disposition is asserted (see comment).
+func TestPendingIdentityWorktreeProtected(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	const id = "pend-run" // path-safe
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	wt := filepath.Join(tempBase, id, "wt")
+	addWorktree(t, repo, wt)
+
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err) // dead detached engine
+	}
+	jp, err := subagent.RunJournalPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := filepath.Dir(filepath.Dir(jp))
+	// meta.PID = the CRASHED engine (dead), so PurgeJobs's processAlive keep-arm can't hold it — only the
+	// pending clause can; child_pid absent (identity write never happened).
+	pendMeta := fmt.Sprintf(`{"job_id":"pend","pid":%d,"status":"running","run_id":%q,"child_identity_pending":true}`, 0x7ffffffe, id)
+	if err := os.WriteFile(filepath.Join(jobsDir, "pend.json"), []byte(pendMeta), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// PurgeJobs keeps the pending member (→ its run's manifest) so the workdir survives.
+	if _, _, _, perr := subagent.PurgeJobs(); perr != nil {
+		t.Fatal(perr)
+	}
+	if _, serr := os.Stat(wt); serr != nil {
+		t.Errorf("PurgeJobs must preserve the workdir under a pending member, err=%v", serr)
+	}
+	// The sweep spares the segment (vetoed by the pending member's read-side fail-safe).
+	sweepRunWorktrees(repo)
+	if _, serr := os.Stat(wt); serr != nil {
+		t.Errorf("the sweep must SPARE the workdir (pending member vetoes the segment), err=%v", serr)
+	}
+	// A path-safe PurgeRun refuses (segment verdict vetoed by the pending member).
+	if err := subagent.PurgeRun(id); err == nil || !strings.Contains(err.Error(), "worktree segment") {
+		t.Errorf("path-safe PurgeRun must refuse under a pending member, got %v", err)
+	}
+	if _, serr := os.Stat(wt); serr != nil {
+		t.Errorf("the refused PurgeRun must leave the workdir, err=%v", serr)
+	}
+
+	// Recovery escape: DeleteJob on the pending job PROCEEDS (record-only — never touches the workdir).
+	if derr := subagent.DeleteJob("pend"); derr != nil {
+		t.Errorf("DeleteJob on the pending job must proceed (recovery escape), got %v", derr)
+	}
+	if _, serr := os.Stat(wt); serr != nil {
+		t.Errorf("DeleteJob itself must be record-only — the workdir must still exist, err=%v", serr)
+	}
+	// After the pending record is gone, the run's rm is unblocked and PROCEEDS. For a worktreePurgeable
+	// (dead detached engine) run it removes the workdir WITH the record (ordered) — the user's explicit
+	// DeleteJob resolved the orphan, so this is user-sanctioned, not a delete under an unverifiable orphan.
+	if perr := subagent.PurgeRun(id); perr != nil {
+		t.Errorf("after recovery the run's rm must proceed, got %v", perr)
+	}
+	if _, serr := os.Stat(wt); !os.IsNotExist(serr) {
+		t.Errorf("after recovery the dead run's workdir is removed WITH the record (ordered), err=%v", serr)
+	}
+}
+
+// TestPendingHeldMemberVetoesSegment (codex r25): a HELD premark clears meta.PID, so a Start-window
+// crash after a hold directive leaves {held, PID 0, ChildPID 0, ChildIdentityPending}. The PID>0
+// fallback would read it DEAD (no segment veto); the read side must instead veto it (aligned with the
+// keep-rule). Dead engine + present workdir → sweep spares, path-safe PurgeRun refuses; DeleteJob
+// recovers (r24 chain, held shape).
+func TestPendingHeldMemberVetoesSegment(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees")
+	const id = "held-pend" // path-safe
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	wt := filepath.Join(tempBase, id, "wt")
+	addWorktree(t, repo, wt)
+
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	jp, err := subagent.RunJournalPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := filepath.Dir(filepath.Dir(jp))
+	// {held, PID 0, pending, no child}: the hold premark cleared PID, but a child may have started.
+	heldMeta := fmt.Sprintf(`{"job_id":"hp","pid":0,"status":"held","run_id":%q,"child_identity_pending":true}`, id)
+	if err := os.WriteFile(filepath.Join(jobsDir, "hp.json"), []byte(heldMeta), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepRunWorktrees(repo)
+	if _, serr := os.Stat(wt); serr != nil {
+		t.Errorf("the sweep must SPARE the workdir — a held-pending member vetoes the segment, err=%v", serr)
+	}
+	if perr := subagent.PurgeRun(id); perr == nil || !strings.Contains(perr.Error(), "worktree segment") {
+		t.Errorf("path-safe PurgeRun must refuse under a held-pending member, got %v", perr)
+	}
+	if _, serr := os.Stat(wt); serr != nil {
+		t.Errorf("the refused PurgeRun must leave the workdir, err=%v", serr)
+	}
+	// Recovery: DeleteJob on the held-pending job proceeds → the run's rm is unblocked.
+	if derr := subagent.DeleteJob("hp"); derr != nil {
+		t.Errorf("DeleteJob on the held-pending job must proceed (recovery), got %v", derr)
+	}
+	if perr := subagent.PurgeRun(id); perr != nil {
+		t.Errorf("after recovery the run's rm must proceed, got %v", perr)
+	}
+}

--- a/internal/workflow/pending_identity_test.go
+++ b/internal/workflow/pending_identity_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
-// TestPendingIdentityWorktreeProtected (codex r24): a DETACHED dead-engine run with a PENDING
+// TestPendingIdentityWorktreeProtected: a DETACHED dead-engine run with a PENDING
 // identity-less member (Start-window crash) + a present workdir. The pending member's read-side veto
 // protects the workdir: PurgeJobs keeps it (its run stays), the sweep spares it (segment vetoed), and a
 // path-safe PurgeRun refuses. The explicit DeleteJob on the pending job is the record-only recovery
@@ -78,11 +78,11 @@ func TestPendingIdentityWorktreeProtected(t *testing.T) {
 	}
 }
 
-// TestPendingHeldMemberVetoesSegment (codex r25): a HELD premark clears meta.PID, so a Start-window
+// TestPendingHeldMemberVetoesSegment: a HELD premark clears meta.PID, so a Start-window
 // crash after a hold directive leaves {held, PID 0, ChildPID 0, ChildIdentityPending}. The PID>0
 // fallback would read it DEAD (no segment veto); the read side must instead veto it (aligned with the
 // keep-rule). Dead engine + present workdir → sweep spares, path-safe PurgeRun refuses; DeleteJob
-// recovers (r24 chain, held shape).
+// recovers.
 func TestPendingHeldMemberVetoesSegment(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/workflow/restart.go
+++ b/internal/workflow/restart.go
@@ -52,19 +52,42 @@ func restartLocked(ctx context.Context, runID, journalKey string) error {
 	return err
 }
 
-// resumeBlockedReason reports why a run must not be resumed or restarted (nil when it may). The sole
-// block is the ambiguous {stopped, EnginePID 0} record: a Ctrl-C'd foreground engine writes it in its
-// shutdown defer then exits (dead), and StopRun's blind flip of a still-LIVE foreground engine it
-// couldn't reap writes the identical record — indistinguishable. Resuming the live one would start a
-// second engine sharing this manifest/journal/worktree segment, whose later-dead pid would falsely
-// condemn the survivor's live worktrees to the sweep; refuse both so a segment is never co-owned.
-// (Pre-retained-pid StopRun left stopped-detached runs at {stopped,0} too.) Shared by Launch's resume
-// preflight and ensureRestartable so both refuse identically — the latter BEFORE any journal rewrite.
+// resumeBlockedReason reports why a run may not be resumed or restarted (nil when it may). It decides
+// the FOREGROUND cases (no reapable detached pid, EnginePID<=0) from the recorded fg engine identity:
+// a provably-dead fg engine — a Ctrl-C'd run (its shutdown defer wrote the manifest then it exited) or
+// a crashed one — is resumable; a still-LIVE one is refused (resuming would run a second engine on this
+// manifest/journal/worktree segment, whose later-dead pid would falsely condemn the survivor's live
+// worktrees to the sweep); an absent/unverifiable identity (an old pre-field record, or a platform
+// that can't read the token) keeps the conservative refusal. A recorded DETACHED engine (EnginePID>0)
+// is decided by the tri-state ClassifyDetachedEngine: dead/recycled or verifiably-live → nil (the
+// caller's running-refuse / stop-and-confirm path replays or reaps it); an alive-but-UNVERIFIABLE
+// retained pid → refused here (its stop-and-confirm keys on Status=="running", so a blind-stopped one
+// would otherwise resume under a possibly-live engine). Shared by Launch's resume preflight and
+// ensureRestartable so both refuse identically — the latter BEFORE any journal rewrite.
 func resumeBlockedReason(run subagent.WorkflowRun) error {
-	if run.Status == "stopped" && run.EnginePID == 0 {
-		return fmt.Errorf("workflow: run %s was stopped and its foreground engine's death cannot be verified; confirm its terminal process has exited, then delete it (workflow rm) or launch fresh", run.RunID)
+	if run.Status != "stopped" && run.Status != "running" {
+		return nil // terminal (done/failed) — a resume/restart is not a live-engine concern here
 	}
-	return nil
+	if run.EnginePID > 0 {
+		// A recorded DETACHED engine: dead/recycled or verifiably-live → nil (the running-refuse /
+		// stop-and-confirm path replays or reaps it). But an alive-but-UNVERIFIABLE retained pid is
+		// refused: a blind-stop collapse can leave {stopped, retained pid} whose stop-and-confirm never
+		// fires (that guard keys on Status=="running"), so resuming could run a SECOND engine on this
+		// manifest / journal / worktree segment — whose later-dead pid would then falsely condemn the
+		// survivor's live worktrees to the sweep. Self-clearing: once the pid exits it reads DetachedDead.
+		if subagent.ClassifyDetachedEngine(run) == subagent.DetachedUnknown {
+			return fmt.Errorf("workflow: run %s has a detached engine (pid %d) whose death cannot be verified; confirm the process has exited, then delete it (workflow rm) or launch fresh", run.RunID, run.EnginePID)
+		}
+		return nil
+	}
+	switch subagent.ClassifyFgEngine(run) {
+	case subagent.FgDead:
+		return nil // the foreground engine exited (Ctrl-C'd or crashed) — safe to resume/restart
+	case subagent.FgAlive:
+		return fmt.Errorf("workflow: run %s is still running in the foreground; stop it in its terminal (Ctrl-C) first", run.RunID)
+	default: // FgUnknown — an old record with no fg identity, or one whose liveness can't be verified
+		return fmt.Errorf("workflow: run %s has a foreground engine whose death cannot be verified; confirm its terminal process has exited, then delete it (workflow rm) or launch fresh", run.RunID)
+	}
 }
 
 // ensureRestartable is the shared pre-restart barrier: the run must be resumable
@@ -94,23 +117,16 @@ func ensureRestartable(runID string) (string, error) {
 		}
 		return "", fmt.Errorf("workflow: saved script for run %s is unavailable; cannot restart: %w", runID, serr)
 	}
-	if run.Status == "running" {
-		switch {
-		case subagent.EngineAlive(run):
-			// A verifiably-live detached engine → stop it + confirm dead (abort if it won't die in time).
-			if _, serr := subagent.StopRun(runID); serr != nil {
-				return "", serr
-			}
-			if !subagent.WaitEngineStopped(runID, stopBarrierTimeout) {
-				return "", fmt.Errorf("workflow: run %s engine did not stop in time; restart aborted", runID)
-			}
-		case run.EnginePID <= 0:
-			// A foreground run (or a detached run in the mint→stamp-pid window) still claiming to run has
-			// no killable engine to confirm dead — resuming could run two engines on one journal. Fail
-			// closed; stop it first.
-			return "", fmt.Errorf("workflow: run %s is running in the foreground; stop it first", runID)
+	if run.Status == "running" && subagent.EngineAlive(run) {
+		// A verifiably-live DETACHED engine → stop it + confirm dead (abort if it won't die in time). A
+		// foreground run (EnginePID<=0) was already vetted by resumeBlockedReason above (dead→resume,
+		// live→refused); a crashed/killed detached run (recorded pid now dead) falls straight through.
+		if _, serr := subagent.StopRun(runID); serr != nil {
+			return "", serr
 		}
-		// else: a crashed/killed DETACHED run (recorded pid now dead) — safe to resume as-is.
+		if !subagent.WaitEngineStopped(runID, stopBarrierTimeout) {
+			return "", fmt.Errorf("workflow: run %s engine did not stop in time; restart aborted", runID)
+		}
 	}
 	return scriptPath, nil
 }

--- a/internal/workflow/restart.go
+++ b/internal/workflow/restart.go
@@ -52,13 +52,35 @@ func restartLocked(ctx context.Context, runID, journalKey string) error {
 	return err
 }
 
-// ensureRestartable is the shared pre-restart barrier: the saved script must be
-// readable (with the explicit pre-JS-engine refusal) and a still-"running" run's
-// engine must be verifiably GONE before any journal rewrite (it O_APPENDs to it).
+// resumeBlockedReason reports why a run must not be resumed or restarted (nil when it may). The sole
+// block is the ambiguous {stopped, EnginePID 0} record: a Ctrl-C'd foreground engine writes it in its
+// shutdown defer then exits (dead), and StopRun's blind flip of a still-LIVE foreground engine it
+// couldn't reap writes the identical record — indistinguishable. Resuming the live one would start a
+// second engine sharing this manifest/journal/worktree segment, whose later-dead pid would falsely
+// condemn the survivor's live worktrees to the sweep; refuse both so a segment is never co-owned.
+// (Pre-retained-pid StopRun left stopped-detached runs at {stopped,0} too.) Shared by Launch's resume
+// preflight and ensureRestartable so both refuse identically — the latter BEFORE any journal rewrite.
+func resumeBlockedReason(run subagent.WorkflowRun) error {
+	if run.Status == "stopped" && run.EnginePID == 0 {
+		return fmt.Errorf("workflow: run %s was stopped and its foreground engine's death cannot be verified; confirm its terminal process has exited, then delete it (workflow rm) or launch fresh", run.RunID)
+	}
+	return nil
+}
+
+// ensureRestartable is the shared pre-restart barrier: the run must be resumable
+// (resumeBlockedReason), the saved script must be readable (with the explicit pre-JS-engine
+// refusal), and a still-"running" run's engine must be verifiably GONE before any journal rewrite
+// (it O_APPENDs to it).
 func ensureRestartable(runID string) (string, error) {
 	run, err := subagent.ReadRun(runID)
 	if err != nil {
 		return "", err
+	}
+	// Refuse an unresumable run BEFORE the caller rewrites the journal (removeJournalKey/Keys), so a
+	// restart never leaves a mutate-then-fail half-state — the journal must not be touched under an
+	// engine whose death can't be verified. Same predicate Launch's preflight uses, so no drift.
+	if reason := resumeBlockedReason(run); reason != nil {
+		return "", reason
 	}
 	scriptPath, err := subagent.RunScriptPath(runID)
 	if err != nil {

--- a/internal/workflow/restart_cluster_test.go
+++ b/internal/workflow/restart_cluster_test.go
@@ -10,19 +10,20 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
-// TestLaunch_ResumeLiveGuard: Launch's resume branch refuses a run that still claims to be running with a
-// live (or foreground/unverifiable EnginePID<=0) engine, so a public `workflow run --resume` can't launch a
-// second engine over a live one. A freshly minted run is Status="running", EnginePID=0 → the guard fires.
+// TestLaunch_ResumeLiveGuard: Launch's resume branch refuses a run that still claims to be running
+// without a verifiably-exited engine. A freshly minted run is Status="running", EnginePID=0 with no
+// foreground identity yet → FgUnknown → refused (its engine can't be confirmed dead), so a public
+// `workflow run --resume` can't launch a second engine over a possibly-live one.
 func TestLaunch_ResumeLiveGuard(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	run, err := subagent.NewRunWithMeta("n", "d", "", nil) // mints Status="running", EnginePID=0
+	run, err := subagent.NewRunWithMeta("n", "d", "", nil) // mints Status="running", EnginePID=0, no fg fields
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, lerr := Launch(context.Background(), "/nonexistent.js", Options{Resume: run.RunID}, false)
-	if lerr == nil || !strings.Contains(lerr.Error(), "already has a live engine") {
-		t.Fatalf("Launch --resume of a still-running run must refuse with a live-engine error, got: %v", lerr)
+	if lerr == nil || !strings.Contains(lerr.Error(), "cannot be verified") {
+		t.Fatalf("Launch --resume of a still-running run with no verifiable engine must refuse, got: %v", lerr)
 	}
 }
 
@@ -53,6 +54,10 @@ func TestRestart_StarOnlyRunRefused(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	run, err := subagent.NewRunWithMeta("n", "d", "", nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = "done" // a completed run clears the liveness gate, so the restart reaches the script-availability check
+	if err := subagent.SaveRun(run); err != nil {
 		t.Fatal(err)
 	}
 	lp, err := subagent.LegacyRunScriptPath(run.RunID)

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -95,7 +95,7 @@ func sweepRunWorktrees(root string) {
 	if err != nil {
 		return
 	}
-	globalPrefix := filepath.Join(os.TempDir(), "cc-fleet-worktrees") + string(os.PathSeparator)
+	globalPrefix := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") + string(os.PathSeparator)
 	deadBySegment := map[string]bool{}
 	if runs, lerr := subagent.ListRuns(); lerr == nil {
 		for _, r := range runs {
@@ -134,7 +134,7 @@ func sweepOwnSegment(root, runID string) {
 	if sanitizeRunID(runID) != runID {
 		return // non-path-safe: the segment is shared with colliding ids — never reclaim it
 	}
-	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	segDir := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees", runID)
 	if out, err := runGit(root, "worktree", "list", "--porcelain"); err == nil {
 		segPrefix := segDir + string(os.PathSeparator)
 		for _, line := range strings.Split(out, "\n") {
@@ -174,13 +174,15 @@ func normPath(p string) string {
 }
 
 // gitTopLevel returns the repo root containing dir, or a clear error when dir is not in a
-// git repository (worktree isolation requires one).
+// git repository (worktree isolation requires one). The path is canonicalized (canonPath) so the
+// stored root matches the canonical form git porcelain uses — idempotent, since `rev-parse
+// --show-toplevel` already resolves symlinks / 8.3 short names, but explicit and platform-uniform.
 func gitTopLevel(dir string) (string, error) {
 	out, err := runGit(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", fmt.Errorf("isolation='worktree' requires a git repository (cwd is not one): %v", err)
 	}
-	return strings.TrimSpace(out), nil
+	return canonPath(strings.TrimSpace(out)), nil
 }
 
 // runGit runs a git command in dir with a cred-scrubbed env and returns combined output.

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -27,6 +27,11 @@ var (
 	sweepOwnSegmentFn   = sweepOwnSegment
 )
 
+// reclaimVerdicts is the reclaim verdict as this package's sweeps see it, held as a seam so a test can
+// drive a colliding worktree into the snapshot→verdict window; production is
+// subagent.SegmentReclaimVerdicts.
+var reclaimVerdicts = subagent.SegmentReclaimVerdicts
+
 // createWorktree makes a fresh detached `git worktree` from the run's repo (cwd's repo)
 // at HEAD, under a run-scoped temp root, and returns its path + a cleanup. A leaf run with
 // cwd = this worktree edits an isolated copy, so parallel file-editing leaves don't
@@ -46,7 +51,11 @@ func createWorktree(runID string) (string, func(), error) {
 	if err != nil {
 		return "", nil, err
 	}
-	base := filepath.Join(os.TempDir(), "cc-fleet-worktrees", ids.WorktreeSegment(runID))
+	storeDir, err := subagent.WorktreeStoreDir()
+	if err != nil {
+		return "", nil, fmt.Errorf("worktree store dir: %w", err)
+	}
+	base := filepath.Join(storeDir, ids.WorktreeSegment(runID))
 	if err := os.MkdirAll(base, 0o700); err != nil {
 		return "", nil, fmt.Errorf("worktree base: %w", err)
 	}
@@ -70,9 +79,9 @@ func removeWorktree(root, wt string) {
 // sweepRunWorktrees reclaims stale isolation-worktree registrations left in root's .git by
 // crashed/SIGKILLed engines (a bare SIGKILL skips the deferred cleanup, so both the git
 // registration and the temp workdir leak). Best-effort, no error return. It lists root's
-// worktrees, keeps only those whose workdir is under the global cc-fleet-worktrees temp prefix,
-// and removes a candidate iff a DEATH PROOF holds — one uniform rule, nothing reclaimed on
-// identity alone:
+// worktrees, keeps only those whose workdir is under THIS store's temp prefix
+// (cc-fleet-worktrees/<WorktreeStoreID>), and removes a candidate iff a DEATH PROOF holds — one
+// uniform rule, nothing reclaimed on identity alone:
 //
 //	(a) the segment's verdict (subagent.SegmentReclaimVerdicts) clears — a path-safe owner is provably
 //	    engine-dead AND leaf-free (Reclaimer) AND no owner, path-safe or a colliding twin, is alive/
@@ -84,55 +93,78 @@ func removeWorktree(root, wt string) {
 //	    and this also reclaims a run whose manifest was already purged out from under a leaked
 //	    registration.
 //
-// An UNKNOWN segment whose workdir still EXISTS is left alone: absence from THIS store's list is
-// not proof of death — a different config store (another HOME/XDG_CONFIG_HOME) may own a live run
-// this process cannot see. This run's OWN segment gets no privileged reclamation here (an earlier
-// design reclaimed it unconditionally, which could delete a blind-stopped-but-live foreground
-// twin's worktrees — the twin shares this run's id); a resumed engine's own stale worktrees are
-// reclaimed in the launcher under a death proof (sweepOwnSegment). A live foreground engine, a
-// still-running detached engine, and an alive-but-unverifiable pid are all left untouched, as are
-// the user's own worktrees (they never live under the temp prefix). Segments are ids.WorktreeSegment(id);
-// because that collapses '.'/':'/separators to '-' (non-injective: ids "a.b"/"a:b"/"a-b" all yield
-// "a-b"), the reclaim verdict is SEGMENT-level (subagent.SegmentReclaimVerdicts): a non-path-safe twin
-// never RECLAIMS (identity reclaim is path-safe-only) yet, while alive, always VETOES its segment — so
-// a live "a.b" can't lose its workdirs to a dead "a-b", and a dead twin can't provoke reclaiming a live
-// one.
+// The temp prefix is namespaced by config store (WorktreeStoreID), so the VERDICT (clause a) is applied
+// only to THIS store's worktrees — a foreign store (another HOME/XDG_CONFIG_HOME) sharing os.TempDir()
+// and this repo lives under a DIFFERENT prefix, is verdict-exempt, and can never have its live worktree
+// deleted by this store's verdict. A worktree under the shared cc-fleet-worktrees root but outside this
+// store's prefix (a foreign store's, or a pre-namespacing flat leftover) is pruned by clause (b) ONLY —
+// when its workdir has vanished, which needs no verdict — so present foreign workdirs stay untouched
+// while stale registrations don't strand. An UNKNOWN segment under THIS store's prefix whose workdir
+// still EXISTS is left alone: it is this store's own run whose manifest is missing/unreadable (a live
+// one is spared by the verdict's fail-closed handling), not proof of death. This run's OWN segment gets no privileged reclamation here (an earlier design reclaimed it
+// unconditionally, which could delete a blind-stopped-but-live foreground twin's worktrees — the twin
+// shares this run's id); a resumed engine's own stale worktrees are reclaimed in the launcher under a
+// death proof (sweepOwnSegment). A live foreground engine, a still-running detached engine, and an
+// alive-but-unverifiable pid are all left untouched, as are the user's own worktrees (they never live
+// under the temp prefix). Segments are ids.WorktreeSegment(id); because that collapses '.'/':'/separators
+// to '-' (non-injective: ids "a.b"/"a:b"/"a-b" all yield "a-b"), the reclaim verdict is SEGMENT-level
+// (subagent.SegmentReclaimVerdicts): a non-path-safe twin never RECLAIMS (identity reclaim is
+// path-safe-only) yet, while alive, always VETOES its segment — so a live "a.b" can't lose its workdirs
+// to a dead "a-b", and a dead twin can't provoke reclaiming a live one.
 func sweepRunWorktrees(root string) {
+	storeID, err := subagent.WorktreeStoreID()
+	if err != nil {
+		return
+	}
 	out, err := runGit(root, "worktree", "list", "--porcelain")
 	if err != nil {
 		return
 	}
-	globalPrefix := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") + string(os.PathSeparator)
+	globalPrefix := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName, storeID) + string(os.PathSeparator)
+	// flatRoot is the SHARED cc-fleet-worktrees root every store (and any pre-namespacing legacy leftover)
+	// sits beneath. A worktree under flatRoot but NOT under globalPrefix belongs to a FOREIGN store or is
+	// a legacy flat leftover: this store's verdict says nothing about it, so it is NEVER verdict-reclaimed
+	// (that store-local verdict on a foreign present workdir was the r34 deletion hole). It is pruned ONLY
+	// when its workdir has vanished — clause (b) needs no verdict (a deleted cwd cannot host a live
+	// process, whichever store owned it) — so a stale registration doesn't strand until a manual
+	// `git worktree prune`.
+	flatRoot := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName) + string(os.PathSeparator)
 	// Ownership is keyed by SEGMENT (ids.WorktreeSegment), not exact id, and engine death does NOT prove
 	// leaf death (a SIGKILLed engine's claude leaf children — own process groups, cwd = the worktree —
 	// outlive it). One ListRuns pass + one leaf scan aggregates, per segment, a Reclaimer (a path-safe
 	// dead+leaf-free owner) and a Vetoed flag (ANY owner — path-safe or a colliding twin — alive/
 	// unverifiable or leaf-bearing). A scan failure (!verdictsOK) makes every present-workdir reclamation
 	// unsafe. The workdir-MISSING clause needs no verdict — a vanished cwd cannot host a running process.
-	verdicts, verdictsOK := subagent.SegmentReclaimVerdicts()
+	verdicts, verdictsOK := reclaimVerdicts()
 	for _, line := range strings.Split(out, "\n") {
 		wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree ")
 		if !ok {
 			continue
 		}
-		if !pathUnder(globalPrefix, wt) {
-			continue
+		if pathUnder(globalPrefix, wt) {
+			seg := runSegment(globalPrefix, wt)
+			v := verdicts[seg]
+			_, statErr := os.Stat(wt)
+			presentReclaimable := verdictsOK && v.Reclaimer && !v.Vetoed
+			if presentReclaimable || os.IsNotExist(statErr) {
+				removeWorktree(root, wt)
+			}
+			continue // unknown/live/leaf-bearing present, or a segment a live owner vetoes → kept
 		}
-		seg := runSegment(globalPrefix, wt)
-		v := verdicts[seg]
-		_, statErr := os.Stat(wt)
-		presentReclaimable := verdictsOK && v.Reclaimer && !v.Vetoed
-		remove := presentReclaimable || os.IsNotExist(statErr)
-		if !remove {
-			continue // unknown/live/leaf-bearing present, or a segment a live owner vetoes
+		if pathUnder(flatRoot, wt) {
+			// A foreign store's or a legacy flat worktree — verdict-exempt: prune ONLY a vanished workdir
+			// (clause b), never a present one (it may be a foreign store's live cwd — the r34 hole).
+			if _, statErr := os.Stat(wt); os.IsNotExist(statErr) {
+				removeWorktree(root, wt)
+			}
 		}
-		removeWorktree(root, wt)
+		// else: not under the cc-fleet temp root at all (the user's own worktree) → left untouched.
 	}
 }
 
 // sweepOwnSegment reclaims ONLY runID's own isolation-worktree segment in root's .git — every
-// registration under cc-fleet-worktrees/<ids.WorktreeSegment(id)>/ plus the segment dir. It is the
-// resume launcher's own-stale-worktree cleanup, run there (not in the Execute-time sweep) and only
+// registration under cc-fleet-worktrees/<WorktreeStoreID>/<ids.WorktreeSegment(id)>/ plus the segment
+// dir. It is the resume launcher's own-stale-worktree cleanup, run there (not in the Execute-time sweep) and only
 // after the prior record is confirmed provably dead: the launcher holds the death evidence that the
 // manifest rewrite then erases. A non-path-safe id is a no-op — its segment collides with other ids,
 // so reclaiming it could delete a twin's live worktrees. Since the launcher already established the
@@ -142,19 +174,30 @@ func sweepOwnSegment(root, runID string) {
 	if ids.WorktreeSegment(runID) != runID {
 		return // non-path-safe: the segment is shared with colliding ids — never reclaim it
 	}
-	verdicts, ok := subagent.SegmentReclaimVerdicts()
+	storeID, err := subagent.WorktreeStoreID()
+	if err != nil {
+		return
+	}
+	// Snapshot the segment's registrations BEFORE the verdict — the same ordering sweepRunWorktrees and
+	// PurgeRun use. A colliding twin ("a.b", same segment) runs under a DIFFERENT run id, so its run lock
+	// never serializes against this sweep; the pre-verdict snapshot is the only guard. A twin that
+	// registers a fresh worktree AFTER this list is structurally out of the removal set below, so a stale
+	// "reclaimable" verdict can never delete a live owner's just-created worktree.
+	out, err := runGit(root, "worktree", "list", "--porcelain")
+	if err != nil {
+		return
+	}
 	// Fail closed: a MISSING entry (no known owner) or a non-reclaimer/vetoed one skips — only a
 	// KNOWN path-safe dead+leaf-free owner with no live/colliding twin reclaims.
+	verdicts, ok := reclaimVerdicts()
 	if v, present := verdicts[runID]; !ok || !present || !v.Reclaimer || v.Vetoed {
 		return
 	}
-	segDir := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees", runID)
-	if out, err := runGit(root, "worktree", "list", "--porcelain"); err == nil {
-		segPrefix := segDir + string(os.PathSeparator)
-		for _, line := range strings.Split(out, "\n") {
-			if wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree "); ok && pathUnder(segPrefix, wt) {
-				removeWorktree(root, wt) // only the porcelain-listed (snapshot) registrations
-			}
+	segDir := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName, storeID, runID)
+	segPrefix := segDir + string(os.PathSeparator)
+	for _, line := range strings.Split(out, "\n") {
+		if wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree "); ok && pathUnder(segPrefix, wt) {
+			removeWorktree(root, wt) // only the pre-verdict snapshot's registrations
 		}
 	}
 	// Remove the segment dir only if now EMPTY — a post-snapshot colliding fresh-uuid workdir (unlisted,
@@ -162,8 +205,8 @@ func sweepOwnSegment(root, runID string) {
 	_ = os.Remove(segDir)
 }
 
-// runSegment returns the run-id path segment (the first component after the global
-// cc-fleet-worktrees prefix) of a worktree path known to be under that prefix.
+// runSegment returns the run-id path segment (the first component after the store-scoped
+// cc-fleet-worktrees/<storeID> prefix) of a worktree path known to be under that prefix.
 func runSegment(globalPrefix, wt string) string {
 	rest := strings.TrimPrefix(normPath(wt), normPath(globalPrefix))
 	if i := strings.IndexByte(rest, '/'); i >= 0 {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -6,25 +6,36 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/google/uuid"
 
 	"github.com/ethanhq/cc-fleet/internal/childenv"
+	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
 // createWorktreeFn is a seam so tests inject a fake worktree (no real git) — production is
 // createWorktree. It returns the worktree path, a cleanup func, and an error.
 var createWorktreeFn = createWorktree
 
+// sweepRunWorktreesFn / sweepOwnSegmentFn are seams so tests assert the Execute-time and resume-
+// launcher sweeps fire without real git — production is sweepRunWorktrees / sweepOwnSegment.
+var (
+	sweepRunWorktreesFn = sweepRunWorktrees
+	sweepOwnSegmentFn   = sweepOwnSegment
+)
+
 // createWorktree makes a fresh detached `git worktree` from the run's repo (cwd's repo)
 // at HEAD, under a run-scoped temp root, and returns its path + a cleanup. A leaf run with
 // cwd = this worktree edits an isolated copy, so parallel file-editing leaves don't
-// collide. The worktree is removed on cleanup (deferred by the caller on done/fail/panic);
-// the run-scoped root means an engine SIGKILL leaves at most that run's worktrees on a
-// temp filesystem, not the user's repo. Cross-platform via the git CLI (no cgo). A non-git
-// cwd is a clear error. The git child env is scrubbed of creds (childenv.Clean) — git
-// needs none.
+// collide. The worktree is removed on cleanup (deferred by the caller on done/fail/panic).
+// The git registration lands in the user's repo .git; a graceful path removes it at once,
+// while an engine SIGKILL/crash skips the deferred cleanup and leaves a stale registration —
+// reclaimed later under a death proof: the next engine's startup sweepRunWorktrees (a
+// provably-dead detached run, or any vanished workdir), or a resume's own-segment sweep.
+// Cross-platform via the git CLI (no cgo). A non-git cwd is a clear error. The git child env
+// is scrubbed of creds (childenv.Clean) — git needs none.
 func createWorktree(runID string) (string, func(), error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -40,17 +51,126 @@ func createWorktree(runID string) (string, func(), error) {
 	}
 	wt := filepath.Join(base, uuid.NewString())
 	if out, gerr := runGit(root, "worktree", "add", "--detach", wt, "HEAD"); gerr != nil {
-		// A partial `worktree add` can leave a registered worktree and/or a dir behind;
-		// clean both up best-effort so a failure doesn't leak.
-		_, _ = runGit(root, "worktree", "remove", "--force", wt)
-		_ = os.RemoveAll(wt)
+		removeWorktree(root, wt) // a partial add may have left a registration and/or a dir
 		return "", nil, fmt.Errorf("git worktree add: %v: %s", gerr, strings.TrimSpace(out))
 	}
-	cleanup := func() {
-		_, _ = runGit(root, "worktree", "remove", "--force", wt)
-		_ = os.RemoveAll(wt) // belt-and-braces if `worktree remove` left anything
-	}
+	cleanup := func() { removeWorktree(root, wt) }
 	return wt, cleanup, nil
+}
+
+// removeWorktree unregisters wt from root's .git and deletes its workdir, best-effort. The
+// RemoveAll is belt-and-braces: `worktree remove --force` normally clears the dir, but a
+// partial add or a stray file can outlive it; a git error just means nothing was registered.
+func removeWorktree(root, wt string) {
+	_, _ = runGit(root, "worktree", "remove", "--force", wt)
+	_ = os.RemoveAll(wt)
+}
+
+// sweepRunWorktrees reclaims stale isolation-worktree registrations left in root's .git by
+// crashed/SIGKILLed engines (a bare SIGKILL skips the deferred cleanup, so both the git
+// registration and the temp workdir leak). Best-effort, no error return. It lists root's
+// worktrees, keeps only those whose workdir is under the global cc-fleet-worktrees temp prefix,
+// and removes a candidate iff a DEATH PROOF holds — one uniform rule, nothing reclaimed on
+// identity alone:
+//
+//	(a) the segment is KNOWN to this config store's ListRuns AND its owning run is provably dead
+//	    (RunEngineProvablyNotLive); or
+//	(b) the candidate workdir no longer exists on disk — git treats such a registration as prunable,
+//	    a live isolation leaf cannot be running in a deleted cwd, and this also reclaims a run whose
+//	    manifest was already purged out from under a leaked registration.
+//
+// An UNKNOWN segment whose workdir still EXISTS is left alone: absence from THIS store's list is
+// not proof of death — a different config store (another HOME/XDG_CONFIG_HOME) may own a live run
+// this process cannot see. This run's OWN segment gets no privileged reclamation here (an earlier
+// design reclaimed it unconditionally, which could delete a blind-stopped-but-live foreground
+// twin's worktrees — the twin shares this run's id); a resumed engine's own stale worktrees are
+// reclaimed in the launcher under a death proof (sweepOwnSegment). A live foreground engine, a
+// still-running detached engine, and an alive-but-unverifiable pid are all left untouched, as are
+// the user's own worktrees (they never live under the temp prefix). Segments are sanitizeRunID(id);
+// because that collapses '.'/':'/separators to '-' (non-injective: ids "a.b"/"a:b"/"a-b" all yield
+// "a-b"), only PATH-SAFE ids populate deadBySegment, keeping it injective so a dead twin can't
+// last-writer-wins overwrite a live run's liveness.
+func sweepRunWorktrees(root string) {
+	out, err := runGit(root, "worktree", "list", "--porcelain")
+	if err != nil {
+		return
+	}
+	globalPrefix := filepath.Join(os.TempDir(), "cc-fleet-worktrees") + string(os.PathSeparator)
+	deadBySegment := map[string]bool{}
+	if runs, lerr := subagent.ListRuns(); lerr == nil {
+		for _, r := range runs {
+			if sanitizeRunID(r.RunID) == r.RunID { // path-safe → equals its own segment
+				deadBySegment[r.RunID] = subagent.RunEngineProvablyNotLive(r)
+			}
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree ")
+		if !ok {
+			continue
+		}
+		if !pathUnder(globalPrefix, wt) {
+			continue
+		}
+		seg := runSegment(globalPrefix, wt)
+		dead, known := deadBySegment[seg]
+		_, statErr := os.Stat(wt)
+		remove := (known && dead) || os.IsNotExist(statErr)
+		if !remove {
+			continue // unknown-but-present, or a known-live run — another store may own it
+		}
+		removeWorktree(root, wt)
+	}
+}
+
+// sweepOwnSegment reclaims ONLY runID's own isolation-worktree segment in root's .git — every
+// registration under cc-fleet-worktrees/<sanitizeRunID(id)>/ plus the segment dir. It is the resume
+// launcher's own-stale-worktree cleanup, run there (not in the Execute-time sweep) and only after
+// the prior record is confirmed provably dead: the launcher holds the death evidence that the
+// manifest rewrite then erases. A non-path-safe id is a no-op — its segment collides with other ids
+// under sanitizeRunID, so reclaiming it could delete a twin's live worktrees (the guard PurgeRun and
+// deadBySegment apply). Best-effort, no error return.
+func sweepOwnSegment(root, runID string) {
+	if sanitizeRunID(runID) != runID {
+		return // non-path-safe: the segment is shared with colliding ids — never reclaim it
+	}
+	segDir := filepath.Join(os.TempDir(), "cc-fleet-worktrees", runID)
+	if out, err := runGit(root, "worktree", "list", "--porcelain"); err == nil {
+		segPrefix := segDir + string(os.PathSeparator)
+		for _, line := range strings.Split(out, "\n") {
+			if wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree "); ok && pathUnder(segPrefix, wt) {
+				removeWorktree(root, wt)
+			}
+		}
+	}
+	_ = os.RemoveAll(segDir)
+}
+
+// runSegment returns the run-id path segment (the first component after the global
+// cc-fleet-worktrees prefix) of a worktree path known to be under that prefix.
+func runSegment(globalPrefix, wt string) string {
+	rest := strings.TrimPrefix(normPath(wt), normPath(globalPrefix))
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// pathUnder reports whether wt is under prefix. Both sides are normalized (forward slashes,
+// and case-folded on Windows, where git porcelain emits forward-slash paths while os.TempDir
+// yields backslashes) so the comparison holds cross-platform.
+func pathUnder(prefix, wt string) bool {
+	return strings.HasPrefix(normPath(wt), normPath(prefix))
+}
+
+// normPath forward-slashes a path and, on Windows only, lower-cases it, so a case- and
+// separator-insensitive prefix comparison is correct on each platform.
+func normPath(p string) string {
+	p = filepath.ToSlash(p)
+	if runtime.GOOS == "windows" {
+		p = strings.ToLower(p)
+	}
+	return p
 }
 
 // gitTopLevel returns the repo root containing dir, or a clear error when dir is not in a

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/ethanhq/cc-fleet/internal/childenv"
+	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
@@ -45,7 +46,7 @@ func createWorktree(runID string) (string, func(), error) {
 	if err != nil {
 		return "", nil, err
 	}
-	base := filepath.Join(os.TempDir(), "cc-fleet-worktrees", sanitizeRunID(runID))
+	base := filepath.Join(os.TempDir(), "cc-fleet-worktrees", ids.WorktreeSegment(runID))
 	if err := os.MkdirAll(base, 0o700); err != nil {
 		return "", nil, fmt.Errorf("worktree base: %w", err)
 	}
@@ -73,11 +74,15 @@ func removeWorktree(root, wt string) {
 // and removes a candidate iff a DEATH PROOF holds — one uniform rule, nothing reclaimed on
 // identity alone:
 //
-//	(a) the segment is KNOWN to this config store's ListRuns AND its owning run is provably dead
-//	    (RunEngineProvablyNotLive); or
+//	(a) the segment's verdict (subagent.SegmentReclaimVerdicts) clears — a path-safe owner is provably
+//	    engine-dead AND leaf-free (Reclaimer) AND no owner, path-safe or a colliding twin, is alive/
+//	    unverifiable or leaf-bearing (!Vetoed). Engine death alone does NOT prove the workdir is unused:
+//	    a SIGKILLed engine's claude leaf children (own process groups, cwd = the worktree) outlive it,
+//	    and a colliding live twin shares the segment; or
 //	(b) the candidate workdir no longer exists on disk — git treats such a registration as prunable,
-//	    a live isolation leaf cannot be running in a deleted cwd, and this also reclaims a run whose
-//	    manifest was already purged out from under a leaked registration.
+//	    a live isolation leaf cannot be running in a deleted cwd (so clause (b) needs no leaf check),
+//	    and this also reclaims a run whose manifest was already purged out from under a leaked
+//	    registration.
 //
 // An UNKNOWN segment whose workdir still EXISTS is left alone: absence from THIS store's list is
 // not proof of death — a different config store (another HOME/XDG_CONFIG_HOME) may own a live run
@@ -86,24 +91,25 @@ func removeWorktree(root, wt string) {
 // twin's worktrees — the twin shares this run's id); a resumed engine's own stale worktrees are
 // reclaimed in the launcher under a death proof (sweepOwnSegment). A live foreground engine, a
 // still-running detached engine, and an alive-but-unverifiable pid are all left untouched, as are
-// the user's own worktrees (they never live under the temp prefix). Segments are sanitizeRunID(id);
+// the user's own worktrees (they never live under the temp prefix). Segments are ids.WorktreeSegment(id);
 // because that collapses '.'/':'/separators to '-' (non-injective: ids "a.b"/"a:b"/"a-b" all yield
-// "a-b"), only PATH-SAFE ids populate deadBySegment, keeping it injective so a dead twin can't
-// last-writer-wins overwrite a live run's liveness.
+// "a-b"), the reclaim verdict is SEGMENT-level (subagent.SegmentReclaimVerdicts): a non-path-safe twin
+// never RECLAIMS (identity reclaim is path-safe-only) yet, while alive, always VETOES its segment — so
+// a live "a.b" can't lose its workdirs to a dead "a-b", and a dead twin can't provoke reclaiming a live
+// one.
 func sweepRunWorktrees(root string) {
 	out, err := runGit(root, "worktree", "list", "--porcelain")
 	if err != nil {
 		return
 	}
 	globalPrefix := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") + string(os.PathSeparator)
-	deadBySegment := map[string]bool{}
-	if runs, lerr := subagent.ListRuns(); lerr == nil {
-		for _, r := range runs {
-			if sanitizeRunID(r.RunID) == r.RunID { // path-safe → equals its own segment
-				deadBySegment[r.RunID] = subagent.RunEngineProvablyNotLive(r)
-			}
-		}
-	}
+	// Ownership is keyed by SEGMENT (ids.WorktreeSegment), not exact id, and engine death does NOT prove
+	// leaf death (a SIGKILLed engine's claude leaf children — own process groups, cwd = the worktree —
+	// outlive it). One ListRuns pass + one leaf scan aggregates, per segment, a Reclaimer (a path-safe
+	// dead+leaf-free owner) and a Vetoed flag (ANY owner — path-safe or a colliding twin — alive/
+	// unverifiable or leaf-bearing). A scan failure (!verdictsOK) makes every present-workdir reclamation
+	// unsafe. The workdir-MISSING clause needs no verdict — a vanished cwd cannot host a running process.
+	verdicts, verdictsOK := subagent.SegmentReclaimVerdicts()
 	for _, line := range strings.Split(out, "\n") {
 		wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree ")
 		if !ok {
@@ -113,37 +119,47 @@ func sweepRunWorktrees(root string) {
 			continue
 		}
 		seg := runSegment(globalPrefix, wt)
-		dead, known := deadBySegment[seg]
+		v := verdicts[seg]
 		_, statErr := os.Stat(wt)
-		remove := (known && dead) || os.IsNotExist(statErr)
+		presentReclaimable := verdictsOK && v.Reclaimer && !v.Vetoed
+		remove := presentReclaimable || os.IsNotExist(statErr)
 		if !remove {
-			continue // unknown-but-present, or a known-live run — another store may own it
+			continue // unknown/live/leaf-bearing present, or a segment a live owner vetoes
 		}
 		removeWorktree(root, wt)
 	}
 }
 
 // sweepOwnSegment reclaims ONLY runID's own isolation-worktree segment in root's .git — every
-// registration under cc-fleet-worktrees/<sanitizeRunID(id)>/ plus the segment dir. It is the resume
-// launcher's own-stale-worktree cleanup, run there (not in the Execute-time sweep) and only after
-// the prior record is confirmed provably dead: the launcher holds the death evidence that the
-// manifest rewrite then erases. A non-path-safe id is a no-op — its segment collides with other ids
-// under sanitizeRunID, so reclaiming it could delete a twin's live worktrees (the guard PurgeRun and
-// deadBySegment apply). Best-effort, no error return.
+// registration under cc-fleet-worktrees/<ids.WorktreeSegment(id)>/ plus the segment dir. It is the
+// resume launcher's own-stale-worktree cleanup, run there (not in the Execute-time sweep) and only
+// after the prior record is confirmed provably dead: the launcher holds the death evidence that the
+// manifest rewrite then erases. A non-path-safe id is a no-op — its segment collides with other ids,
+// so reclaiming it could delete a twin's live worktrees. Since the launcher already established the
+// prior run's death, it adds only the SEGMENT-level veto check: it reclaims unless an owner of the
+// segment — the run's own orphan leaf, or a colliding twin — is alive/leaf-bearing. Best-effort.
 func sweepOwnSegment(root, runID string) {
-	if sanitizeRunID(runID) != runID {
+	if ids.WorktreeSegment(runID) != runID {
 		return // non-path-safe: the segment is shared with colliding ids — never reclaim it
+	}
+	verdicts, ok := subagent.SegmentReclaimVerdicts()
+	// Fail closed: a MISSING entry (no known owner) or a non-reclaimer/vetoed one skips — only a
+	// KNOWN path-safe dead+leaf-free owner with no live/colliding twin reclaims.
+	if v, present := verdicts[runID]; !ok || !present || !v.Reclaimer || v.Vetoed {
+		return
 	}
 	segDir := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees", runID)
 	if out, err := runGit(root, "worktree", "list", "--porcelain"); err == nil {
 		segPrefix := segDir + string(os.PathSeparator)
 		for _, line := range strings.Split(out, "\n") {
 			if wt, ok := strings.CutPrefix(strings.TrimSpace(line), "worktree "); ok && pathUnder(segPrefix, wt) {
-				removeWorktree(root, wt)
+				removeWorktree(root, wt) // only the porcelain-listed (snapshot) registrations
 			}
 		}
 	}
-	_ = os.RemoveAll(segDir)
+	// Remove the segment dir only if now EMPTY — a post-snapshot colliding fresh-uuid workdir (unlisted,
+	// so not removed above) keeps it, so os.Remove (not RemoveAll) leaks-not-deletes it.
+	_ = os.Remove(segDir)
 }
 
 // runSegment returns the run-id path segment (the first component after the global
@@ -195,14 +211,4 @@ func runGit(dir string, args ...string) (string, error) {
 	cmd.Stderr = &buf
 	err := cmd.Run()
 	return buf.String(), err
-}
-
-// sanitizeRunID keeps a run id safe as a single path segment for the temp worktree root.
-func sanitizeRunID(id string) string {
-	return strings.Map(func(r rune) rune {
-		if r == '/' || r == '\\' || r == '.' || r == ':' {
-			return '-'
-		}
-		return r
-	}, id)
 }

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -101,9 +101,9 @@ func removeWorktree(root, wt string) {
 // when its workdir has vanished, which needs no verdict — so present foreign workdirs stay untouched
 // while stale registrations don't strand. An UNKNOWN segment under THIS store's prefix whose workdir
 // still EXISTS is left alone: it is this store's own run whose manifest is missing/unreadable (a live
-// one is spared by the verdict's fail-closed handling), not proof of death. This run's OWN segment gets no privileged reclamation here (an earlier design reclaimed it
-// unconditionally, which could delete a blind-stopped-but-live foreground twin's worktrees — the twin
-// shares this run's id); a resumed engine's own stale worktrees are reclaimed in the launcher under a
+// one is spared by the verdict's fail-closed handling), not proof of death. This run's OWN segment gets no privileged
+// reclamation here — unconditional reclaim could delete a blind-stopped-but-live foreground twin's
+// worktrees (the twin shares this run's id); a resumed engine's own stale worktrees are reclaimed in the launcher under a
 // death proof (sweepOwnSegment). A live foreground engine, a still-running detached engine, and an
 // alive-but-unverifiable pid are all left untouched, as are the user's own worktrees (they never live
 // under the temp prefix). Segments are ids.WorktreeSegment(id); because that collapses '.'/':'/separators
@@ -123,9 +123,8 @@ func sweepRunWorktrees(root string) {
 	globalPrefix := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName, storeID) + string(os.PathSeparator)
 	// flatRoot is the SHARED cc-fleet-worktrees root every store (and any pre-namespacing legacy leftover)
 	// sits beneath. A worktree under flatRoot but NOT under globalPrefix belongs to a FOREIGN store or is
-	// a legacy flat leftover: this store's verdict says nothing about it, so it is NEVER verdict-reclaimed
-	// (that store-local verdict on a foreign present workdir was the r34 deletion hole). It is pruned ONLY
-	// when its workdir has vanished — clause (b) needs no verdict (a deleted cwd cannot host a live
+	// a legacy flat leftover: this store's verdict says nothing about it, so it is NEVER verdict-reclaimed.
+	// It is pruned ONLY when its workdir has vanished — clause (b) needs no verdict (a deleted cwd cannot host a live
 	// process, whichever store owned it) — so a stale registration doesn't strand until a manual
 	// `git worktree prune`.
 	flatRoot := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName) + string(os.PathSeparator)
@@ -153,7 +152,7 @@ func sweepRunWorktrees(root string) {
 		}
 		if pathUnder(flatRoot, wt) {
 			// A foreign store's or a legacy flat worktree — verdict-exempt: prune ONLY a vanished workdir
-			// (clause b), never a present one (it may be a foreign store's live cwd — the r34 hole).
+			// (clause b), never a present one (it may be a foreign store's live cwd).
 			if _, statErr := os.Stat(wt); os.IsNotExist(statErr) {
 				removeWorktree(root, wt)
 			}

--- a/internal/workflow/worktree_sweep_test.go
+++ b/internal/workflow/worktree_sweep_test.go
@@ -154,9 +154,9 @@ func TestSweepRunWorktreesNonGit(t *testing.T) {
 	sweepRunWorktrees(t.TempDir())
 }
 
-// TestSweepRunWorktreesMapGuard: sanitizeRunID collapses '.'/':'/separators to '-', so ids
-// "a.b"/"a:b"/"a-b" share segment "a-b". Only PATH-SAFE ids populate deadBySegment, so a DEAD
-// non-path-safe twin can't last-writer-wins the segment and condemn a live run that maps to it.
+// TestSweepRunWorktreesMapGuard: ids.WorktreeSegment collapses '.'/':'/separators to '-', so ids
+// "a.b"/"a:b"/"a-b" share segment "a-b". The segment verdict reclaims only under a PATH-SAFE
+// dead+leaf-free owner, so a DEAD non-path-safe twin can't provoke reclaiming a live run that maps to it.
 func TestSweepRunWorktreesMapGuard(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -196,6 +196,11 @@ func TestSweepOwnSegment(t *testing.T) {
 	t.Run("path-safe id reclaims its own segment", func(t *testing.T) {
 		const id = "own-seg"
 		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+		// The launcher calls sweepOwnSegment only after confirming the prior run provably dead; the
+		// verdict now requires that KNOWN dead+leaf-free owner (fail-closed on a missing entry).
+		if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+			t.Fatal(err)
+		}
 		wt := filepath.Join(tempBase, id, "wt")
 		addWorktree(t, repo, wt)
 
@@ -506,9 +511,11 @@ await agent("x", {provider: "v"});
 	if leafKey == "" {
 		t.Fatal("precondition: expected a member leaf with a journal key")
 	}
-	// Force the completed run into the ambiguous {stopped,0} state, leaving its journal + member jobs.
+	// Force the completed run into the ambiguous OLD-record {stopped, 0, no fg identity} state — the
+	// pre-field transition shape (clear the fg fields the real run just stamped) → FgUnknown → refused.
 	run, _ := subagent.ReadRun(id)
 	run.Status, run.EnginePID = "stopped", 0
+	run.FgEnginePID, run.FgEngineProcStart = 0, ""
 	if err := subagent.SaveRun(run); err != nil {
 		t.Fatal(err)
 	}
@@ -681,8 +688,9 @@ func TestResumeForegroundSerializesAgainstHeldLock(t *testing.T) {
 	t.Cleanup(func() { sweepOwnSegmentFn = oldOwn; sweepRunWorktreesFn = oldAll })
 
 	t.Chdir(repo)
-	// A detached-lane holder of the per-run lock that wins the preflight: it flips the run "running"
-	// before releasing, mirroring what a detached resume does under the CLI/Restart lock.
+	// A holder of the per-run lock that wins the preflight: it flips the run to a running state with no
+	// verifiable engine identity ({running, 0, no fg} → FgUnknown) before releasing, mirroring a winner
+	// whose fg identity is not yet re-stamped. The loser must block on the lock, then be refused.
 	holding, release := make(chan struct{}), make(chan struct{})
 	go func() {
 		_ = subagent.WithRunLock(id, func() error {
@@ -690,6 +698,7 @@ func TestResumeForegroundSerializesAgainstHeldLock(t *testing.T) {
 			<-release
 			r, _ := subagent.ReadRun(id)
 			r.Status, r.EnginePID = "running", 0
+			r.FgEnginePID, r.FgEngineProcStart = 0, ""
 			return subagent.SaveRun(r)
 		})
 	}()
@@ -705,7 +714,7 @@ func TestResumeForegroundSerializesAgainstHeldLock(t *testing.T) {
 	close(release)
 
 	err := <-done
-	if err == nil || !strings.Contains(err.Error(), "already has a live engine") {
+	if err == nil || !strings.Contains(err.Error(), "foreground") {
 		t.Errorf("foreground resume must be refused after the holder flipped the run to running, got %v", err)
 	}
 	if sweeps != 0 {

--- a/internal/workflow/worktree_sweep_test.go
+++ b/internal/workflow/worktree_sweep_test.go
@@ -52,14 +52,18 @@ func addWorktree(t *testing.T, repo, path string) {
 	}
 }
 
-// worktreeListed reports whether path appears in `git worktree list`.
+// worktreeListed reports whether path appears in `git worktree list`. BOTH the porcelain output and
+// the sought path are canonicalized (canonPath: macOS /private, Windows 8.3→long) and normalized
+// (normPath: forward slashes + case-fold on Windows). Folding only the sought side — as a naive
+// Contains(out, normPath(path)) does — misses on Windows, where porcelain reports mixed-case paths
+// (the production pathUnder already folds both sides, so this only fixes the test lookup).
 func worktreeListed(t *testing.T, repo, path string) bool {
 	t.Helper()
 	out, err := runGit(repo, "worktree", "list", "--porcelain")
 	if err != nil {
 		t.Fatalf("worktree list: %v %s", err, out)
 	}
-	return strings.Contains(out, normPath(path))
+	return strings.Contains(normPath(out), normPath(canonPath(path)))
 }
 
 // TestSweepRunWorktreesScoped: the Execute-time sweep applies one uniform rule — remove a

--- a/internal/workflow/worktree_sweep_test.go
+++ b/internal/workflow/worktree_sweep_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/subagent"
 )
 
+// storeWorktreeBase is this store's canonicalized isolation-worktree temp root as the sweeps see it
+// (canonPath(os.TempDir())/cc-fleet-worktrees/<WorktreeStoreID>), so a test seeds workdirs where
+// production looks after the per-store namespacing. Both read the same process env in-test, so the
+// store id always matches production.
+func storeWorktreeBase(t *testing.T) string {
+	t.Helper()
+	id, err := subagent.WorktreeStoreID()
+	if err != nil {
+		t.Fatalf("WorktreeStoreID: %v", err)
+	}
+	return filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName, id)
+}
+
 // initSweepRepo makes a committed git repo and chdirs into it, returning its root.
 func initSweepRepo(t *testing.T) string {
 	t.Helper()
@@ -68,12 +81,13 @@ func worktreeListed(t *testing.T, repo, path string) bool {
 
 // TestSweepRunWorktreesScoped: the Execute-time sweep applies one uniform rule — remove a
 // registration only under a DEATH PROOF: a KNOWN provably-dead run (clause a) or a vanished workdir
-// (clause b). A live/known-not-dead run, an UNKNOWN still-present segment (another config store may
-// own it), and the user's own worktree are all left untouched. It never privileges its own segment.
+// (clause b). A live/known-not-dead run, an UNKNOWN still-present segment (this store's own
+// manifest-less orphan), and the user's own worktree are all left untouched. It never privileges its
+// own segment.
 func TestSweepRunWorktreesScoped(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
+	tempBase := storeWorktreeBase(t)
 
 	const (
 		runDead        = "run-dead"
@@ -116,8 +130,8 @@ func TestSweepRunWorktreesScoped(t *testing.T) {
 	// The user's OWN worktree, elsewhere (never under the temp prefix) — must survive.
 	userWt := filepath.Join(t.TempDir(), "user-wt")
 	addWorktree(t, repo, userWt)
-	// An UNKNOWN segment (no manifest) whose workdir EXISTS — another config store may own a live
-	// run we can't see, so it must be left alone.
+	// An UNKNOWN segment (no manifest) whose workdir EXISTS — this store's own manifest-less orphan
+	// (no proof of death), so it must be left alone.
 	unknownHereWt := filepath.Join(tempBase, runUnknownHere, "wt")
 	addWorktree(t, repo, unknownHereWt)
 	// An UNKNOWN segment whose workdir is GONE — prunable (clause b), swept with no record to consult.
@@ -142,7 +156,7 @@ func TestSweepRunWorktreesScoped(t *testing.T) {
 		t.Error("the user's own worktree must never be touched")
 	}
 	if !worktreeListed(t, repo, unknownHereWt) {
-		t.Error("an unknown segment whose workdir still exists must be left alone (another store may own it)")
+		t.Error("an unknown segment whose workdir still exists must be left alone (this store's own manifest-less orphan)")
 	}
 	if worktreeListed(t, repo, unknownGoneWt) {
 		t.Error("an unknown segment whose workdir is gone must be swept (clause b)")
@@ -160,7 +174,7 @@ func TestSweepRunWorktreesNonGit(t *testing.T) {
 func TestSweepRunWorktreesMapGuard(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
+	tempBase := storeWorktreeBase(t)
 	const liveID = "a-b"
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, liveID)) })
 
@@ -191,7 +205,7 @@ func TestSweepRunWorktreesMapGuard(t *testing.T) {
 func TestSweepOwnSegment(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
+	tempBase := storeWorktreeBase(t)
 
 	t.Run("path-safe id reclaims its own segment", func(t *testing.T) {
 		const id = "own-seg"
@@ -231,6 +245,132 @@ func TestSweepOwnSegment(t *testing.T) {
 	})
 }
 
+// TestSweepOwnSegmentSnapshotBeforeVerdict (codex r33): sweepOwnSegment must snapshot the segment's
+// registrations BEFORE it computes the reclaim verdict — the ordering sweepRunWorktrees and PurgeRun
+// already use. A colliding twin ("own.seg", same segment "own-seg") runs under a DIFFERENT run id, so
+// its run lock never serializes against this sweep; if it registers a fresh worktree in the
+// snapshot→verdict window, the stale "reclaimable" verdict must NOT delete it. Modeled by a verdict
+// seam that registers the twin's worktree as the verdict is taken: with the pre-verdict snapshot the
+// twin is out of the removal set and survives, while the own dead run is still reclaimed. Under the
+// pre-fix (verdict-then-snapshot) ordering the twin would be listed and wrongly removed.
+func TestSweepOwnSegmentSnapshotBeforeVerdict(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tempBase := storeWorktreeBase(t)
+	const id = "own-seg"
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	ownWt := filepath.Join(tempBase, id, "own-wt")
+	addWorktree(t, repo, ownWt)
+
+	// The colliding twin's worktree, registered ONLY when the verdict is computed — i.e. after the
+	// snapshot in the fixed ordering. It has no manifest, so the real verdict still reports segment
+	// "own-seg" reclaimable; the twin models the createWorktree→saveManifest window of a live owner.
+	twinWt := filepath.Join(tempBase, id, "twin-wt")
+	orig := reclaimVerdicts
+	var once sync.Once
+	reclaimVerdicts = func() (map[string]subagent.SegmentReclaim, bool) {
+		once.Do(func() { addWorktree(t, repo, twinWt) })
+		return orig()
+	}
+	t.Cleanup(func() { reclaimVerdicts = orig })
+
+	sweepOwnSegment(repo, id)
+
+	if worktreeListed(t, repo, ownWt) {
+		t.Error("the own dead run's registration must still be reclaimed")
+	}
+	if !worktreeListed(t, repo, twinWt) {
+		t.Error("a colliding twin's worktree that appeared in the snapshot→verdict window must SURVIVE (snapshot-before-verdict)")
+	}
+	if _, err := os.Stat(twinWt); err != nil {
+		t.Errorf("the twin's workdir must survive on disk (err=%v)", err)
+	}
+}
+
+// TestSweepRunWorktreesForeignStoreSpared (codex r34): the isolation-worktree temp root is namespaced by
+// config store (subagent.WorktreeStoreID) and the sweep is scoped to THIS store's prefix. A worktree NOT
+// under this store's prefix — a foreign store (another HOME/XDG sharing os.TempDir()+repo), or a
+// pre-namespacing flat-path leftover — is structurally invisible to the sweep and must survive, even
+// when this store's verdict marks the colliding segment reclaimable (it can't see the foreign store's
+// live run, so it records no veto). Under the pre-fix shared flat namespace this store would have
+// deleted the foreign live worktree. Modeled with the foreign worktree at the shared
+// cc-fleet-worktrees/<segment> root a foreign/older store uses, registered in the same repo.
+func TestSweepRunWorktreesForeignStoreSpared(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // this store
+
+	base := storeWorktreeBase(t) // cc-fleet-worktrees/<this store id>
+	flatRoot := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(filepath.Join(base, "a-b"))
+		_ = os.RemoveAll(filepath.Join(flatRoot, "a-b"))
+	})
+
+	// This store owns a dead path-safe "a-b" → its verdict marks segment a-b reclaimable (a foreign
+	// store's live "a.b" lives in the foreign runs dir, invisible here, so nothing vetoes).
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a-b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	ownDeadWt := filepath.Join(base, "a-b", "wt")
+	addWorktree(t, repo, ownDeadWt)
+	// A worktree OUTSIDE this store's prefix (a foreign store's live workdir), registered in the SAME repo.
+	foreignWt := filepath.Join(flatRoot, "a-b", "wt")
+	addWorktree(t, repo, foreignWt)
+
+	sweepRunWorktrees(repo)
+
+	if worktreeListed(t, repo, ownDeadWt) {
+		t.Error("this store's own dead worktree must be reclaimed")
+	}
+	if !worktreeListed(t, repo, foreignWt) {
+		t.Error("a worktree outside this store's prefix must be invisible to the sweep and SURVIVE")
+	}
+	if _, err := os.Stat(foreignWt); err != nil {
+		t.Errorf("the foreign worktree's workdir must survive on disk (err=%v)", err)
+	}
+}
+
+// TestSweepRunWorktreesLegacyFlatVanishedPruned (codex r35): a worktree under the shared cc-fleet-worktrees
+// root but OUTSIDE this store's prefix (a foreign store's, or a pre-namespacing flat leftover) is pruned
+// by clause (b) when its workdir has VANISHED — a deleted cwd can host no live process, whichever store
+// owned it — while a PRESENT such workdir (possibly a foreign store's live cwd) is spared. This drains
+// legacy leftovers without reopening the r34 cross-store deletion.
+func TestSweepRunWorktreesLegacyFlatVanishedPruned(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	flatRoot := filepath.Join(canonPath(os.TempDir()), subagent.WorktreeTempName)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(filepath.Join(flatRoot, "a-b"))
+		_ = os.RemoveAll(filepath.Join(flatRoot, "c-d"))
+	})
+
+	// A legacy/foreign flat registration whose workdir is GONE → clause (b) prunes it.
+	goneWt := filepath.Join(flatRoot, "a-b", "wt")
+	addWorktree(t, repo, goneWt)
+	if err := os.RemoveAll(goneWt); err != nil {
+		t.Fatal(err)
+	}
+	// A PRESENT flat workdir (a foreign store's possibly-live cwd) → spared.
+	presentWt := filepath.Join(flatRoot, "c-d", "wt")
+	addWorktree(t, repo, presentWt)
+
+	sweepRunWorktrees(repo)
+
+	if worktreeListed(t, repo, goneWt) {
+		t.Error("a flat registration whose workdir vanished must be pruned (clause b)")
+	}
+	if !worktreeListed(t, repo, presentWt) {
+		t.Error("a PRESENT flat workdir (possibly a foreign store's live cwd) must be spared")
+	}
+	if _, err := os.Stat(presentWt); err != nil {
+		t.Errorf("the present flat workdir must survive on disk (err=%v)", err)
+	}
+}
+
 // TestPurgeThenSweepReclaimsRegistration: purging a provably-dead run drops its worktree WORKDIR
 // before the manifest (PurgeRun does no git ops by design), so the leftover git registration is
 // reclaimed by a later same-repo sweep via the workdir-missing clause.
@@ -238,7 +378,7 @@ func TestPurgeThenSweepReclaimsRegistration(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
+	tempBase := storeWorktreeBase(t)
 
 	const id = "purge-reclaim" // path-safe
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
@@ -553,7 +693,7 @@ func TestBlindStoppedForegroundChainWorktreeSurvives(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
+	tempBase := storeWorktreeBase(t)
 
 	const id = "chain-fg"
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })

--- a/internal/workflow/worktree_sweep_test.go
+++ b/internal/workflow/worktree_sweep_test.go
@@ -1,0 +1,710 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethanhq/cc-fleet/internal/subagent"
+)
+
+// initSweepRepo makes a committed git repo and chdirs into it, returning its root.
+func initSweepRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"}, {"config", "user.email", "t@t"}, {"config", "user.name", "t"},
+	} {
+		if out, err := runGit(repo, args...); err != nil {
+			t.Fatalf("git %v: %v %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "f.txt"), []byte("base"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runGit(repo, "add", "."); err != nil {
+		t.Fatalf("git add: %v %s", err, out)
+	}
+	if out, err := runGit(repo, "commit", "-qm", "init"); err != nil {
+		t.Fatalf("git commit: %v %s", err, out)
+	}
+	return repo
+}
+
+// addWorktree registers a detached worktree at path from repo.
+func addWorktree(t *testing.T, repo, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runGit(repo, "worktree", "add", "--detach", path, "HEAD"); err != nil {
+		t.Fatalf("worktree add %s: %v %s", path, err, out)
+	}
+}
+
+// worktreeListed reports whether path appears in `git worktree list`.
+func worktreeListed(t *testing.T, repo, path string) bool {
+	t.Helper()
+	out, err := runGit(repo, "worktree", "list", "--porcelain")
+	if err != nil {
+		t.Fatalf("worktree list: %v %s", err, out)
+	}
+	return strings.Contains(out, normPath(path))
+}
+
+// TestSweepRunWorktreesScoped: the Execute-time sweep applies one uniform rule — remove a
+// registration only under a DEATH PROOF: a KNOWN provably-dead run (clause a) or a vanished workdir
+// (clause b). A live/known-not-dead run, an UNKNOWN still-present segment (another config store may
+// own it), and the user's own worktree are all left untouched. It never privileges its own segment.
+func TestSweepRunWorktreesScoped(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+
+	const (
+		runDead        = "run-dead"
+		runLive        = "run-live"
+		runFgStopped   = "run-fg-stopped"   // foreground blind-flipped to stopped (pid 0) → spared
+		runUnknownHere = "run-unknown"      // no manifest, workdir intact → spared
+		runUnknownGone = "run-unknown-gone" // no manifest, workdir gone → swept (clause b)
+	)
+	t.Cleanup(func() {
+		for _, id := range []string{runDead, runLive, runFgStopped, runUnknownHere, runUnknownGone} {
+			_ = os.RemoveAll(filepath.Join(tempBase, id))
+		}
+	})
+
+	// runDead models a DETACHED run StopRun reaped: "stopped" with its now-dead pid retained (the
+	// death evidence) → provably dead. runLive is a running foreground engine (EnginePID 0), and
+	// runFgStopped is a foreground run blind-flipped to "stopped" (EnginePID 0, nothing reaped) —
+	// neither is provably dead, so both must be spared.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: runDead, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: runLive, StartedAt: "2026-01-01T00:00:00Z", Status: "running", EnginePID: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: runFgStopped, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A provably-dead KNOWN run whose workdir is PRESENT — swept via clause a (a death proof, not
+	// an own-segment privilege).
+	deadWt := filepath.Join(tempBase, runDead, "wt")
+	addWorktree(t, repo, deadWt)
+	// A live KNOWN run's registration — must survive.
+	liveWt := filepath.Join(tempBase, runLive, "wt")
+	addWorktree(t, repo, liveWt)
+	// A FOREGROUND run externally flipped to "stopped" (EnginePID 0 — nothing reaped): NOT provably
+	// dead, so its still-present registration must survive (its engine may still be live).
+	fgStoppedWt := filepath.Join(tempBase, runFgStopped, "wt")
+	addWorktree(t, repo, fgStoppedWt)
+	// The user's OWN worktree, elsewhere (never under the temp prefix) — must survive.
+	userWt := filepath.Join(t.TempDir(), "user-wt")
+	addWorktree(t, repo, userWt)
+	// An UNKNOWN segment (no manifest) whose workdir EXISTS — another config store may own a live
+	// run we can't see, so it must be left alone.
+	unknownHereWt := filepath.Join(tempBase, runUnknownHere, "wt")
+	addWorktree(t, repo, unknownHereWt)
+	// An UNKNOWN segment whose workdir is GONE — prunable (clause b), swept with no record to consult.
+	unknownGoneWt := filepath.Join(tempBase, runUnknownGone, "wt")
+	addWorktree(t, repo, unknownGoneWt)
+	if err := os.RemoveAll(unknownGoneWt); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepRunWorktrees(repo)
+
+	if worktreeListed(t, repo, deadWt) {
+		t.Error("a provably-dead known run's registration must be swept (clause a)")
+	}
+	if !worktreeListed(t, repo, liveWt) {
+		t.Error("a LIVE known run's registration must be left untouched")
+	}
+	if !worktreeListed(t, repo, fgStoppedWt) {
+		t.Error("a foreground run blind-flipped to stopped (EnginePID 0) must be left alone — its engine may still be live")
+	}
+	if !worktreeListed(t, repo, userWt) {
+		t.Error("the user's own worktree must never be touched")
+	}
+	if !worktreeListed(t, repo, unknownHereWt) {
+		t.Error("an unknown segment whose workdir still exists must be left alone (another store may own it)")
+	}
+	if worktreeListed(t, repo, unknownGoneWt) {
+		t.Error("an unknown segment whose workdir is gone must be swept (clause b)")
+	}
+}
+
+// TestSweepRunWorktreesNonGit: a non-git root is a best-effort no-op (no panic).
+func TestSweepRunWorktreesNonGit(t *testing.T) {
+	sweepRunWorktrees(t.TempDir())
+}
+
+// TestSweepRunWorktreesMapGuard: sanitizeRunID collapses '.'/':'/separators to '-', so ids
+// "a.b"/"a:b"/"a-b" share segment "a-b". Only PATH-SAFE ids populate deadBySegment, so a DEAD
+// non-path-safe twin can't last-writer-wins the segment and condemn a live run that maps to it.
+func TestSweepRunWorktreesMapGuard(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+	const liveID = "a-b"
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, liveID)) })
+
+	// A DEAD twin "a.b" (older StartedAt → the LAST, overwriting insert into a segment-keyed map
+	// without the guard) and a LIVE "a-b" (newer). The path-safe map guard drops the dead twin, so
+	// "a-b"'s own liveness stands and its registration survives.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: "a.b", StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: liveID, StartedAt: "2026-01-02T00:00:00Z", Status: "running", EnginePID: 0}); err != nil {
+		t.Fatal(err)
+	}
+	liveWt := filepath.Join(tempBase, liveID, "wt")
+	addWorktree(t, repo, liveWt)
+
+	sweepRunWorktrees(repo)
+
+	if !worktreeListed(t, repo, liveWt) {
+		t.Error("a dead colliding twin must not condemn the live run's registration (map guard)")
+	}
+	if _, err := os.Stat(liveWt); err != nil {
+		t.Errorf("the live run's workdir must survive (err=%v)", err)
+	}
+}
+
+// TestSweepOwnSegment: the launcher's own-segment reclaimer removes a PATH-SAFE run's registrations
+// and temp dir, and is a no-op for a non-path-safe id (whose sanitized segment collides with others).
+func TestSweepOwnSegment(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+
+	t.Run("path-safe id reclaims its own segment", func(t *testing.T) {
+		const id = "own-seg"
+		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+		wt := filepath.Join(tempBase, id, "wt")
+		addWorktree(t, repo, wt)
+
+		sweepOwnSegment(repo, id)
+
+		if worktreeListed(t, repo, wt) {
+			t.Error("own-segment registration must be reclaimed")
+		}
+		if _, err := os.Stat(filepath.Join(tempBase, id)); !os.IsNotExist(err) {
+			t.Errorf("own-segment temp dir must be removed (err=%v)", err)
+		}
+	})
+
+	t.Run("non-path-safe id is a no-op (colliding segment spared)", func(t *testing.T) {
+		const collidingID = "a-b" // the segment "a.b" would sanitize into
+		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, collidingID)) })
+		wt := filepath.Join(tempBase, collidingID, "wt")
+		addWorktree(t, repo, wt)
+
+		sweepOwnSegment(repo, "a.b") // non-path-safe → must not touch the colliding "a-b" segment
+
+		if !worktreeListed(t, repo, wt) {
+			t.Error("a non-path-safe id must not reclaim a colliding segment")
+		}
+		if _, err := os.Stat(wt); err != nil {
+			t.Errorf("the colliding segment's workdir must survive (err=%v)", err)
+		}
+	})
+}
+
+// TestPurgeThenSweepReclaimsRegistration: purging a provably-dead run drops its worktree WORKDIR
+// before the manifest (PurgeRun does no git ops by design), so the leftover git registration is
+// reclaimed by a later same-repo sweep via the workdir-missing clause.
+func TestPurgeThenSweepReclaimsRegistration(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+
+	const id = "purge-reclaim" // path-safe
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	// A provably-dead detached run (stopped + retained dead pid) with a real registered worktree.
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	wt := filepath.Join(tempBase, id, "wt")
+	addWorktree(t, repo, wt)
+
+	if err := subagent.PurgeRun(id); err != nil {
+		t.Fatalf("PurgeRun: %v", err)
+	}
+	// Workdir + manifest gone; the git registration lingers (PurgeRun touches no git state).
+	if _, err := os.Stat(filepath.Join(tempBase, id)); !os.IsNotExist(err) {
+		t.Errorf("worktree workdir must be gone after purge (err=%v)", err)
+	}
+	if _, err := subagent.ReadRun(id); err == nil {
+		t.Error("run manifest must be gone after purge")
+	}
+	if !worktreeListed(t, repo, wt) {
+		t.Fatal("precondition: the git registration should still be listed (purge does no git ops)")
+	}
+
+	sweepRunWorktrees(repo)
+
+	if worktreeListed(t, repo, wt) {
+		t.Error("the leftover registration must be reclaimed by the workdir-missing clause after purge")
+	}
+}
+
+// writeTrivialScript writes a no-leaf workflow script and returns its path + a minted run.
+func writeTrivialScript(t *testing.T) (string, subagent.WorkflowRun) {
+	t.Helper()
+	old := runLeaf
+	runLeaf = func(context.Context, subagent.Request) subagent.Result {
+		return subagent.Result{OK: true, Result: "ok"}
+	}
+	t.Cleanup(func() { runLeaf = old })
+	script := filepath.Join(t.TempDir(), "wf.js")
+	if err := os.WriteFile(script, []byte(`const meta = {name: "n", description: "d", phases: [{title: "plan"}]};
+phase("plan");
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run, err := Prepare(script)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	return script, run
+}
+
+// TestSweepEngineWiring (seam): Execute fires the Execute-time sweep exactly once with root = the
+// repo top-level (it no longer passes a run id — the sweep has no own-segment clause); a non-git cwd
+// skips it and the run still succeeds.
+func TestSweepEngineWiring(t *testing.T) {
+	t.Run("git cwd fires sweep", func(t *testing.T) {
+		repo := initSweepRepo(t)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		var gotRoot string
+		var calls int
+		old := sweepRunWorktreesFn
+		sweepRunWorktreesFn = func(root string) { calls++; gotRoot = root }
+		t.Cleanup(func() { sweepRunWorktreesFn = old })
+
+		script, run := writeTrivialScript(t)
+		t.Chdir(repo)
+		if err := Execute(context.Background(), script, run.RunID, Options{}); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("sweep called %d times, want 1", calls)
+		}
+		if normPath(gotRoot) != normPath(repo) {
+			t.Errorf("sweep root = %q, want repo %q", gotRoot, repo)
+		}
+	})
+
+	t.Run("non-git cwd skips sweep", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		var calls int
+		old := sweepRunWorktreesFn
+		sweepRunWorktreesFn = func(string) { calls++ }
+		t.Cleanup(func() { sweepRunWorktreesFn = old })
+
+		script, run := writeTrivialScript(t)
+		t.Chdir(t.TempDir()) // not a git repo
+		if err := Execute(context.Background(), script, run.RunID, Options{}); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if calls != 0 {
+			t.Errorf("sweep must be skipped on a non-git cwd, got %d calls", calls)
+		}
+	})
+}
+
+// TestResumeLauncherOwnSegmentSweep: resuming a PROVABLY-DEAD prior reclaims the run's OWN
+// isolation-worktree segment in the launcher — the last point the death evidence exists, before the
+// manifest rewrite. Both a properly-stopped detached prior ({stopped, dead pid retained}) and a
+// crashed detached prior ({running, dead pid}) are reclaimed. (A {stopped, pid 0} prior is refused
+// outright — see TestResumeStoppedZeroPidRefused.)
+func TestResumeLauncherOwnSegmentSweep(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    string
+		enginePID int
+	}{
+		{"stopped detached (dead pid retained)", "stopped", 0x7ffffffe},
+		{"crashed detached (running + dead pid)", "running", 0x7ffffffe},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo := initSweepRepo(t)
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("HOME", t.TempDir())
+
+			// Seam both sweeps: assert the own-segment one, silence the Execute-time one.
+			var gotRoot, gotRun string
+			var ownCalls int
+			oldOwn := sweepOwnSegmentFn
+			oldAll := sweepRunWorktreesFn
+			sweepOwnSegmentFn = func(root, runID string) { ownCalls++; gotRoot, gotRun = root, runID }
+			sweepRunWorktreesFn = func(string) {}
+			t.Cleanup(func() { sweepOwnSegmentFn = oldOwn; sweepRunWorktreesFn = oldAll })
+
+			script, _ := writeTrivialScript(t) // stubs runLeaf; we resume a manifest we seed below
+			const id = "resume-own"
+			if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: c.status, EnginePID: c.enginePID}); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(repo)
+			if _, err := Launch(context.Background(), script, Options{Resume: id}, true); err != nil {
+				t.Fatalf("launch resume: %v", err)
+			}
+			if ownCalls != 1 {
+				t.Fatalf("own-segment sweep fired %d times, want 1 (prior provably dead)", ownCalls)
+			}
+			if gotRun != id {
+				t.Errorf("own sweep runID = %q, want %q", gotRun, id)
+			}
+			if normPath(gotRoot) != normPath(repo) {
+				t.Errorf("own sweep root = %q, want repo %q", gotRoot, repo)
+			}
+		})
+	}
+}
+
+// TestResumeStoppedZeroPidRefused: a {stopped, EnginePID 0} record is unresumable on every entry —
+// foreground resume, detached resume, and board Restart — because a live blind-stopped foreground
+// engine is indistinguishable from a dead Ctrl-C'd one. The refusal fires in the shared preflight
+// BEFORE any own-segment sweep, so nothing is reclaimed.
+func TestResumeStoppedZeroPidRefused(t *testing.T) {
+	const wantErr = "cannot be verified"
+	// seed a {stopped,0} run, chdir into a fresh repo, and seam the sweeps to counters.
+	seed := func(t *testing.T) (id string, sweeps *int32) {
+		repo := initSweepRepo(t)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		id = "resume-stopped0"
+		if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0}); err != nil {
+			t.Fatal(err)
+		}
+		var n int32
+		oldOwn := sweepOwnSegmentFn
+		oldAll := sweepRunWorktreesFn
+		sweepOwnSegmentFn = func(string, string) { atomic.AddInt32(&n, 1) }
+		sweepRunWorktreesFn = func(string) {}
+		t.Cleanup(func() { sweepOwnSegmentFn = oldOwn; sweepRunWorktreesFn = oldAll })
+		t.Chdir(repo)
+		return id, &n
+	}
+
+	t.Run("foreground resume", func(t *testing.T) {
+		id, sweeps := seed(t)
+		script, _ := writeTrivialScript(t)
+		if _, err := Launch(context.Background(), script, Options{Resume: id}, true); err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("foreground resume of {stopped,0} must be refused, got %v", err)
+		}
+		if *sweeps != 0 {
+			t.Errorf("a refused resume must not sweep, got %d", *sweeps)
+		}
+	})
+
+	t.Run("detached resume", func(t *testing.T) {
+		id, sweeps := seed(t)
+		script, _ := writeTrivialScript(t)
+		// Detached Launch reaches the same preflight; the refusal returns before launchDetached.
+		if _, err := Launch(context.Background(), script, Options{Resume: id}, false); err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("detached resume of {stopped,0} must be refused, got %v", err)
+		}
+		if *sweeps != 0 {
+			t.Errorf("a refused resume must not sweep, got %d", *sweeps)
+		}
+	})
+
+	t.Run("board restart", func(t *testing.T) {
+		id, sweeps := seed(t)
+		script, _ := writeTrivialScript(t)
+		// Restart reads the saved-script sidecar and flows through Launch's resume branch.
+		sp, err := subagent.RunScriptPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, rerr := os.ReadFile(script)
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		if werr := os.WriteFile(sp, data, 0o600); werr != nil {
+			t.Fatal(werr)
+		}
+		if err := Restart(context.Background(), id, ""); err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("board Restart of {stopped,0} must be refused, got %v", err)
+		}
+		if *sweeps != 0 {
+			t.Errorf("a refused restart must not sweep, got %d", *sweeps)
+		}
+	})
+}
+
+// TestRestartStoppedZeroPidRefusedNoJournalMutation: a {stopped, EnginePID 0} record is refused by
+// BOTH leaf restart and phase restart, and the refusal fires in ensureRestartable BEFORE any journal
+// rewrite — the journal file is byte-identical after (no mutate-then-fail half-state). A real one-leaf
+// "plan"-phase run seeds a removable journal key + a member job carrying it + the script sidecar, so
+// a restart WOULD rewrite the journal if it weren't refused first (else the assertion couldn't tell
+// "guarded" from "nothing to drop").
+func TestRestartStoppedZeroPidRefusedNoJournalMutation(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	const wantErr = "cannot be verified"
+
+	old := runLeaf
+	oldAll := sweepRunWorktreesFn
+	runLeaf = func(context.Context, subagent.Request) subagent.Result {
+		return subagent.Result{OK: true, Result: "ok"}
+	}
+	sweepRunWorktreesFn = func(string) {} // silence the Execute-time sweep during the seed run
+	t.Cleanup(func() { runLeaf = old; sweepRunWorktreesFn = oldAll })
+
+	script := filepath.Join(t.TempDir(), "s.js")
+	if err := os.WriteFile(script, []byte(`const meta = {name: "n", description: "d", phases: [{title: "plan"}]};
+phase("plan");
+await agent("x", {provider: "v"});
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	id, err := Launch(context.Background(), script, Options{}, true) // fresh foreground run to completion
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	jp, err := subagent.RunJournalPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, rerr := os.ReadFile(jp)
+	if rerr != nil || len(before) == 0 {
+		t.Fatalf("precondition: the run must have journaled its leaf (err=%v, bytes=%d)", rerr, len(before))
+	}
+	_, leaves, serr := subagent.RunStatus(id)
+	if serr != nil {
+		t.Fatal(serr)
+	}
+	var leafKey string
+	for _, l := range leaves {
+		if l.JournalKey != "" {
+			leafKey = l.JournalKey
+			break
+		}
+	}
+	if leafKey == "" {
+		t.Fatal("precondition: expected a member leaf with a journal key")
+	}
+	// Force the completed run into the ambiguous {stopped,0} state, leaving its journal + member jobs.
+	run, _ := subagent.ReadRun(id)
+	run.Status, run.EnginePID = "stopped", 0
+	if err := subagent.SaveRun(run); err != nil {
+		t.Fatal(err)
+	}
+	assertUnmutated := func(t *testing.T) {
+		after, err := os.ReadFile(jp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Errorf("journal must be byte-identical after a refused restart\nbefore=%q\nafter =%q", before, after)
+		}
+	}
+
+	t.Run("leaf restart", func(t *testing.T) {
+		if err := Restart(context.Background(), id, leafKey); err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("leaf restart of {stopped,0} must be refused, got %v", err)
+		}
+		assertUnmutated(t)
+	})
+
+	t.Run("phase restart", func(t *testing.T) {
+		if _, err := RestartPhase(context.Background(), id, "plan"); err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("phase restart of {stopped,0} must be refused, got %v", err)
+		}
+		assertUnmutated(t)
+	})
+}
+
+// TestBlindStoppedForegroundChainWorktreeSurvives: the end-to-end chain. A blind-stopped live
+// foreground run ({stopped,0}) with a real worktree in its segment: resume is REFUSED (no twin engine
+// is ever created), and a subsequent Execute-time sweep spares the segment ({stopped,0} is not
+// provably dead) — so the (possibly still-live) worktree survives. The chain's destructive half never
+// fires.
+func TestBlindStoppedForegroundChainWorktreeSurvives(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+
+	const id = "chain-fg"
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0}); err != nil {
+		t.Fatal(err)
+	}
+	wt := filepath.Join(tempBase, id, "wt")
+	addWorktree(t, repo, wt)
+
+	script, _ := writeTrivialScript(t)
+	t.Chdir(repo)
+	if _, err := Launch(context.Background(), script, Options{Resume: id}, true); err == nil || !strings.Contains(err.Error(), "cannot be verified") {
+		t.Fatalf("resume of the blind-stopped foreground run must be refused, got %v", err)
+	}
+
+	sweepRunWorktrees(repo)
+
+	if !worktreeListed(t, repo, wt) {
+		t.Error("the blind-stopped foreground run's worktree must survive the sweep (not provably dead)")
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("the worktree workdir must survive (err=%v)", err)
+	}
+}
+
+// TestResumeLegitStatesAllowed: the {stopped,0} refusal must NOT catch legitimately-resumable states
+// — a completed foreground run ({done,0}), a crashed detached run ({running, dead pid}), and a
+// properly-stopped detached run ({stopped, dead pid>0}) all resume without the refusal.
+func TestResumeLegitStatesAllowed(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    string
+		enginePID int
+	}{
+		{"completed foreground {done,0}", "done", 0},
+		{"crashed detached {running, dead pid}", "running", 0x7ffffffe},
+		{"stopped detached {stopped, dead pid}", "stopped", 0x7ffffffe},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo := initSweepRepo(t)
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("HOME", t.TempDir())
+			oldOwn := sweepOwnSegmentFn
+			oldAll := sweepRunWorktreesFn
+			sweepOwnSegmentFn = func(string, string) {}
+			sweepRunWorktreesFn = func(string) {}
+			t.Cleanup(func() { sweepOwnSegmentFn = oldOwn; sweepRunWorktreesFn = oldAll })
+
+			script, _ := writeTrivialScript(t)
+			const id = "resume-legit"
+			if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: c.status, EnginePID: c.enginePID}); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(repo)
+			if _, err := Launch(context.Background(), script, Options{Resume: id}, true); err != nil {
+				t.Errorf("resume of %s must be allowed, got %v", c.name, err)
+			}
+		})
+	}
+}
+
+// TestResumeConcurrentForegroundResumesSweepOnce: two foreground resumes of the same provably-dead
+// run race. The foreground preflight self-serializes under the per-run lock, so exactly ONE resumer
+// sweeps the dead prior's own segment (the other, seeing the manifest already flipped to "running",
+// is refused) and the two preflights never sweep concurrently — closing the stale-death-proof TOCTOU
+// where the loser would delete the winner's live worktrees.
+func TestResumeConcurrentForegroundResumesSweepOnce(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	const id = "resume-race"
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	script, _ := writeTrivialScript(t)
+
+	// The own-segment sweep IS the protected operation — use its seam to count invocations and detect
+	// any concurrent overlap, widening the window so an unserialized race would reliably double-sweep.
+	var sweeps, inSweep, overlap int32
+	oldOwn := sweepOwnSegmentFn
+	oldAll := sweepRunWorktreesFn
+	sweepOwnSegmentFn = func(string, string) {
+		if atomic.AddInt32(&inSweep, 1) > 1 {
+			atomic.StoreInt32(&overlap, 1)
+		}
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&sweeps, 1)
+		atomic.AddInt32(&inSweep, -1)
+	}
+	sweepRunWorktreesFn = func(string) {} // silence the Execute-time sweep during the concurrent runs
+	t.Cleanup(func() { sweepOwnSegmentFn = oldOwn; sweepRunWorktreesFn = oldAll })
+
+	t.Chdir(repo)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); _, _ = Launch(context.Background(), script, Options{Resume: id}, true) }()
+	}
+	wg.Wait()
+
+	if overlap != 0 {
+		t.Error("two foreground resume preflights swept concurrently — the per-run lock did not serialize them")
+	}
+	if sweeps != 1 {
+		t.Errorf("own-segment sweep fired %d times, want exactly 1 (only one resumer reclaims the dead prior)", sweeps)
+	}
+}
+
+// TestResumeForegroundSerializesAgainstHeldLock: a foreground resume must block on the per-run lock
+// while a detached-lane holder (as the CLI/Restart wrap Launch) owns it, then — once the holder has
+// flipped the manifest to "running" and released — be refused by the resume guard without sweeping.
+// This is the cross-lane serialization: the foreground self-lock and the caller-held lock contend on
+// the same runs/<id>.lock.
+func TestResumeForegroundSerializesAgainstHeldLock(t *testing.T) {
+	repo := initSweepRepo(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	const id = "resume-held"
+	if err := subagent.SaveRun(subagent.WorkflowRun{RunID: id, StartedAt: "2026-01-01T00:00:00Z", Status: "stopped", EnginePID: 0x7ffffffe}); err != nil {
+		t.Fatal(err)
+	}
+	script, _ := writeTrivialScript(t)
+
+	var sweeps int32
+	oldOwn := sweepOwnSegmentFn
+	oldAll := sweepRunWorktreesFn
+	sweepOwnSegmentFn = func(string, string) { atomic.AddInt32(&sweeps, 1) }
+	sweepRunWorktreesFn = func(string) {}
+	t.Cleanup(func() { sweepOwnSegmentFn = oldOwn; sweepRunWorktreesFn = oldAll })
+
+	t.Chdir(repo)
+	// A detached-lane holder of the per-run lock that wins the preflight: it flips the run "running"
+	// before releasing, mirroring what a detached resume does under the CLI/Restart lock.
+	holding, release := make(chan struct{}), make(chan struct{})
+	go func() {
+		_ = subagent.WithRunLock(id, func() error {
+			close(holding)
+			<-release
+			r, _ := subagent.ReadRun(id)
+			r.Status, r.EnginePID = "running", 0
+			return subagent.SaveRun(r)
+		})
+	}()
+	<-holding
+
+	done := make(chan error, 1)
+	go func() { _, e := Launch(context.Background(), script, Options{Resume: id}, true); done <- e }()
+	select {
+	case <-done:
+		t.Fatal("foreground resume completed while the per-run lock was held — not serialized")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+
+	err := <-done
+	if err == nil || !strings.Contains(err.Error(), "already has a live engine") {
+		t.Errorf("foreground resume must be refused after the holder flipped the run to running, got %v", err)
+	}
+	if sweeps != 0 {
+		t.Errorf("the refused foreground resume must not sweep, got %d", sweeps)
+	}
+}

--- a/internal/workflow/worktree_sweep_test.go
+++ b/internal/workflow/worktree_sweep_test.go
@@ -69,7 +69,7 @@ func worktreeListed(t *testing.T, repo, path string) bool {
 func TestSweepRunWorktreesScoped(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
 
 	const (
 		runDead        = "run-dead"
@@ -156,7 +156,7 @@ func TestSweepRunWorktreesNonGit(t *testing.T) {
 func TestSweepRunWorktreesMapGuard(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
 	const liveID = "a-b"
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, liveID)) })
 
@@ -187,7 +187,7 @@ func TestSweepRunWorktreesMapGuard(t *testing.T) {
 func TestSweepOwnSegment(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
 
 	t.Run("path-safe id reclaims its own segment", func(t *testing.T) {
 		const id = "own-seg"
@@ -229,7 +229,7 @@ func TestPurgeThenSweepReclaimsRegistration(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
 
 	const id = "purge-reclaim" // path-safe
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })
@@ -304,7 +304,7 @@ func TestSweepEngineWiring(t *testing.T) {
 		if calls != 1 {
 			t.Fatalf("sweep called %d times, want 1", calls)
 		}
-		if normPath(gotRoot) != normPath(repo) {
+		if normPath(gotRoot) != normPath(canonPath(repo)) { // gitTopLevel canonicalizes; match it
 			t.Errorf("sweep root = %q, want repo %q", gotRoot, repo)
 		}
 	})
@@ -371,7 +371,7 @@ func TestResumeLauncherOwnSegmentSweep(t *testing.T) {
 			if gotRun != id {
 				t.Errorf("own sweep runID = %q, want %q", gotRun, id)
 			}
-			if normPath(gotRoot) != normPath(repo) {
+			if normPath(gotRoot) != normPath(canonPath(repo)) { // gitTopLevel canonicalizes; match it
 				t.Errorf("own sweep root = %q, want repo %q", gotRoot, repo)
 			}
 		})
@@ -542,7 +542,7 @@ func TestBlindStoppedForegroundChainWorktreeSurvives(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
-	tempBase := filepath.Join(os.TempDir(), "cc-fleet-worktrees")
+	tempBase := filepath.Join(canonPath(os.TempDir()), "cc-fleet-worktrees") // match git porcelain (macOS /private, win long path)
 
 	const id = "chain-fg"
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tempBase, id)) })

--- a/internal/workflow/worktree_sweep_test.go
+++ b/internal/workflow/worktree_sweep_test.go
@@ -245,7 +245,7 @@ func TestSweepOwnSegment(t *testing.T) {
 	})
 }
 
-// TestSweepOwnSegmentSnapshotBeforeVerdict (codex r33): sweepOwnSegment must snapshot the segment's
+// TestSweepOwnSegmentSnapshotBeforeVerdict: sweepOwnSegment must snapshot the segment's
 // registrations BEFORE it computes the reclaim verdict — the ordering sweepRunWorktrees and PurgeRun
 // already use. A colliding twin ("own.seg", same segment "own-seg") runs under a DIFFERENT run id, so
 // its run lock never serializes against this sweep; if it registers a fresh worktree in the
@@ -291,7 +291,7 @@ func TestSweepOwnSegmentSnapshotBeforeVerdict(t *testing.T) {
 	}
 }
 
-// TestSweepRunWorktreesForeignStoreSpared (codex r34): the isolation-worktree temp root is namespaced by
+// TestSweepRunWorktreesForeignStoreSpared: the isolation-worktree temp root is namespaced by
 // config store (subagent.WorktreeStoreID) and the sweep is scoped to THIS store's prefix. A worktree NOT
 // under this store's prefix — a foreign store (another HOME/XDG sharing os.TempDir()+repo), or a
 // pre-namespacing flat-path leftover — is structurally invisible to the sweep and must survive, even
@@ -334,11 +334,11 @@ func TestSweepRunWorktreesForeignStoreSpared(t *testing.T) {
 	}
 }
 
-// TestSweepRunWorktreesLegacyFlatVanishedPruned (codex r35): a worktree under the shared cc-fleet-worktrees
+// TestSweepRunWorktreesLegacyFlatVanishedPruned: a worktree under the shared cc-fleet-worktrees
 // root but OUTSIDE this store's prefix (a foreign store's, or a pre-namespacing flat leftover) is pruned
 // by clause (b) when its workdir has VANISHED — a deleted cwd can host no live process, whichever store
 // owned it — while a PRESENT such workdir (possibly a foreign store's live cwd) is spared. This drains
-// legacy leftovers without reopening the r34 cross-store deletion.
+// legacy leftovers without deleting a present foreign workdir.
 func TestSweepRunWorktreesLegacyFlatVanishedPruned(t *testing.T) {
 	repo := initSweepRepo(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())


### PR DESCRIPTION
`isolation: 'worktree'` registers a git worktree inside the user's repo (`.git/worktrees/<uuid>`), and the only remover was a deferred cleanup closure — a SIGKILLed or crashed engine skips its defers, so every stopped or OOM-killed run left a stale registration plus an orphaned temp workdir, accumulating until a manual `git worktree prune`. This reworks reclamation around one invariant: a worktree registration or temp workdir is never deleted while any process — the workflow engine or a leaf `claude` child — might still be using it as a cwd, while provably-dead runs are reclaimed.

Liveness is decided tri-state everywhere — Dead, Live, or Unknown — where an unreadable pid start-token reads Unknown and Unknown is treated as possibly-alive. Engine death alone is not sufficient proof: a SIGKILLed engine's leaf `claude` children keep the worktree as their cwd, so each sync leaf stamps its child pid and start token atomically after spawn (with a pending marker covering the spawn-to-record window), and reclamation is vetoed while any leaf may still be alive. A run's worktrees are removable only when its engine is provably dead and no leaf may still hold the workdir.

Reclamation runs at three snapshot-scoped sites — a startup sweep, the resume launcher's own-segment sweep, and the manual delete's temp removal — each of which snapshots the candidate worktrees before it computes the reclaim verdict, so a colliding run that registers a fresh worktree in the window is structurally outside the removal set. The temp root is namespaced per config store (a hash of the absolute config dir), so two stores sharing `/tmp` and a repo can never collide on a segment and delete each other's live worktree: a foreign store's worktrees sit under a different prefix and are pruned only when their workdir has already vanished (which needs no verdict), draining pre-namespacing leftovers without ever touching a present one. Identity-based reclamation applies only to ids that equal their own sanitized path segment, so colliding ids can never condemn a live twin's worktrees.

`StopRun` now retains the dead pid and start token as death evidence instead of zeroing them, and a foreground engine records its own pid and token in the resume preflight — so a Ctrl-C'd or crashed foreground run resumes and restarts again. A legacy `{stopped, EnginePID 0}` record with no foreground identity — a pre-upgrade record, or a blind stop of a still-live foreground engine, which are manifest-indistinguishable — is refused resume and restart with an error asking the user to confirm the terminal process exited and then delete the run or launch fresh; that record's own worktree is provably never touched. Stopped runs' `list --json` now carries the engine pid and foreground identity as death evidence, while `status` stays authoritative and the TUI is unchanged.

Because `AtomicWrite` renames files into place, a concurrent Windows reader can hit `ERROR_SHARING_VIOLATION` where POSIX never does; meta and manifest reads now retry that transient window on Windows (a no-op on unix), and the reclaim verdict fails closed on a manifest it cannot read, so a transient read fault is never mistaken for engine death — while a readable-but-corrupt manifest stays deletable.

Every clause is covered by real-git unit tests — scoped removal, live and unknown and foreign-store and user-owned worktrees spared, the collision guards, the snapshot-before-verdict ordering, purge gating, no-journal-mutation restart refusals, and concurrent-resume serialization — plus a whole-engine end-to-end run that branches HEAD into an isolation worktree with crash recovery and resume, and a real-provider run confirming the store-scoped worktree is created, used by the leaf, and cleaned up with no leaked registration.

Closes #89