### PR TITLE
fix(npm): verify the Ed25519 release signature before trusting checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - uses: actions/setup-node@v4
+        if: runner.os == 'Linux'
+        with:
+          node-version: "20"
+      - name: test (npm postinstall verify)
+        if: runner.os == 'Linux'
+        run: node --test npm/install.test.js
       - name: gofmt
         if: runner.os != 'Windows'
         run: |

--- a/npm/install.js
+++ b/npm/install.js
@@ -13,6 +13,47 @@ const { execFileSync } = require("child_process");
 const REPO = "ethanhq/cc-fleet";
 const version = require("./package.json").version;
 
+// Base64 Ed25519 PUBLIC key the release pipeline signs checksums.txt with. It mirrors
+// releaseSigningKeyB64 in internal/selfupdate/signing.go; signing-preflight.sh fails the
+// release unless the two literals (and the key derived from the signing secret) match.
+const RELEASE_SIGNING_KEY_B64 = "dAbMy8Omb0En+n0xZNGTjKsNHDdwBipwqy+jHXGpZjw=";
+
+// verifyChecksumsSig verifies a base64 Ed25519 detached signature (sigBuf) over the EXACT
+// bytes of checksums.txt (sumsBuf) against the embedded release public key. It is the trust
+// anchor checked before any sha256 is trusted, and fails closed on a malformed embedded key,
+// a malformed/wrong-length signature, or a verification mismatch — a mirror / redirect /
+// arbitrary CCF_BASE_URL cannot forge it.
+function verifyChecksumsSig(sumsBuf, sigBuf) {
+  const raw = Buffer.from(RELEASE_SIGNING_KEY_B64, "base64");
+  if (raw.length !== 32) {
+    throw new Error("release signing key unavailable (malformed embedded public key)");
+  }
+  // Wrap the raw 32-byte key in a DER SPKI header so createPublicKey accepts it.
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    raw,
+  ]);
+  const key = crypto.createPublicKey({ key: spki, format: "der", type: "spki" });
+  // Trim only ASCII whitespace (String.trim strips U+FEFF/BOM, Go's strings.TrimSpace strips
+  // U+0085/NEL — they disagree at the edges); any exotic whitespace then survives into the
+  // canonical round-trip below and fails it, so this path is never more permissive than the
+  // Go verifier.
+  const trimmed = sigBuf.toString("utf8").replace(/^[\t\n\v\f\r ]+|[\t\n\v\f\r ]+$/g, "");
+  const sig = Buffer.from(trimmed, "base64");
+  if (sig.length !== 64) {
+    throw new Error(`signature is ${sig.length} bytes, want 64`);
+  }
+  // Buffer.from decodes base64 permissively (ignoring stray characters and missing padding);
+  // the Go verifier's base64.StdEncoding.DecodeString rejects both. Require a canonical
+  // round-trip so a corrupted .sig cannot pass here yet be rejected by `cc-fleet update`.
+  if (sig.toString("base64") !== trimmed) {
+    throw new Error("signature is not canonical base64");
+  }
+  if (!crypto.verify(null, sumsBuf, key, sig)) {
+    throw new Error("checksums.txt signature does not match the release key");
+  }
+}
+
 const PLATFORM = { linux: "linux", darwin: "darwin", win32: "windows" }[
   process.platform
 ];
@@ -33,10 +74,24 @@ const archive = WIN
   ? `cc-fleet-${PLATFORM}-${ARCH}.zip`
   : `cc-fleet-${PLATFORM}-${ARCH}.tar.gz`;
 const binName = WIN ? "cc-fleet.exe" : "cc-fleet";
