### PR TITLE
fix(run): reject a provider whose endpoint does not serve the Anthropic Messages API

### DIFF
--- a/cmd/cc-fleet/run.go
+++ b/cmd/cc-fleet/run.go
@@ -22,6 +22,7 @@ func newRunCmd() *cobra.Command {
 		model          string
 		permissionMode string
 		dangerSkip     bool
+		noProbe        bool
 	)
 	cmd := &cobra.Command{
 		Use:   "run [provider] [-- <claude args>]",
@@ -53,7 +54,7 @@ func newRunCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "cc-fleet run: stdin and stdout must both be a terminal for an interactive session")
 				os.Exit(1)
 			}
-			if err := run.Run(run.Request{Provider: provider, Model: model, PermissionMode: permMode, ExtraArgs: extra}); err != nil {
+			if err := run.Run(run.Request{Provider: provider, Model: model, PermissionMode: permMode, NoProbe: noProbe, ExtraArgs: extra}); err != nil {
 				fmt.Fprintln(os.Stderr, "cc-fleet run:", err)
 				os.Exit(1)
 			}
@@ -65,6 +66,8 @@ func newRunCmd() *cobra.Command {
 		"Permission mode for the session (default|acceptEdits|plan|auto|bypassPermissions)")
 	cmd.Flags().BoolVar(&dangerSkip, "dangerously-skip-permissions", false,
 		"Skip permission prompts (alias for --permission-mode bypassPermissions)")
+	cmd.Flags().BoolVar(&noProbe, "no-probe", false,
+		"Skip the pre-launch endpoint protocol check")
 	return cmd
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,6 +126,7 @@ cc-fleet run deepseek --dangerously-skip-permissions
 `cc-fleet run [provider]` replaces the current process with an interactive `claude` REPL whose backend is the provider — **omit the provider to use the fleet-wide default** (the profile pins the `apiKeyHelper` + base URL; the model is the provider's `default_model` unless `--model` overrides). Unlike spawn/subagent, this is **you** using a provider, not Claude delegating.
 
 - `--permission-mode <mode>` / `--dangerously-skip-permissions` — the session's permission posture (mutually exclusive). `run` execs the binary directly, so a `claude` shell alias that adds such a flag does not carry over — pass it here.
+- `--no-probe` — skip the pre-launch endpoint protocol check (before launching, `run` checks how an Anthropic-protocol provider's endpoint answers `POST /v1/messages`; a bare 404 — typically an OpenAI-only endpoint added as Anthropic-protocol — is rejected with a fix hint instead of claude's generic "model may not exist").
 - `-- <claude args>` — everything after `--` is forwarded to `claude`.
 
 Requires an interactive terminal. Works on Linux, macOS, and Windows.

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -126,6 +126,7 @@ cc-fleet run deepseek --dangerously-skip-permissions
 `cc-fleet run [provider]` 用一个交互式 `claude` REPL 替换当前进程,后端换成该 provider — **省略 provider 时解析到全局默认**(profile 钉住 `apiKeyHelper` + base URL;模型取 provider 的 `default_model`,`--model` 可覆盖)。与 spawn/subagent 不同,这是**你自己**在用 provider,不是 Claude 委派。
 
 - `--permission-mode <mode>` / `--dangerously-skip-permissions` — 会话权限档(互斥)。`run` 直接 exec 二进制,你给 `claude` 配的 shell 别名里的这类 flag 带不过来 — 在这里传。
+- `--no-probe` — 跳过启动前的端点协议检查(启动前 `run` 会看 Anthropic 协议 provider 的端点对 `POST /v1/messages` 的应答;回 404 且非 Anthropic 错误体的 — 典型是被当成 Anthropic 协议添加的 OpenAI-only 端点 — 会带修复提示直接拒绝,而不是让 claude 报笼统的 "model may not exist")。
 - `-- <claude args>` — `--` 之后全部转发给 `claude`。
 
 需要交互式终端。Linux、macOS、Windows 均可用。

--- a/internal/providerclass/sniff.go
+++ b/internal/providerclass/sniff.go
@@ -1,0 +1,72 @@
+package providerclass
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// messagesProbeBody is a minimal syntactically-valid Messages request. The probe
+// attaches no credentials, so an Anthropic-protocol endpoint that authenticates
+// requests rejects it at auth (401/403) without reaching a model.
+const messagesProbeBody = `{"model":"x","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`
+
+// sniffClient never follows redirects: a redirecting base_url answers with its
+// 3xx (not the redirect target's status), so a host canonicalization can't turn
+// the POST into a GET whose 404 would read as a protocol mismatch.
+var sniffClient = &http.Client{
+	CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+}
+
+// MessagesRouteMissing reports strong evidence that baseURL does not serve the
+// Anthropic Messages API: an unauthenticated POST {base}/v1/messages answering
+// HTTP 404. Status is the one usable discriminator — verified Anthropic-protocol
+// providers answer the unauthenticated probe 401/403 (auth precedes routing)
+// while OpenAI-only endpoints 404 the route, and auth-failure BODIES vary too
+// much to classify (plain text, flat JSON, OpenAI-shaped envelopes). A 404 that
+// carries an Anthropic error envelope is treated as an Anthropic endpoint after
+// all (e.g. an anonymously-reachable gateway resolving the probe's dummy
+// model), and a base_url carrying userinfo, a query, or a fragment is not
+// probed at all (the client would send its userinfo as Basic auth). Every other
+// outcome — any status, redirect, timeout, transport failure — returns false:
+// this is evidence, not proof, so the guard blocks only on the positive signal.
+func MessagesRouteMissing(baseURL string) bool {
+	u, err := url.Parse(baseURL)
+	if err != nil || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.JoinPath("v1", "messages").String(), strings.NewReader(messagesProbeBody))
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	resp, err := sniffClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		return false
+	}
+	return !anthropicErrorEnvelope(resp.Body)
+}
+
+// anthropicErrorEnvelope reports whether body is an Anthropic-format error
+// ({"type":"error","error":{...}}), reading at most a small prefix.
+func anthropicErrorEnvelope(body io.Reader) bool {
+	var e struct {
+		Type  string          `json:"type"`
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.NewDecoder(io.LimitReader(body, 4096)).Decode(&e); err != nil {
+		return false
+	}
+	return e.Type == "error" && len(e.Error) > 0
+}

--- a/internal/providerclass/sniff_test.go
+++ b/internal/providerclass/sniff_test.go
@@ -1,0 +1,139 @@
+package providerclass
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// shapeServer answers every request with status + body, echoing the shapes real
+// providers answer an unauthenticated POST /v1/messages with.
+func shapeServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// TestMessagesRouteMissing: ONLY a bare 404 is protocol-mismatch evidence.
+// Every real-provider auth-failure shape — envelope, plain text, flat JSON,
+// OpenAI-shaped — and every transport failure must pass (false).
+func TestMessagesRouteMissing(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"route 404 (openai endpoint)", http.StatusNotFound, "404 page not found", true},
+		{"401 anthropic envelope", http.StatusUnauthorized, `{"type":"error","error":{"type":"authentication_error","message":"x-api-key header is required"}}`, false},
+		{"401 plain text (deepseek shape)", http.StatusUnauthorized, "Authentication Fails (governor)", false},
+		{"403 flat json (qwen shape)", http.StatusForbidden, `{"message":"api-key is required","type":"authentication_error"}`, false},
+		{"401 openai-shaped (glm/kimi shape)", http.StatusUnauthorized, `{"error":{"message":"Incorrect API key provided","type":"incorrect_api_key_error"}}`, false},
+		{"400 bad request", http.StatusBadRequest, `{"error":"bad"}`, false},
+		{"500 server error", http.StatusInternalServerError, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := shapeServer(t, tc.status, tc.body)
+			if got := MessagesRouteMissing(s.URL); got != tc.want {
+				t.Errorf("MessagesRouteMissing(%d %q) = %v, want %v", tc.status, tc.body, got, tc.want)
+			}
+			// A trailing slash on base_url must not double the path separator.
+			if got := MessagesRouteMissing(s.URL + "/"); got != tc.want {
+				t.Errorf("MessagesRouteMissing with trailing slash = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("404 with anthropic envelope passes", func(t *testing.T) {
+		// An anonymously-reachable Anthropic-protocol gateway resolves the probe's
+		// dummy model to a genuine Anthropic 404 — that is NOT mismatch evidence.
+		s := shapeServer(t, http.StatusNotFound, `{"type":"error","error":{"type":"not_found_error","message":"model: x"}}`)
+		if MessagesRouteMissing(s.URL) {
+			t.Error("an Anthropic-enveloped 404 must not read as protocol mismatch")
+		}
+	})
+
+	t.Run("transport failure fails open", func(t *testing.T) {
+		s := shapeServer(t, http.StatusNotFound, "")
+		s.Close() // conn-refused from here on
+		if MessagesRouteMissing(s.URL) {
+			t.Error("a connection failure must not read as protocol mismatch")
+		}
+	})
+
+	t.Run("redirect is not followed into a 404", func(t *testing.T) {
+		// A canonicalizing endpoint 301s the POST; following it would GET the
+		// target (Go rewrites the method) where a 404 would false-trip. The
+		// sniff must judge the 3xx itself → pass.
+		notFound := shapeServer(t, http.StatusNotFound, "404 page not found")
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, notFound.URL+r.URL.Path, http.StatusMovedPermanently)
+		}))
+		t.Cleanup(s.Close)
+		if MessagesRouteMissing(s.URL) {
+			t.Error("a redirecting endpoint must not read as protocol mismatch")
+		}
+	})
+
+	t.Run("credential-bearing base_url is never probed", func(t *testing.T) {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Error("a base_url with userinfo/query/fragment must not be probed")
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(s.Close)
+		host := strings.TrimPrefix(s.URL, "http://")
+		for _, base := range []string{
+			"http://user:secret@" + host,
+			s.URL + "?key=secret",
+			s.URL + "#frag",
+		} {
+			if MessagesRouteMissing(base) {
+				t.Errorf("MessagesRouteMissing(%q) = true, want fail-open", base)
+			}
+		}
+	})
+
+	t.Run("escaped path segments survive the join", func(t *testing.T) {
+		// Joining must go through the URL (u.JoinPath), not u.Path — a naive
+		// Path append leaves RawPath stale, flattening %2F and probing a path
+		// the endpoint never served (a false trip on a working provider).
+		var escaped string
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			escaped = r.URL.EscapedPath()
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(s.Close)
+		MessagesRouteMissing(s.URL + "/a%2Fb")
+		if escaped != "/a%2Fb/v1/messages" {
+			t.Errorf("probed escaped path %q, want /a%%2Fb/v1/messages", escaped)
+		}
+	})
+
+	t.Run("probe shape: POST /v1/messages, versioned, no credentials", func(t *testing.T) {
+		var method, path, version, auth, apiKey string
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			method, path = r.Method, r.URL.Path
+			version = r.Header.Get("anthropic-version")
+			auth = r.Header.Get("Authorization")
+			apiKey = r.Header.Get("x-api-key")
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(s.Close)
+		MessagesRouteMissing(s.URL + "/anthropic")
+		if method != http.MethodPost || path != "/anthropic/v1/messages" {
+			t.Errorf("probed %s %s, want POST /anthropic/v1/messages", method, path)
+		}
+		if version == "" {
+			t.Error("probe must carry anthropic-version")
+		}
+		if auth != "" || apiKey != "" {
+			t.Errorf("probe must carry no credentials, got Authorization=%q x-api-key=%q", auth, apiKey)
+		}
+	})
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -18,17 +18,20 @@ import (
 	"github.com/ethanhq/cc-fleet/internal/ids"
 	"github.com/ethanhq/cc-fleet/internal/permmode"
 	"github.com/ethanhq/cc-fleet/internal/profile"
+	"github.com/ethanhq/cc-fleet/internal/providerclass"
 )
 
 // Request is a lane-0 launch request. Model overrides the provider's default_model
 // when non-empty; PermissionMode is a validated permmode value — "" means the
 // caller passed no permission flag, so Run falls back to the provider's configured
