### PR TITLE
docs(skills): clarify execution-environment requirements in agent lane skills

### DIFF
--- a/codex-plugin/skills/subagent/SKILL.md
+++ b/codex-plugin/skills/subagent/SKILL.md
@@ -9,6 +9,18 @@ description: Fan out a one-shot or flat parallel batch of cc-fleet PROVIDER suba
 
 When this skill cites `cc-fleet-shared/<file>.md`, read `../cc-fleet-shared/<file>.md` relative to this SKILL.md (load-bearing, not optional background).
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 `cc-fleet subagent` runs a provider model headless and returns the result directly on your shell's stdout — no tmux pane, no team, no locks. A one-shot provider agent whose model can be a provider id. It reuses the same provider selection and fingerprint gate as the rest of cc-fleet. It's the lightweight synchronous branch.
 
 **Preflight (first fan-out per session).** Run `cc-fleet doctor --json` once and read the per-check results. The ONLY hard stops are the **claude binary** check and the **fingerprint** check (the worker engine) — if either fails, tell the user to install or fix Claude Code, and stop. Do **not** stop on the "all configured providers' keys reachable" check: it aggregates every enabled provider, so one unrelated provider — especially a daemon-backed `codex` / `openai-*`, whose loopback proxy is only up during a spawn — flips `ok:false` / exit 1 while your target provider is fine. Provider API keys are configured separately in cc-fleet, so a provider model needs the claude **binary** but not a Claude subscription. To check the provider you'll actually use, run `cc-fleet models <provider> --json` (`PROVIDER_UNKNOWN` ⇒ not configured); that confirms it's configured + enabled, not that it's reachable — the run itself proves reachability.

--- a/codex-plugin/skills/workflow/SKILL.md
+++ b/codex-plugin/skills/workflow/SKILL.md
@@ -9,6 +9,18 @@ description: Orchestrate a MULTI-PHASE, dependent, or resumable run over many cc
 
 When this skill cites `cc-fleet-shared/<file>.md`, read the file at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 A **workflow** is a JavaScript script that fans out provider `cc-fleet subagent` leaves and runs in a **cc-fleet process, OFF the main session's context**. You write the script; `cc-fleet workflow run` executes it. The orchestration plan lives in script variables (CPU, ~0 of your tokens) — you are invoked only when *authoring* the script, not on every scheduling decision. The API mirrors the native Claude Code Workflow tool — write the script exactly as you would a native workflow; the only addition is the `provider` option on `agent()`.
 
 ## Preflight (once per session)

--- a/skills/subagent/SKILL.md
+++ b/skills/subagent/SKILL.md
@@ -9,6 +9,18 @@ description: Run a one-shot or flat parallel batch of provider LLM subagents (he
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 `cc-fleet subagent` runs a provider model headless and returns the result directly on Bash stdout — **no** tmux pane, **no** `TeamCreate`/`SendMessage`/`TeamDelete`. The analog of the native `Agent`/`Task` tool, but the model can be a provider id. It reuses the same provider selection and the same fingerprint self-heal flow as spawn (cc-fleet-shared/troubleshooting.md). It's the lightweight synchronous branch.
 
 ## When to use it

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -11,6 +11,18 @@ Run a third-party provider model as a real Claude Code teammate in a tmux pane: 
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 **Precondition — agent-teams must be ON:** check your own tool list for `SendMessage` / `TeamCreate`; absent → do NOT spawn (an unmessageable pane bills the provider with no work) — enablement + fallback in cc-fleet-shared/routing.md.
 
 ---

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -9,6 +9,18 @@ description: Orchestrate a MULTI-PHASE, dependent, or resumable run over many pr
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 A **workflow** is a JavaScript script that fans out provider `cc-fleet subagent` leaves and runs in a **cc-fleet process, OFF the main session's context**. You write the script; `cc-fleet workflow run` executes it. The orchestration plan lives in script variables (CPU, ~0 of your tokens) — you are invoked only when *authoring* the script, not on every scheduling decision. The API mirrors the native Claude Code Workflow tool — write the script exactly as you would a native workflow; the only addition is the `provider` option on `agent()`.
 
 ## When to use it


### PR DESCRIPTION
## Summary

Adds a short preflight note to each agent-facing lane skill explaining that in sandboxed or remote agent sessions, the shell tool may execute on a different machine from the cc-fleet installation. The note directs agents to detect this early and route through any available host-executing bridge, without prescribing a specific product or changing runtime behavior.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Docs
- [ ] Tests
- [ ] Refactor / chore

## Related issue

None — small focused docs change.

## Context

The lane skills implicitly assume the Bash tool runs on the cc-fleet installation host. That assumption breaks in sessions like **Claude Cowork** (Anthropic's desktop app), where the Bash tool executes inside an isolated Linux VM — different filesystem, PATH, processes, and tmux server, with only mounted folders shared with the host. An agent there following the skills literally hits `command not found`, misreads a healthy `doctor` whose leaves can't reach its files, and retries or reports cc-fleet as broken — observed in the field driving cc-fleet from a Cowork session via a host-executing bridge (desktop-commander). The same shape applies to any remote/cloud agent session; it differs from the same-machine codex sandbox already covered by the codex-plugin skills' "Approval & sandbox" sections.

The note is duplicated per skill (identical ~10-line blockquote in all five) because each skill loads independently; the shipped wording stays mechanism-generic ("isolated machine," "host-executing bridge") so it isn't tied to any one product — Cowork and desktop-commander are the motivating example, not the spec. No README expansion, no new shared file, no behavior change.

## Checklist

- [x] `go test -race ./...` passes
- [x] `gofmt -l .` prints nothing and `go vet ./...` is clean
- [x] `make build` compiles
- [x] If plugin/skill touched: `claude plugin validate . --strict` is green (and `make skill-drift-check` passes)
- [x] Commits follow Conventional Commits; AI-assisted commits carry a `Co-Authored-By` trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> 🤖 This PR was generated autonomously by an AI agent. A human is accountable for it: @linxule.