-// CCF_BASE_URL overrides the asset base for a mirror or a local test.
-const base =
-  process.env.CCF_BASE_URL ||
-  `https://github.com/${REPO}/releases/download/v${version}`;
+// CCF_BASE_URL overrides the asset base for an https mirror or a local https test; a
+// non-https override is rejected so the source cannot be silently re-pointed at plaintext.
+const base = (() => {
+  const override = process.env.CCF_BASE_URL;
+  if (override) {
+    let u;
+    try {
+      u = new URL(override);
+    } catch {
+      throw new Error(`CCF_BASE_URL must be an https:// URL, got ${JSON.stringify(override)}`);
+    }
+    if (u.protocol !== "https:") {
+      throw new Error(`CCF_BASE_URL must be an https:// URL, got ${JSON.stringify(override)}`);
+    }
+    return override;
+  }
+  return `https://github.com/${REPO}/releases/download/v${version}`;
+})();
 
 // GET that follows redirects (GitHub release assets redirect to a CDN).
 function get(url, redirects = 0) {
@@ -72,10 +127,16 @@ async function main() {
   const binDir = path.join(__dirname, "bin");
   fs.mkdirSync(binDir, { recursive: true });
 
-  const [archiveBuf, sumsBuf] = await Promise.all([
+  const [archiveBuf, sumsBuf, sigBuf] = await Promise.all([
     get(`${base}/${archive}`),
     get(`${base}/checksums.txt`),
+    get(`${base}/checksums.txt.sig`),
   ]);
+
+  // Verify the release signature over checksums.txt against the embedded public key BEFORE
+  // trusting any sha256: the checksum is same-channel and only proves the archive matches a
+  // hash fetched from the same place; the signature is the trust anchor. Fail closed.
+  verifyChecksumsSig(sumsBuf, sigBuf);
 
   const expected = checksumFor(sumsBuf.toString("utf8"), archive);
   if (!expected) throw new Error(`no checksum for ${archive} in checksums.txt`);
@@ -113,7 +174,11 @@ async function main() {
   );
 }
 
-main().catch((err) => {
-  console.error(`cc-fleet: install failed: ${err.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`cc-fleet: install failed: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { RELEASE_SIGNING_KEY_B64, verifyChecksumsSig, checksumFor };

--- a/npm/install.test.js
+++ b/npm/install.test.js
@@ -1,0 +1,131 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert");
+const crypto = require("crypto");
+
+const { RELEASE_SIGNING_KEY_B64, verifyChecksumsSig } = require("./install.js");
+
+// pubKeyRaw exports an Ed25519 public KeyObject to SPKI DER and returns its trailing 32
+// raw key bytes — the inverse of the SPKI wrapping the verifier does — so a generated test
+// keypair can be fed through verifyWithKey below.
+function pubKeyRaw(publicKey) {
+  const der = publicKey.export({ format: "der", type: "spki" });
+  return der.subarray(der.length - 32);
+}
+
+// signWith returns a base64 StdEncoding detached signature over body using privateKey.
+function signWith(privateKey, body) {
+  return crypto.sign(null, body, privateKey).toString("base64");
+}
+
+// verifyWithKey re-runs the shipped verify logic but against an arbitrary raw pubkey, so
+// tests can feed a keypair they control without touching the shipped constant.
+function verifyWithKey(rawKey, sumsBuf, sigStr) {
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    rawKey,
+  ]);
+  const key = crypto.createPublicKey({ key: spki, format: "der", type: "spki" });
+  const trimmed = String(sigStr).replace(/^[\t\n\v\f\r ]+|[\t\n\v\f\r ]+$/g, "");
+  const sig = Buffer.from(trimmed, "base64");
+  if (sig.length !== 64) throw new Error(`signature is ${sig.length} bytes, want 64`);
+  if (sig.toString("base64") !== trimmed) throw new Error("signature is not canonical base64");
+  if (!crypto.verify(null, sumsBuf, key, sig)) {
+    throw new Error("checksums.txt signature does not match the release key");
+  }
+}
+
+test("verifyChecksumsSig accepts a valid detached sig, with or without trailing newline", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(publicKey);
+  const body = Buffer.from("abc123  cc-fleet-linux-amd64.tar.gz\n");
+  const sig = signWith(privateKey, body);
+  assert.doesNotThrow(() => verifyWithKey(raw, body, sig));
+  assert.doesNotThrow(() => verifyWithKey(raw, body, sig + "\n"));
+});
+
+test("verifyChecksumsSig verifies over the exact un-trimmed body", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(publicKey);
+  const body = Buffer.from("line\n"); // trailing newline is part of the signed message
+  const sig = signWith(privateKey, body);
+  assert.doesNotThrow(() => verifyWithKey(raw, body, sig));
+  // Trimming the message must break verification (message is not trimmed).
+  assert.throws(() => verifyWithKey(raw, Buffer.from("line"), sig));
+});
+
+test("verifyChecksumsSig rejects a tampered body", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(publicKey);
+  const sig = signWith(privateKey, Buffer.from("body A"));
+  assert.throws(() => verifyWithKey(raw, Buffer.from("body B"), sig));
+});
+
+test("verifyChecksumsSig rejects a truncated or malformed sig", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(publicKey);
+  const body = Buffer.from("body");
+  const good = signWith(privateKey, body);
+  // truncated (< 64 bytes decoded)
+  const truncated = Buffer.from(good, "base64").subarray(0, 32).toString("base64");
+  assert.throws(() => verifyWithKey(raw, body, truncated), /64/);
+  // malformed base64 → decodes to some other length
+  assert.throws(() => verifyWithKey(raw, body, "!!!not base64!!!"));
+});
+
+test("verifyChecksumsSig rejects a non-canonical base64 sig (Buffer.from decodes permissively)", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(publicKey);
+  const body = Buffer.from("abc123  cc-fleet-linux-amd64.tar.gz\n");
+  const good = signWith(privateKey, body); // canonical StdEncoding base64, padded
+  // The exact canonical sig still verifies, with and without the trailing newline the signer writes.
+  assert.doesNotThrow(() => verifyWithKey(raw, body, good));
+  assert.doesNotThrow(() => verifyWithKey(raw, body, good + "\n"));
+  // Padding stripped: still decodes to 64 bytes, but is not canonical → reject.
+  const noPad = good.replace(/=+$/, "");
+  assert.notStrictEqual(noPad, good);
+  assert.strictEqual(Buffer.from(noPad, "base64").length, 64);
+  assert.throws(() => verifyWithKey(raw, body, noPad), /canonical/);
+  // Trailing invalid characters that Buffer.from silently ignores (still 64 bytes) → reject.
+  const junk = good + "!!!";
+  assert.strictEqual(Buffer.from(junk, "base64").length, 64);
+  assert.throws(() => verifyWithKey(raw, body, junk), /canonical/);
+});
+
+test("verifyChecksumsSig trims only ASCII whitespace — exotic whitespace fails the round-trip, never looser than Go", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(publicKey);
+  const body = Buffer.from("abc123  cc-fleet-linux-amd64.tar.gz\n");
+  const good = signWith(privateKey, body); // canonical, padded
+  // BOM prefix: String.trim would strip U+FEFF but Go's strings.TrimSpace does not — the ASCII
+  // trim leaves it in, so the round-trip rejects. Go also rejects → true parity for this case.
+  assert.throws(() => verifyWithKey(raw, body, "\uFEFF" + good), /canonical/);
+  // NEL-wrapped: Go's TrimSpace strips U+0085 and would accept; npm rejects → npm is stricter,
+  // never looser, than the Go verifier (worst case an install fails where update would succeed).
+  assert.throws(() => verifyWithKey(raw, body, "\u0085" + good + "\u0085"), /canonical/);
+  // The signer writes canonical base64 + a trailing '\n' (ASCII) → still verifies.
+  assert.doesNotThrow(() => verifyWithKey(raw, body, good + "\n"));
+});
+
+test("verifyChecksumsSig rejects a wrong key", () => {
+  const { privateKey } = crypto.generateKeyPairSync("ed25519");
+  const other = crypto.generateKeyPairSync("ed25519");
+  const raw = pubKeyRaw(other.publicKey);
+  const body = Buffer.from("body");
+  const sig = signWith(privateKey, body);
+  assert.throws(() => verifyWithKey(raw, body, sig));
+});
+
+test("shipped constant decodes to a 32-byte Ed25519 public key", () => {
+  assert.strictEqual(Buffer.from(RELEASE_SIGNING_KEY_B64, "base64").length, 32);
+});
+
+test("shipped verifyChecksumsSig verifies against the real release key", () => {
+  // A signature produced by a random key must NOT verify against the embedded release key.
+  // sigBuf carries the base64 sig text, as the .sig asset does on disk.
+  const { privateKey } = crypto.generateKeyPairSync("ed25519");
+  const body = Buffer.from("checksums");
+  const sig = Buffer.from(signWith(privateKey, body) + "\n");
+  assert.throws(() => verifyChecksumsSig(body, sig), /does not match/);
+});