-// default_permission (itself possibly "" → no permission flag); ExtraArgs are
-// passed through to claude after cc-fleet's flags.
+// default_permission (itself possibly "" → no permission flag); NoProbe skips the
+// pre-launch endpoint protocol check; ExtraArgs are passed through to claude after
+// cc-fleet's flags.
 type Request struct {
 	Provider       string
 	Model          string
 	PermissionMode string
+	NoProbe        bool
 	ExtraArgs      []string
 }
 
@@ -36,6 +39,14 @@ type Request struct {
 // permission flags itself (before the passthrough). Repeating one in the
 // passthrough would shadow the managed value, so it is rejected up front.
 var reservedFlags = []string{"--settings", "--model", "--permission-mode", "--dangerously-skip-permissions"}
+
+// sniffMessagesRoute and ensureDaemon are seams so tests stay hermetic: the
+// suite must neither touch the network nor let EnsureForProvider start a
+// daemon from os.Executable() — which, in a test, is the test binary itself.
+var (
+	sniffMessagesRoute = providerclass.MessagesRouteMissing
+	ensureDaemon       = codexproxy.EnsureForProvider
+)
 
 // resolveBinary returns the live claude binary path via the same gate spawn and
 // subagent use (bundled-or-cached recipe → resolve → validate). It is a seam so
@@ -95,10 +106,23 @@ func Run(req Request) error {
 		return err
 	}
 
+	// Protocol guard: an Anthropic-protocol provider whose endpoint 404s
+	// POST /v1/messages (an OpenAI-only endpoint added under the Anthropic
+	// "Custom" option) would exec a claude that can only render its generic
+	// "model may not exist" — cc-fleet leaves the process image at exec and can
+	// never rewrite it, so this is the last point an actionable error exists.
+	// The sniff trips only on that positive signal and fails open on everything
+	// else. The error never echoes the base_url: a path segment may embed a
+	// credential, and this text is exactly what a user pastes into an issue.
+	if !req.NoProbe && v.EffectiveProtocol() == "" && sniffMessagesRoute(v.BaseURL) {
+		return fmt.Errorf("provider %q is configured as an Anthropic-protocol provider, but its endpoint answered HTTP 404 to POST /v1/messages — it likely speaks the OpenAI protocol; re-add the provider with an OpenAI protocol, or pass --no-probe to skip this check",
+			req.Provider)
+	}
+
 	// For a codex provider, ensure the conversion daemon is up before the profile
 	// write (and before the exec that replaces this process — there is no
 	// after-exec hook), fail-before-mutation.
-	if err := codexproxy.EnsureForProvider(v, nil); err != nil {
+	if err := ensureDaemon(v, nil); err != nil {
 		return fmt.Errorf("codex proxy unavailable: %w", err)
 	}
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethanhq/cc-fleet/internal/config"
+	"github.com/ethanhq/cc-fleet/internal/diag"
 	"github.com/ethanhq/cc-fleet/internal/fingerprint"
 )
 
@@ -18,18 +19,25 @@ type launch struct {
 	argv, env []string
 }
 
-// stubSeams swaps resolveBinary + execClaude for the test and returns the
-// capture. binErr != nil makes binary resolution fail (no exec should happen).
+// stubSeams swaps resolveBinary + execClaude + sniffMessagesRoute + ensureDaemon
+// for the test and returns the capture. binErr != nil makes binary resolution
+// fail (no exec should happen). The sniff stub never trips and the ensure stub
+// is a no-op, keeping the suite off the network and off os.Executable() (which
+// EnsureForProvider would otherwise start as a daemon — the test binary itself).
 func stubSeams(t *testing.T, binPath string, binErr error) *launch {
 	t.Helper()
 	got := &launch{}
-	origResolve, origExec := resolveBinary, execClaude
+	origResolve, origExec, origSniff, origEnsure := resolveBinary, execClaude, sniffMessagesRoute, ensureDaemon
 	resolveBinary = func() (string, error) { return binPath, binErr }
 	execClaude = func(_ *config.Provider, bin string, argv, env []string) error {
 		got.called, got.bin, got.argv, got.env = true, bin, argv, env
 		return nil
 	}
-	t.Cleanup(func() { resolveBinary, execClaude = origResolve, origExec })
+	sniffMessagesRoute = func(string) bool { return false }
+	ensureDaemon = func(*config.Provider, *diag.Logger) error { return nil }
+	t.Cleanup(func() {
+		resolveBinary, execClaude, sniffMessagesRoute, ensureDaemon = origResolve, origExec, origSniff, origEnsure
+	})
 	return got
 }
 
@@ -178,6 +186,90 @@ func TestRun_GatesFailBeforeExec(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRun_ProtocolGuard: the pre-exec sniff blocks an Anthropic-protocol
+// provider whose endpoint 404s POST /v1/messages, and ONLY that — the guard
+// is skipped for --no-probe and daemon-backed providers, and a non-tripping
+// sniff launches normally.
+func TestRun_ProtocolGuard(t *testing.T) {
+	t.Run("trip blocks before exec", func(t *testing.T) {
+		seedProvider(t, "deepseek", true, "deepseek-chat")
+		got := stubSeams(t, "/fake/claude", nil)
+		var probed string
+		sniffMessagesRoute = func(base string) bool { probed = base; return true }
+
+		err := Run(Request{Provider: "deepseek"})
+		if err == nil || !strings.Contains(err.Error(), "HTTP 404 to POST /v1/messages") {
+			t.Fatalf("err = %v, want protocol-mismatch error", err)
+		}
+		for _, want := range []string{"deepseek", "--no-probe"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q lacks %q", err, want)
+			}
+		}
+		// The base_url never appears in the error — a path segment may embed a
+		// credential and the message is exactly what a user pastes into an issue.
+		if strings.Contains(err.Error(), "api.deepseek.example") {
+			t.Errorf("error %q echoes the base_url", err)
+		}
+		if probed != "https://api.deepseek.example/anthropic" {
+			t.Errorf("sniffed %q, want the provider base_url", probed)
+		}
+		if got.called {
+			t.Fatal("a tripped guard reached exec")
+		}
+	})
+
+	t.Run("no trip execs", func(t *testing.T) {
+		seedProvider(t, "deepseek", true, "deepseek-chat")
+		got := stubSeams(t, "/fake/claude", nil)
+		sniffMessagesRoute = func(string) bool { return false }
+
+		if err := Run(Request{Provider: "deepseek"}); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if !got.called {
+			t.Fatal("execClaude was not called")
+		}
+	})
+
+	t.Run("--no-probe skips the sniff", func(t *testing.T) {
+		seedProvider(t, "deepseek", true, "deepseek-chat")
+		got := stubSeams(t, "/fake/claude", nil)
+		sniffMessagesRoute = func(string) bool { t.Error("sniff must not run under NoProbe"); return true }
+
+		if err := Run(Request{Provider: "deepseek", NoProbe: true}); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if !got.called {
+			t.Fatal("execClaude was not called")
+		}
+	})
+
+	t.Run("daemon-backed provider skips the sniff", func(t *testing.T) {
+		seedProvider(t, "deepseek", true, "deepseek-chat")
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("config.Load: %v", err)
+		}
+		v := cfg.Providers["deepseek"]
+		v.Protocol = config.ProtocolOpenAIChat
+		v.BaseURL = "http://127.0.0.1:17997/"
+		v.UpstreamURL = "https://api.openai.example/v1"
+		if err := config.Save(cfg); err != nil {
+			t.Fatalf("config.Save: %v", err)
+		}
+		got := stubSeams(t, "/fake/claude", nil)
+		sniffMessagesRoute = func(string) bool { t.Error("sniff must not run for a daemon-backed provider"); return true }
+
+		if err := Run(Request{Provider: "deepseek"}); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if !got.called {
+			t.Fatal("execClaude was not called")
+		}
+	})
 }
 
 func TestBuildArgv(t *testing.T) {


### PR DESCRIPTION
An OpenAI-only endpoint (NVIDIA, Gemini, api.openai.com) added under the Anthropic-protocol "Custom" option passes the add-time models probe — the models endpoint parses identically for both protocols — and `ccf run` then execs claude pointed straight at it. claude POSTs the Anthropic Messages API to an endpoint that does not serve it and renders its generic "There's an issue with the selected model… It may not exist", while cc-fleet has already left the process image at the exec and can no longer explain the real cause. The conversion daemon is never in this path (an Anthropic-protocol provider is not daemon-backed), so no daemon-side error shaping can reach it either.

`run` now checks the endpoint before the exec — the last point where an actionable error can exist: an unauthenticated `POST {base_url}/v1/messages` capped at ~3s. The launch is rejected only on the one discriminating signal, an HTTP 404 whose body is not an Anthropic error envelope, with a message that names the mismatch and the fix (re-add the provider under an OpenAI protocol, or pass `--no-probe`). Everything else fails open — any other status, a redirect (never followed), a timeout, a transport failure — so a working provider is never blocked. The probe attaches no credentials; a base_url carrying userinfo, a query, or a fragment is never probed; and the error never echoes the base_url, since a path segment may embed a credential and this text is exactly what gets pasted into an issue. The discriminator held against real endpoints: NVIDIA, api.openai.com, and Gemini's OpenAI surface all answer the probe with a bare 404, while api.anthropic.com, MiniMax, DeepSeek, Qwen, GLM, and Kimi answer 401/403 in wildly different body shapes — which is why status rather than body shape decides, and why an enveloped 404 (an anonymously reachable Anthropic gateway resolving the probe's dummy model) passes.

The guard runs only for Anthropic-protocol providers — daemon-backed `openai-*` / `codex` providers skip it — and before any side effect (daemon ensure, profile write, exec). `--no-probe` skips the check and is documented in `docs/cli.md` (en + zh). A daemon-side 404→`not_found_error` mapping was considered and deliberately left out: how claude renders that envelope cannot be verified from this repo, and a wrong-route upstream 404 would mislabel as model-missing.

Testing: unit tables for the sniff (every real-provider auth-failure shape, the enveloped 404, redirects, credential-bearing URLs, `%2F`-escaped path joins, and the probe shape — POST, `anthropic-version`, no credentials) and for the run guard (trip / pass / `--no-probe` / daemon-backed skip, via the package's existing seam style); the full `-race` suite is green. Live end-to-end: a misconfigured NVIDIA row is rejected with the new message and no claude launch, a real MiniMax provider passes the guard into an interactive claude, `--no-probe` boots claude against the misconfigured row, and a codex-provider run carried a real billed message end to end.

Closes #98
