### PR TITLE
chore(release): set version to v0.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) — even your Codex subscription — as real Claude Code workflows, agent-team teammates, or one-shot subagents, driven exactly like native ones. Your main session's own auth is untouched (OAuth subscription or API key, either works); API-key providers bill the provider key via apiKeyHelper, while a Codex subscription bills through a local OAuth daemon — each worker receives its credential on demand, never through its env or argv. Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-fleet",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Fan out provider LLM subagents and multi-phase JS workflows from Codex via the cc-fleet CLI — DeepSeek / GLM / Kimi / Qwen / MiniMax, or your Codex/Claude subscription. Each worker receives its credential on demand, never through its env or argv. Requires the cc-fleet and claude binaries on PATH (installed separately).",
   "author": {
     "name": "Ethan Guo",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
Sets the release version to 0.3.1 across the Claude plugin manifest, the codex plugin manifest, and the npm package; version-guard passes against the v0.3.1 tag.

Included since v0.3.0:
- Kimi Code provider preset in the TUI add wizard, seeding the Kimi Code Console endpoint and the `kimi-for-coding` model with a medium default effort.
- npm install now verifies the Ed25519 release signature before trusting the checksums.
- The background subagent terminal classifier streams past oversized lines instead of stalling on them.
- The release workflow pins every action to a commit SHA and the goreleaser binary to v2.16.0, removing the mutable-tag execution surface.

Merge, then tag v0.3.1 to trigger the release; goreleaser drafts the GitHub release and generates the changelog from the commit range, and it is undrafted only after the signed checksums are confirmed.