--- a/scripts/signing-preflight.sh
+++ b/scripts/signing-preflight.sh
@@ -13,6 +13,22 @@ if [ -z "$embedded" ]; then
   exit 1
 fi
 
+# The npm postinstall channel embeds the same key literal (RELEASE_SIGNING_KEY_B64 in
+# npm/install.js). Assert the two agree so a key rotation that misses install.js fails the
+# release. This half is secret-free — it runs before the derived-key check below.
+npm_embedded="$(sed -n 's/.*RELEASE_SIGNING_KEY_B64[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' npm/install.js | head -1)"
+if [ -z "$npm_embedded" ]; then
+  echo "signing-preflight: could not read RELEASE_SIGNING_KEY_B64 from npm/install.js" >&2
+  exit 1
+fi
+if [ "$embedded" != "$npm_embedded" ]; then
+  echo "signing-preflight: npm/install.js public key does not match internal/selfupdate/signing.go" >&2
+  echo "  signing.go:  $embedded" >&2
+  echo "  install.js:  $npm_embedded" >&2
+  echo "signing-preflight: update RELEASE_SIGNING_KEY_B64 in npm/install.js to the release key." >&2
+  exit 1
+fi
+
 # Derives the public key from $CCF_RELEASE_SIGNING_KEY; fails if the secret is unset/malformed.
 derived="$(go run ./tools/sign-checksums -pubkey)"
 


