### PR TITLE
docs(skills): environment-awareness note in the lane skills (lands #99)

### DIFF
--- a/codex-plugin/skills/subagent/SKILL.md
+++ b/codex-plugin/skills/subagent/SKILL.md
@@ -9,6 +9,18 @@ description: Fan out a one-shot or flat parallel batch of cc-fleet PROVIDER suba
 
 When this skill cites `cc-fleet-shared/<file>.md`, read `../cc-fleet-shared/<file>.md` relative to this SKILL.md (load-bearing, not optional background).
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 `cc-fleet subagent` runs a provider model headless and returns the result directly on your shell's stdout — no tmux pane, no team, no locks. A one-shot provider agent whose model can be a provider id. It reuses the same provider selection and fingerprint gate as the rest of cc-fleet. It's the lightweight synchronous branch.
 
 **Preflight (first fan-out per session).** Run `cc-fleet doctor --json` once and read the per-check results. The ONLY hard stops are the **claude binary** check and the **fingerprint** check (the worker engine) — if either fails, tell the user to install or fix Claude Code, and stop. Do **not** stop on the "all configured providers' keys reachable" check: it aggregates every enabled provider, so one unrelated provider — especially a daemon-backed `codex` / `openai-*`, whose loopback proxy is only up during a spawn — flips `ok:false` / exit 1 while your target provider is fine. Provider API keys are configured separately in cc-fleet, so a provider model needs the claude **binary** but not a Claude subscription. To check the provider you'll actually use, run `cc-fleet models <provider> --json` (`PROVIDER_UNKNOWN` ⇒ not configured); that confirms it's configured + enabled, not that it's reachable — the run itself proves reachability.

--- a/codex-plugin/skills/subagent/SKILL.md
+++ b/codex-plugin/skills/subagent/SKILL.md
@@ -9,17 +9,7 @@ description: Fan out a one-shot or flat parallel batch of cc-fleet PROVIDER suba
 
 When this skill cites `cc-fleet-shared/<file>.md`, read `../cc-fleet-shared/<file>.md` relative to this SKILL.md (load-bearing, not optional background).
 
-> **Execution environment — check before running anything.** Confirm your shell
-> tool executes on the host where cc-fleet is installed. In sandboxed or remote
-> agent sessions, a tool named Bash may run on an isolated machine with a
-> different filesystem, PATH, processes, and tmux server — `command not found`,
-> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
-> working directory usually means you are in a sandbox shell, not that cc-fleet
-> is broken. Route commands through a host-executing bridge tool (for example,
-> desktop-commander) and pass host paths for any files you reference; do not
-> retry the same Bash call expecting different results. If no host-executing
-> tool is available, stop and explain that cc-fleet must run on its
-> installation host.
+> **Execution environment — check before running anything.** Confirm this shell runs on the machine where cc-fleet is installed. In a remote or split-host agent session the shell can run on a separate machine with its own filesystem and PATH, so `cc-fleet: command not found` or a wrong working directory can indicate that the shell is running on the wrong machine, not that cc-fleet is broken — route commands through a host-executing bridge and pass host paths for the files you reference, and stop cleanly if no such bridge exists. (Different-machine case only; for the same-machine codex sandbox — a clean `doctor` but network-blocked leaves — see Approval & sandbox below.)
 
 `cc-fleet subagent` runs a provider model headless and returns the result directly on your shell's stdout — no tmux pane, no team, no locks. A one-shot provider agent whose model can be a provider id. It reuses the same provider selection and fingerprint gate as the rest of cc-fleet. It's the lightweight synchronous branch.
 

--- a/codex-plugin/skills/workflow/SKILL.md
+++ b/codex-plugin/skills/workflow/SKILL.md
@@ -9,6 +9,18 @@ description: Orchestrate a MULTI-PHASE, dependent, or resumable run over many cc
 
 When this skill cites `cc-fleet-shared/<file>.md`, read the file at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 A **workflow** is a JavaScript script that fans out provider `cc-fleet subagent` leaves and runs in a **cc-fleet process, OFF the main session's context**. You write the script; `cc-fleet workflow run` executes it. The orchestration plan lives in script variables (CPU, ~0 of your tokens) — you are invoked only when *authoring* the script, not on every scheduling decision. The API mirrors the native Claude Code Workflow tool — write the script exactly as you would a native workflow; the only addition is the `provider` option on `agent()`.
 
 ## Preflight (once per session)

--- a/codex-plugin/skills/workflow/SKILL.md
+++ b/codex-plugin/skills/workflow/SKILL.md
@@ -9,17 +9,7 @@ description: Orchestrate a MULTI-PHASE, dependent, or resumable run over many cc
 
 When this skill cites `cc-fleet-shared/<file>.md`, read the file at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
-> **Execution environment — check before running anything.** Confirm your shell
-> tool executes on the host where cc-fleet is installed. In sandboxed or remote
-> agent sessions, a tool named Bash may run on an isolated machine with a
-> different filesystem, PATH, processes, and tmux server — `command not found`,
-> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
-> working directory usually means you are in a sandbox shell, not that cc-fleet
-> is broken. Route commands through a host-executing bridge tool (for example,
-> desktop-commander) and pass host paths for any files you reference; do not
-> retry the same Bash call expecting different results. If no host-executing
-> tool is available, stop and explain that cc-fleet must run on its
-> installation host.
+> **Execution environment — check before running anything.** Confirm this shell runs on the machine where cc-fleet is installed. In a remote or split-host agent session the shell can run on a separate machine with its own filesystem and PATH, so `cc-fleet: command not found` or a wrong working directory can indicate that the shell is running on the wrong machine, not that cc-fleet is broken — route commands through a host-executing bridge and pass host paths for the files you reference, and stop cleanly if no such bridge exists. (Different-machine case only; for the same-machine codex sandbox — a clean `doctor` but network-blocked leaves — see Approval & sandbox below.)
 
 A **workflow** is a JavaScript script that fans out provider `cc-fleet subagent` leaves and runs in a **cc-fleet process, OFF the main session's context**. You write the script; `cc-fleet workflow run` executes it. The orchestration plan lives in script variables (CPU, ~0 of your tokens) — you are invoked only when *authoring* the script, not on every scheduling decision. The API mirrors the native Claude Code Workflow tool — write the script exactly as you would a native workflow; the only addition is the `provider` option on `agent()`.
 

--- a/skills/subagent/SKILL.md
+++ b/skills/subagent/SKILL.md
@@ -9,6 +9,18 @@ description: Run a one-shot or flat parallel batch of provider LLM subagents (he
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 `cc-fleet subagent` runs a provider model headless and returns the result directly on Bash stdout — **no** tmux pane, **no** `TeamCreate`/`SendMessage`/`TeamDelete`. The analog of the native `Agent`/`Task` tool, but the model can be a provider id. It reuses the same provider selection and the same fingerprint self-heal flow as spawn (cc-fleet-shared/troubleshooting.md). It's the lightweight synchronous branch.
 
 ## When to use it

--- a/skills/subagent/SKILL.md
+++ b/skills/subagent/SKILL.md
@@ -9,17 +9,7 @@ description: Run a one-shot or flat parallel batch of provider LLM subagents (he
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
-> **Execution environment — check before running anything.** Confirm your shell
-> tool executes on the host where cc-fleet is installed. In sandboxed or remote
-> agent sessions, a tool named Bash may run on an isolated machine with a
-> different filesystem, PATH, processes, and tmux server — `command not found`,
-> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
-> working directory usually means you are in a sandbox shell, not that cc-fleet
-> is broken. Route commands through a host-executing bridge tool (for example,
-> desktop-commander) and pass host paths for any files you reference; do not
-> retry the same Bash call expecting different results. If no host-executing
-> tool is available, stop and explain that cc-fleet must run on its
-> installation host.
+> **Execution environment — check before running anything.** Confirm your shell tool executes on the host where cc-fleet is installed. In sandboxed or remote agent sessions, a tool named Bash may run on an isolated machine with a different filesystem, PATH, processes, and tmux server — `command not found`, a healthy-looking `doctor` whose leaves can't reach your files, or a wrong working directory should prompt you to verify whether you are in a sandbox shell, not conclude that cc-fleet is broken. If so, route commands through a host-executing bridge tool (for example, desktop-commander) and pass host paths for any files you reference; do not retry the same Bash call expecting different results. If no host-executing tool is available, stop and explain that cc-fleet must run on its installation host.
 
 `cc-fleet subagent` runs a provider model headless and returns the result directly on Bash stdout — **no** tmux pane, **no** `TeamCreate`/`SendMessage`/`TeamDelete`. The analog of the native `Agent`/`Task` tool, but the model can be a provider id. It reuses the same provider selection and the same fingerprint self-heal flow as spawn (cc-fleet-shared/troubleshooting.md). It's the lightweight synchronous branch.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -11,6 +11,18 @@ Run a third-party provider model as a real Claude Code teammate in a tmux pane: 
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 **Precondition — agent-teams must be ON:** check your own tool list for `SendMessage` / `TeamCreate`; absent → do NOT spawn (an unmessageable pane bills the provider with no work) — enablement + fallback in cc-fleet-shared/routing.md.
 
 ---

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -11,17 +11,7 @@ Run a third-party provider model as a real Claude Code teammate in a tmux pane: 
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
-> **Execution environment — check before running anything.** Confirm your shell
-> tool executes on the host where cc-fleet is installed. In sandboxed or remote
-> agent sessions, a tool named Bash may run on an isolated machine with a
-> different filesystem, PATH, processes, and tmux server — `command not found`,
-> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
-> working directory usually means you are in a sandbox shell, not that cc-fleet
-> is broken. Route commands through a host-executing bridge tool (for example,
-> desktop-commander) and pass host paths for any files you reference; do not
-> retry the same Bash call expecting different results. If no host-executing
-> tool is available, stop and explain that cc-fleet must run on its
-> installation host.
+> **Execution environment — check before running anything.** Confirm your shell tool executes on the host where cc-fleet is installed. In sandboxed or remote agent sessions, a tool named Bash may run on an isolated machine with a different filesystem, PATH, processes, and tmux server — `command not found`, a healthy-looking `doctor` whose leaves can't reach your files, or a wrong working directory should prompt you to verify whether you are in a sandbox shell, not conclude that cc-fleet is broken. If so, route commands through a host-executing bridge tool (for example, desktop-commander) and pass host paths for any files you reference; do not retry the same Bash call expecting different results. If no host-executing tool is available, stop and explain that cc-fleet must run on its installation host.
 
 **Precondition — agent-teams must be ON:** check your own tool list for `SendMessage` / `TeamCreate`; absent → do NOT spawn (an unmessageable pane bills the provider with no work) — enablement + fallback in cc-fleet-shared/routing.md.
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -9,6 +9,18 @@ description: Orchestrate a MULTI-PHASE, dependent, or resumable run over many pr
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
+> **Execution environment — check before running anything.** Confirm your shell
+> tool executes on the host where cc-fleet is installed. In sandboxed or remote
+> agent sessions, a tool named Bash may run on an isolated machine with a
+> different filesystem, PATH, processes, and tmux server — `command not found`,
+> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
+> working directory usually means you are in a sandbox shell, not that cc-fleet
+> is broken. Route commands through a host-executing bridge tool (for example,
+> desktop-commander) and pass host paths for any files you reference; do not
+> retry the same Bash call expecting different results. If no host-executing
+> tool is available, stop and explain that cc-fleet must run on its
+> installation host.
+
 A **workflow** is a JavaScript script that fans out provider `cc-fleet subagent` leaves and runs in a **cc-fleet process, OFF the main session's context**. You write the script; `cc-fleet workflow run` executes it. The orchestration plan lives in script variables (CPU, ~0 of your tokens) — you are invoked only when *authoring* the script, not on every scheduling decision. The API mirrors the native Claude Code Workflow tool — write the script exactly as you would a native workflow; the only addition is the `provider` option on `agent()`.
 
 ## When to use it

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -9,17 +9,7 @@ description: Orchestrate a MULTI-PHASE, dependent, or resumable run over many pr
 
 When this skill cites `cc-fleet-shared/<file>.md`, OPEN it with the Read tool at `../cc-fleet-shared/<file>.md` relative to this SKILL.md — the cited content is load-bearing, not optional background.
 
-> **Execution environment — check before running anything.** Confirm your shell
-> tool executes on the host where cc-fleet is installed. In sandboxed or remote
-> agent sessions, a tool named Bash may run on an isolated machine with a
-> different filesystem, PATH, processes, and tmux server — `command not found`,
-> a healthy-looking `doctor` whose leaves can't reach your files, or a wrong
-> working directory usually means you are in a sandbox shell, not that cc-fleet
-> is broken. Route commands through a host-executing bridge tool (for example,
-> desktop-commander) and pass host paths for any files you reference; do not
-> retry the same Bash call expecting different results. If no host-executing
-> tool is available, stop and explain that cc-fleet must run on its
-> installation host.
+> **Execution environment — check before running anything.** Confirm your shell tool executes on the host where cc-fleet is installed. In sandboxed or remote agent sessions, a tool named Bash may run on an isolated machine with a different filesystem, PATH, processes, and tmux server — `command not found`, a healthy-looking `doctor` whose leaves can't reach your files, or a wrong working directory should prompt you to verify whether you are in a sandbox shell, not conclude that cc-fleet is broken. If so, route commands through a host-executing bridge tool (for example, desktop-commander) and pass host paths for any files you reference; do not retry the same Bash call expecting different results. If no host-executing tool is available, stop and explain that cc-fleet must run on its installation host.
 
 A **workflow** is a JavaScript script that fans out provider `cc-fleet subagent` leaves and runs in a **cc-fleet process, OFF the main session's context**. You write the script; `cc-fleet workflow run` executes it. The orchestration plan lives in script variables (CPU, ~0 of your tokens) — you are invoked only when *authoring* the script, not on every scheduling decision. The API mirrors the native Claude Code Workflow tool — write the script exactly as you would a native workflow; the only addition is the `provider` option on `agent()`.
 


### PR DESCRIPTION
Lands #99 (thanks @linxule) with a follow-up adaptation, as two commits: the first is the original commit cherry-picked with authorship preserved, the second adjusts the note's shape and its codex-plugin copies.

The note itself is a real catch: in a sandboxed or remote agent session (e.g. Claude Cowork's isolated VM) the shell tool can execute on a different machine than the cc-fleet installation, and an agent following the lane skills literally misreads `command not found` as a broken cc-fleet. The three Claude Code lane skills keep the original wording verbatim, reflowed to the repo's one-line paragraph style.

The two codex-plugin copies are adapted rather than copied: the codex lane's shell tool is not named Bash, and the note's "healthy `doctor` but leaves failing" tell collided with the Approval & sandbox section a few lines below, which documents the same-machine codex sandbox whose failure mode is blocked network egress. The adapted copy describes only the split-host case in neutral terms, softens the symptom claim so a local PATH mistake is not misread as split-host, and cross-references Approval & sandbox for the same-machine case.

`make skill-sync`, `skill-drift-check`, `codex-plugin-drift-check`, and `claude plugin validate --strict` are green. Merge via rebase (not squash) so the contributor's authorship stays on the first commit; #99 is closed manually after this lands since a cherry-pick does not auto-close it.
