### PR TITLE
fix(workflow): classify a stopped run as stopped at quiescence, not as a deadlock

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) — even your Codex subscription — as real Claude Code workflows, agent-team teammates, or one-shot subagents, driven exactly like native ones. Your main session's own auth is untouched (OAuth subscription or API key, either works); API-key providers bill the provider key via apiKeyHelper, while a Codex subscription bills through a local OAuth daemon — each worker receives its credential on demand, never through its env or argv. Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-fleet",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Fan out provider LLM subagents and multi-phase JS workflows from Codex via the cc-fleet CLI — DeepSeek / GLM / Kimi / Qwen / MiniMax, or your Codex/Claude subscription. Each worker receives its credential on demand, never through its env or argv. Requires the cc-fleet and claude binaries on PATH (installed separately).",
   "author": {
     "name": "Ethan Guo",

--- a/internal/workflow/builtins.go
+++ b/internal/workflow/builtins.go
@@ -87,9 +87,10 @@ type engine struct {
 	vm            *goja.Runtime
 	cbs           chan leafCB
 	loopDone      chan struct{}
-	inflight      int  // leaves spawned but not yet completed
-	aborted       bool // drain state-only; no more JS runs
-	stopped       bool // the run ctx was cancelled (finalizes "stopped", not "failed")
+	inflight      int   // leaves spawned but not yet completed
+	aborted       bool  // drain state-only; no more JS runs
+	stopped       bool  // the run ctx was cancelled (finalizes "stopped", not "failed")
+	settleErr     error // first severed promise settlement (goja dropped the reaction jobs); the run error unless stopped wins
 	runCtx        context.Context
 	leafCtx       context.Context // child of runCtx; cancelled on abort → leaf execs die promptly
 	cancelLeaves  context.CancelFunc
@@ -472,8 +473,8 @@ func (e *engine) jsAgent(call goja.FunctionCall) goja.Value {
 	h := &leafCtl{
 		spec: spec,
 		settle: promiseSettle{
-			resolve: func(v goja.Value) { resolve(v) },
-			reject:  func(v goja.Value) { reject(v) },
+			resolve: func(v goja.Value) { e.noteSettleErr(resolve(v)) },
+			reject:  func(v goja.Value) { e.noteSettleErr(reject(v)) },
 		},
 		gen: 1,
 	}

--- a/internal/workflow/loop.go
+++ b/internal/workflow/loop.go
@@ -24,6 +24,10 @@ type leafCB struct {
 // e.g. `await new Promise(() => {})`.
 var errNoProgress = errors.New("workflow: the script awaits a promise nothing will ever settle (no leaf in flight; the runtime has no timers)")
 
+// errRunStopped classifies a cooperatively-stopped run; the caller finalizes the
+// manifest "stopped", not "failed".
+var errRunStopped = errors.New("workflow: run stopped")
+
 // post hands a callback from a leaf goroutine to the loop. It never strands a
 // goroutine past the loop's lifetime: loopDone unblocks stragglers after an abnormal
 // loop exit (the run is already finalizing; their job files hold the terminal truth).
@@ -74,6 +78,17 @@ func (e *engine) drive(prom *goja.Promise) (goja.Value, error) {
 			case cb := <-e.cbs:
 				e.runCB(cb)
 			default:
+				// With zero leaves the loop never blocks on the ctx.Done select
+				// below, so this is the ONLY point a stop of a leafless pending
+				// script (e.g. `await new Promise(() => {})` then cancelled) gets
+				// classified — and the backstop for any settle stranded outside
+				// noteSettleErr's reach. The cancelled ctx decides "stopped" here
+				// exactly as at the loop exit; on a live ctx a quiescent pending
+				// promise remains a proven deadlock.
+				if e.stopped || e.runCtx.Err() != nil {
+					e.stopped = true
+					return nil, errRunStopped
+				}
 				return nil, errNoProgress
 			}
 			continue
@@ -91,7 +106,13 @@ func (e *engine) drive(prom *goja.Promise) (goja.Value, error) {
 	// (with its stopped-class rejection) before the loop sees ctx.Done().
 	if e.stopped || e.runCtx.Err() != nil {
 		e.stopped = true
-		return nil, errors.New("workflow: run stopped")
+		return nil, errRunStopped
+	}
+	// A severed settlement on a live ctx (e.g. a stack overflow tripping the VM
+	// mid-cascade) left the script unrecoverable, possibly with the promise still
+	// pending — the recorded cause is the run error, never a nil result.
+	if e.settleErr != nil {
+		return nil, e.settleErr
 	}
 	if prom.State() == goja.PromiseStateRejected {
 		return nil, rejectionError(prom.Result())
@@ -110,6 +131,25 @@ func (e *engine) abort() {
 	e.aborted = true
 	e.releaseHeld()
 	e.cancelLeaves()
+}
+
+// noteSettleErr handles the error goja's promise resolve/reject return (their
+// documented propagate-upwards contract). A non-nil error means an uncatchable — an
+// Interrupt, a stack overflow — tripped the settle's reaction drain and goja dropped
+// the queued jobs: the script's await graph is unrecoverable, so the run aborts with
+// the cause in hand instead of stranding into a false deadlock at quiescence.
+// Loop-held: settles run only in js halves, and abort's callees touch no JS.
+func (e *engine) noteSettleErr(err error) {
+	if err == nil {
+		return
+	}
+	if e.settleErr == nil {
+		e.settleErr = fmt.Errorf("workflow: promise settlement interrupted: %w", err)
+	}
+	if e.runCtx.Err() != nil {
+		e.stopped = true
+	}
+	e.abort()
 }
 
 // drainLeaves cancels and consumes every in-flight leaf state-only — the abnormal-exit

--- a/internal/workflow/runcontrol_test.go
+++ b/internal/workflow/runcontrol_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -65,5 +66,97 @@ func TestStopRunUniformlyStopped(t *testing.T) {
 				t.Fatalf("iter %d: job %s status = %q, want stopped (uniform — never failed, never stranded)", i, j.JobID, j.Status)
 			}
 		}
+	}
+}
+
+// TestDriveClassifiesStoppedAtQuiescence (W-stop-quiescence): a cancelled run whose
+// script promise is stranded pending reaches drive's quiescence branch — inflight 0,
+// queue empty, promise pending — and must classify "stopped", never a false
+// deadlock. The harness hands drive that exact quiescent state directly, so the
+// misclassification would reproduce on every run, not once per thousand schedules.
+func TestDriveClassifiesStoppedAtQuiescence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the run ctx is already dead at quiescence
+	eng := newTestEngine(ctx, "quiesce", 1)
+	if err := eng.setupVM(); err != nil {
+		t.Fatalf("setupVM: %v", err)
+	}
+	prom, _, _ := eng.vm.NewPromise() // pending; nothing will ever settle it
+
+	_, err := eng.drive(prom)
+	if err == nil || !strings.Contains(err.Error(), "run stopped") {
+		t.Fatalf("err = %v, want run stopped (a cancelled ctx decides stopped at every exit)", err)
+	}
+	if !eng.stopped {
+		t.Fatal("drive must set stopped so the finalizer stamps the manifest stopped")
+	}
+}
+
+// TestDriveGenuineDeadlockStillDetected: the inverse pin — on a LIVE ctx a quiescent
+// pending promise is a proven deadlock and keeps failing with errNoProgress.
+func TestDriveGenuineDeadlockStillDetected(t *testing.T) {
+	eng := newTestEngine(context.Background(), "deadlock", 1)
+	if err := eng.setupVM(); err != nil {
+		t.Fatalf("setupVM: %v", err)
+	}
+	prom, _, _ := eng.vm.NewPromise()
+
+	_, err := eng.drive(prom)
+	if !errors.Is(err, errNoProgress) {
+		t.Fatalf("err = %v, want errNoProgress (genuine deadlock detection must survive)", err)
+	}
+}
+
+// TestSeveredSettleAbortsWithCause (W-settle-sever): an uncatchable that fires inside
+// a promise settle severs goja's reaction drain (the queued jobs are dropped and the
+// interrupt is consumed) — the run must abort with that cause as the run error, not
+// strand into the deadlock text. The interrupt is planted while the loop is provably
+// parked in drive (a probe cb consumed on the loop proves the script body's JS is
+// done), so the first JS after the flag is deterministically the settle's reaction
+// job.
+func TestSeveredSettleAbortsWithCause(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var started atomic.Bool
+	gate := make(chan struct{})
+	old := runLeaf
+	runLeaf = func(ctx context.Context, req subagent.Request) subagent.Result {
+		started.Store(true)
+		<-gate
+		return subagent.Result{OK: true, Result: "done"}
+	}
+	t.Cleanup(func() { runLeaf = old })
+	oldR := resolveProfile
+	resolveProfile = func(requested string) (string, string) { return requested, "" }
+	t.Cleanup(func() { resolveProfile = oldR })
+
+	eng := newTestEngine(context.Background(), "sever", 1) // live ctx: no cancel anywhere
+	src := `return await parallel([() => agent("a", {provider: "v"})]);`
+	done := make(chan error, 1)
+	go func() {
+		_, err := eng.run("s.js", []byte(src), Options{})
+		done <- err
+	}()
+	for !started.Load() {
+		time.Sleep(time.Millisecond)
+	}
+	// started only proves the leaf goroutine ran — the loop may still be finishing
+	// the script body's JS, where the interrupt would exit via the callErr path
+	// instead. A probe cb consumed on the loop proves drive is live.
+	probe := make(chan struct{})
+	eng.post(leafCB{state: func() { close(probe) }})
+	<-probe
+	eng.vm.Interrupt("severed") // sticky flag; trips on the settle's first reaction job
+	close(gate)
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "settlement interrupted") {
+			t.Fatalf("err = %v, want the severed-settlement cause as the run error", err)
+		}
+		if errors.Is(err, errNoProgress) {
+			t.Fatal("a severed settlement must not report as a deadlock")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return after the severed settle")
 	}
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
Cancelling a run could misreport as a deadlock. The watchdog interrupts the VM when the run ctx dies, and that sticky interrupt races the loop's own promise settles: when a settle's reaction job trips the flag, goja drops the whole queued reaction cascade (severing `Promise.all`'s accounting) and consumes the interrupt, while the engine's settle wrappers discarded the error goja's resolve/reject return — its documented signal that exactly this happened. The run then reached quiescence with the script promise stranded pending, and the deadlock check returned "the script awaits a promise nothing will ever settle" without consulting the cancelled ctx. A cooperative stop classified as a deadlock; in the foreground Ctrl-C and direct-SIGTERM lanes, where nothing rewrites the manifest afterwards, the run durably finalized `failed` instead of `stopped`. This is the root cause of the intermittent `TestStopRunUniformlyStopped` failure on macOS CI, whose slow runners realize the multi-condition window.

Two layers close it. The quiescence branch now applies the same arbitration as the loop exit — a cancelled ctx decides "stopped", while a pending promise on a live ctx remains a proven deadlock; with zero leaves the loop never blocks on the ctx select, so this branch is also the only point a stop of a leafless pending script (`await new Promise(() => {})`) gets classified. And the settle wrappers now propagate goja's error: a severed settlement immediately aborts the run with the cause recorded, which the exit returns after the stopped arbitration and before the rejection checks — so a stop-severed run reports "stopped", a live-ctx uncatchable (e.g. a stack overflow mid-cascade) surfaces as the real error, and the previous fall-through that could return a nil result for a still-pending promise is closed.

Both defects are pinned by deterministic regressions that fail pre-fix on every run with the exact production error text: one hands `drive` the race's quiescent product directly (pre-cancelled ctx, hand-minted pending promise), the other plants the sticky interrupt while the loop is provably parked (a probe callback consumed on the loop) so the sever lands on the settle's reaction job every time. A third test pins that genuine deadlock detection on a live ctx is unchanged. Stress: the original test at `-race -count=25` (500 cancel races) plus a `GOMAXPROCS=2` run; the held/ctl lanes (`TestLeafDirectiveEdges`, ctl poller) at `-count=20`; the full `-race` suite; windows and darwin cross-compiles — all green. Held semantics are untouched: held and phase-parked leaves keep the in-flight count above zero, so the quiescence branch is unreachable while anything is held.

The v0.3.2 release prep rides along as its own commit: `.claude-plugin/plugin.json`, the codex-plugin manifest, and `npm/package.json` move to 0.3.2, and version-guard is green against the v0.3.2 tag.