### PR DESCRIPTION
The npm postinstall verified the downloaded archive only against a `checksums.txt` fetched from the same GitHub-Releases channel — an attacker with release-asset write but no signing key could swap the archive and regenerate a matching checksum, and the sha256 comparison passed. The in-process `cc-fleet update` path already rejects exactly that artifact via the signed `checksums.txt.sig`, so the release-signing trust anchor was silently bypassed for npm installs and for npm-managed updates, which re-run this installer.

`install.js` now fetches `checksums.txt.sig` and verifies it against the embedded Ed25519 release key before trusting any sha256, mirroring the Go verifier byte for byte and dependency-free: the raw 32-byte key is DER-SPKI-wrapped for `crypto.verify`, the signature must be exactly 64 bytes of canonical base64 (Node's permissive decoder is round-trip-checked because Go's strict one rejects what it silently tolerates), the message is the exact un-trimmed `checksums.txt` bytes, and only ASCII edge whitespace is trimmed from the signature — exotic whitespace fails the round-trip, so this path is never more permissive than the Go verifier. A verification failure aborts the install. `CCF_BASE_URL` must now be an https URL, matching the Go rule with no carve-out.

The key literal is cross-checked against the one embedded in the binary by a secret-free assertion in `scripts/signing-preflight.sh`, so a key rotation that misses the npm copy fails the release loudly. A dependency-free `node:test` suite (generated-keypair vectors for tampering, truncation, wrong key, non-canonical base64, exotic whitespace, and the signer's trailing newline) runs in CI on Linux.

Closes #90
