### PR TITLE
Add Kimi Code provider preset

### DIFF
--- a/codex-plugin/skills/cc-fleet-shared/providers.md
+++ b/codex-plugin/skills/cc-fleet-shared/providers.md
@@ -26,6 +26,7 @@ Template seeds for the built-in presets (what the TUI add picker prefills). Sugg
 |---|---|---|
 | `deepseek` | `deepseek-v4-flash` | Use canonical names; legacy aliases silently fall back to default. |
 | `kimi` (Moonshot) | `kimi-latest` | 200k+ context; strong Chinese. |
+| `kimi-code` (Kimi Code) | `kimi-for-coding` | Kimi Code Console API key tied to Kimi membership benefits; preset uses medium effort for Thinking/K2.7. Not Kimi CLI OAuth or Moonshot Platform billing. Use `--profile full` for subagent leaves when K2.7 Thinking behavior matters, because slim disables thinking. |
 | `glm` (智谱, bigmodel.cn) | `glm-4.6` | Domain Chinese, industry vertical. |
 | `zai` (GLM international, z.ai) | `glm-4.6` | Same models as `glm`; separate site + separate key. |
 | `qwen` (DashScope) | `qwen-max` | Endpoint/plan vary by region; consult user docs if `refresh` fails. |

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -117,7 +117,7 @@ func newAddForm(t Template) form {
 		{key: "models_endpoint", label: "Models endpoint", kind: fieldText, input: newTextInput(t.ModelsEndpoint, "https://…/v1/models", false)},
 		{key: "api_key", label: "API key", kind: fieldText, input: newTextInput("", "stored at <name>.key (mode 0600)", true)},
 	}
-	fields = append(fields, modelConfigFields(t.DefaultModel, "", "", "", "")...)
+	fields = append(fields, modelConfigFields(t.DefaultModel, "", "", t.Effort, "")...)
 	f := form{
 		title:  "Add provider",
 		intro:  "↑/↓ move rows · → 1M toggle · enter on [Add] submits · esc cancels",

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -722,7 +722,7 @@ func TestTemplatesSeedTable(t *testing.T) {
 	for _, tp := range Templates {
 		byName[tp.Name] = tp
 	}
-	for _, name := range []string{"deepseek", "kimi", "glm", "qwen", "minimax"} {
+	for _, name := range []string{"deepseek", "kimi", "kimi-code", "glm", "qwen", "minimax"} {
 		tp, ok := byName[name]
 		if !ok {
 			t.Errorf("missing seed template %q", name)
@@ -731,6 +731,31 @@ func TestTemplatesSeedTable(t *testing.T) {
 		if tp.BaseURL == "" || tp.ModelsEndpoint == "" || tp.DefaultModel == "" {
 			t.Errorf("template %q has an empty seed field: %+v", name, tp)
 		}
+	}
+	kc := byName["kimi-code"]
+	if kc.Label != "Kimi Code" ||
+		kc.BaseURL != "https://api.kimi.com/coding/" ||
+		kc.ModelsEndpoint != "https://api.kimi.com/coding/v1/models" ||
+		kc.DefaultModel != "kimi-for-coding" ||
+		kc.Effort != "medium" {
+		t.Fatalf("kimi-code seed mismatch: %+v", kc)
+	}
+}
+
+func TestAddForm_TemplateEffortPrefill(t *testing.T) {
+	byName := map[string]Template{}
+	for _, tp := range Templates {
+		byName[tp.Name] = tp
+	}
+	kimiCode, ok := byName["kimi-code"]
+	if !ok {
+		t.Fatal("missing kimi-code template")
+	}
+	if got := newAddForm(kimiCode).choiceValue("effort"); got != "medium" {
+		t.Fatalf("kimi-code effort prefill = %q, want medium", got)
+	}
+	if got := newAddForm(byName["deepseek"]).choiceValue("effort"); got != "off" {
+		t.Fatalf("deepseek effort prefill = %q, want off", got)
 	}
 }
 

--- a/internal/tui/templates.go
+++ b/internal/tui/templates.go
@@ -20,6 +20,7 @@ type Template struct {
 	BaseURL        string // ANTHROPIC_BASE_URL
 	ModelsEndpoint string // /v1/models URL used for the probe + refresh
 	DefaultModel   string // suggested default model id
+	Effort         string // optional suggested reasoning-effort level
 	Note           string // optional caveat shown in the picker preview
 }
 
@@ -78,6 +79,15 @@ var Templates = []Template{
 		BaseURL:        "https://api.moonshot.cn/anthropic",
 		ModelsEndpoint: "https://api.moonshot.cn/anthropic/v1/models",
 		DefaultModel:   "kimi-latest",
+	},
+	{
+		Name:           "kimi-code",
+		Label:          "Kimi Code",
+		BaseURL:        "https://api.kimi.com/coding/",
+		ModelsEndpoint: "https://api.kimi.com/coding/v1/models",
+		DefaultModel:   "kimi-for-coding",
+		Effort:         "medium",
+		Note:           "Kimi Code Console API key; uses Kimi membership quota, not Kimi CLI OAuth or Moonshot Platform billing.",
 	},
 	{
 		Name:           "glm",

--- a/skills/cc-fleet-shared/providers.md
+++ b/skills/cc-fleet-shared/providers.md
@@ -26,6 +26,7 @@ Template seeds for the built-in presets (what the TUI add picker prefills). Sugg
 |---|---|---|
 | `deepseek` | `deepseek-v4-flash` | Use canonical names; legacy aliases silently fall back to default. |
 | `kimi` (Moonshot) | `kimi-latest` | 200k+ context; strong Chinese. |
+| `kimi-code` (Kimi Code) | `kimi-for-coding` | Kimi Code Console API key tied to Kimi membership benefits; preset uses medium effort for Thinking/K2.7. Not Kimi CLI OAuth or Moonshot Platform billing. Use `--profile full` for subagent leaves when K2.7 Thinking behavior matters, because slim disables thinking. |
 | `glm` (智谱, bigmodel.cn) | `glm-4.6` | Domain Chinese, industry vertical. |
 | `zai` (GLM international, z.ai) | `glm-4.6` | Same models as `glm`; separate site + separate key. |
 | `qwen` (DashScope) | `qwen-max` | Endpoint/plan vary by region; consult user docs if `refresh` fails. |


### PR DESCRIPTION
Adds a Kimi Code provider preset for the Kimi Code Console API key flow using `kimi-for-coding`, the Kimi Code Anthropic-compatible endpoint, and `medium` effort by default.

This keeps the existing Moonshot Kimi preset unchanged and documents that Kimi Code uses Kimi membership quota rather than Kimi CLI OAuth or Moonshot Platform billing.

Validation:
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `gofmt -l .`
- `git diff --check`