### PR TITLE
feat(tui): type-to-filter the add-provider picker

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -118,9 +119,11 @@ type Model struct {
 	// configured/auto/disabled wording and whether `s` sets fresh vs switches.
 	defaultProvider string
 
-	// Add-wizard: the single grouped picker (cursor over the flat selectable rows)
-	// and the protocol the chosen row implies (carried into submitAdd).
+	// Add-wizard: the single grouped picker (cursor over the flat selectable rows
+	// that survive tmplFilter, the live type-to-narrow query) and the protocol the
+	// chosen row implies (carried into submitAdd).
 	tmplCursor  int
+	tmplFilter  string
 	addProtocol string
 
 	// screenCodexAuth: an optional source choice (reuse a detected subscription, or
@@ -2075,7 +2078,7 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter", "right":
 		if m.providerCursor == addRow {
 			m.screen = screenPickTemplate
-			m.tmplCursor = 0
+			m.tmplCursor, m.tmplFilter = 0, ""
 			return m, nil
 		}
 		v := m.providers[m.providerCursor]
@@ -3494,6 +3497,12 @@ type addGroup struct {
 	items  []addItem
 }
 
+// The two manual-entry rows, shared by the grouping and the no-match fallback.
+var (
+	customAnthropicItem = addItem{"Custom (fill everything manually)", addCatAnthropic, -1, -1}
+	customOpenAIItem    = addItem{"Custom OpenAI-compatible (fill everything manually)", addCatOpenAI, -1, -1}
+)
+
 // addGroups builds the grouped add picker: every provider class with its seeds
 // under one header, so a provider is chosen in a single screen.
 func addGroups() []addGroup {
@@ -3501,13 +3510,13 @@ func addGroups() []addGroup {
 	for i := range Templates {
 		a.items = append(a.items, addItem{Templates[i].Label, addCatAnthropic, i, -1})
 	}
-	a.items = append(a.items, addItem{"Custom (fill everything manually)", addCatAnthropic, -1, -1})
+	a.items = append(a.items, customAnthropicItem)
 
 	o := addGroup{header: "OpenAI-protocol API  (OpenAI / Groq / Together / vLLM …)"}
 	for i := range OAITemplates {
 		o.items = append(o.items, addItem{OAITemplates[i].Label, addCatOpenAI, -1, i})
 	}
-	o.items = append(o.items, addItem{"Custom OpenAI-compatible (fill everything manually)", addCatOpenAI, -1, -1})
+	o.items = append(o.items, customOpenAIItem)
 
 	c := addGroup{header: "CLI auth  (reuse a ChatGPT subscription via codex)"}
 	c.items = append(c.items, addItem{"Codex", addCatCLI, -1, -1})
@@ -3515,27 +3524,98 @@ func addGroups() []addGroup {
 	return []addGroup{a, o, c}
 }
 
-// addItems flattens the groups to the selectable rows the cursor walks.
-func addItems() []addItem {
+// groupKey is the matchable part of a group header — its class name, without the
+// parenthetical examples. Those name real providers ("… (DeepSeek / GLM / Kimi …)"),
+// so matching them would make one provider's name pull in its whole class.
+func groupKey(header string) string {
+	if i := strings.Index(header, "  ("); i >= 0 {
+		return header[:i]
+	}
+	return header
+}
+
+// addItemHaystack is the text a filter query is matched against for one row: its
+// label, the provider id and endpoint of the seed it carries, and its class — so
+// "zai", "moonshot" and "openai" all find what the user means.
+func addItemHaystack(it addItem, header string) string {
+	class := " " + groupKey(header)
+	switch {
+	case it.tIdx >= 0:
+		t := Templates[it.tIdx]
+		return it.label + " " + t.Name + " " + t.BaseURL + class
+	case it.oIdx >= 0:
+		t := OAITemplates[it.oIdx]
+		return it.label + " " + t.Name + " " + t.UpstreamURL + class
+	}
+	return it.label + class
+}
+
+// filteredAddGroups narrows the grouping to the rows matching q (case-insensitive
+// substring), dropping groups left with nothing, and reports how many rows matched.
+// Zero matches means the catalog has no such preset, so the result is the two manual
+// rows — an unlisted provider is exactly what they are for. They come headerless
+// because the picker explains the fallback on its filter line, which no amount of
+// windowing can scroll away.
+func filteredAddGroups(q string) ([]addGroup, int) {
+	all := addGroups()
+	if q == "" {
+		n := 0
+		for _, g := range all {
+			n += len(g.items)
+		}
+		return all, n
+	}
+	needle := strings.ToLower(q)
+	var out []addGroup
+	matched := 0
+	for _, g := range all {
+		kept := addGroup{header: g.header}
+		for _, it := range g.items {
+			if strings.Contains(strings.ToLower(addItemHaystack(it, g.header)), needle) {
+				kept.items = append(kept.items, it)
+			}
+		}
+		if len(kept.items) > 0 {
+			out = append(out, kept)
+			matched += len(kept.items)
+		}
+	}
+	if matched == 0 {
+		return []addGroup{{items: []addItem{customAnthropicItem, customOpenAIItem}}}, 0
+	}
+	return out, matched
+}
+
+// addItems flattens the filtered grouping to the selectable rows the cursor walks.
+func addItems(q string) []addItem {
+	groups, _ := filteredAddGroups(q)
 	var xs []addItem
-	for _, g := range addGroups() {
+	for _, g := range groups {
 		xs = append(xs, g.items...)
 	}
 	return xs
 }
 
-// updatePickTemplate drives the single grouped add picker: one cursor over every
-// provider across all three classes; enter/→ opens the chosen class's add form.
+// updatePickTemplate drives the single grouped add picker: one cursor over the rows
+// surviving the filter across all three classes; enter/→ opens the chosen class's add
+// form. Printable input narrows the list (type-to-filter), so vim j/k no longer
+// navigate — letters are filter input and the arrow keys move the cursor. Esc clears
+// a live filter first and only leaves once it is empty; picking a row keeps the query,
+// which the next entry into the picker resets.
 func (m Model) updatePickTemplate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	items := addItems()
+	items := addItems(m.tmplFilter)
 	switch msg.String() {
-	case "esc", "q", "left":
+	case "esc", "left":
+		if m.tmplFilter != "" {
+			m.tmplCursor, m.tmplFilter = 0, ""
+			return m, nil
+		}
 		return m.toList()
-	case "up", "k":
+	case "up":
 		if m.tmplCursor > 0 {
 			m.tmplCursor--
 		}
-	case "down", "j":
+	case "down":
 		if m.tmplCursor < len(items)-1 {
 			m.tmplCursor++
 		}
@@ -3543,8 +3623,32 @@ func (m Model) updatePickTemplate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.tmplCursor >= 0 && m.tmplCursor < len(items) {
 			return m.chooseAddItem(items[m.tmplCursor])
 		}
+	case "backspace", "ctrl+h": // some terminals report Backspace as Ctrl-H
+		if m.tmplFilter != "" {
+			r := []rune(m.tmplFilter)
+			m.tmplCursor, m.tmplFilter = 0, string(r[:len(r)-1])
+		}
+	case " ": // arrives as KeySpace, and labels like "Kimi Code" carry one
+		m.tmplCursor, m.tmplFilter = 0, m.tmplFilter+" "
+	default:
+		if s := printableRunes(msg.Runes); msg.Type == tea.KeyRunes && s != "" {
+			m.tmplCursor, m.tmplFilter = 0, m.tmplFilter+s
+		}
 	}
 	return m, nil
+}
+
+// printableRunes drops everything that cannot sit on one line of the box: a bracketed
+// paste arrives as one key message and may carry newlines and control bytes, which
+// would render straight through the pane border.
+func printableRunes(rs []rune) string {
+	var b strings.Builder
+	for _, r := range rs {
+		if unicode.IsPrint(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // uniqueName returns base, or the first free "<base>-N" when base is already a
@@ -3885,11 +3989,16 @@ func (m Model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // returns to the form so the user can type the id manually — the required
 // fallback when the provider list is unavailable. Printable input narrows the
 // list (type-to-filter), so vim j/k no longer navigate — letters are filter
-// input and the arrow keys move the cursor.
+// input and the arrow keys move the cursor. Esc clears a live filter first, and
+// only the second press leaves, matching the add picker.
 func (m Model) updateModelPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	filtered := m.filteredModels()
 	switch msg.String() {
 	case "esc", "left":
+		if m.modelFilter != "" {
+			m.modelCursor, m.modelFilter = 0, ""
+			return m, nil
+		}
 		m.screen = screenForm
 		return m, textinput.Blink
 	case "enter":
@@ -3925,9 +4034,14 @@ func (m Model) updateModelPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.modelFilter = string(r[:len(r)-1])
 			m.modelCursor = 0
 		}
+	case " ": // arrives as KeySpace; same input handling as the add picker
+		if len(m.modelList) > 0 {
+			m.modelFilter += " "
+			m.modelCursor = 0
+		}
 	default:
-		if msg.Type == tea.KeyRunes && len(m.modelList) > 0 {
-			m.modelFilter += string(msg.Runes)
+		if s := printableRunes(msg.Runes); msg.Type == tea.KeyRunes && s != "" && len(m.modelList) > 0 {
+			m.modelFilter += s
 			m.modelCursor = 0
 		}
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -979,8 +979,20 @@ func TestModelPickerFilterResetsOnReopen(t *testing.T) {
 	if m.modelFilter == "" {
 		t.Fatal("filter should be set after typing")
 	}
-	m, _ = press(t, m, "esc")   // back to the form (focus stays on default_model)
-	m, _ = press(t, m, "enter") // reopen the picker
+	m, _ = press(t, m, "esc") // first esc only clears the filter — still on the picker
+	if m.modelFilter != "" || m.screen != screenModelPick {
+		t.Fatalf("first esc: modelFilter = %q, screen = %d, want cleared and screenModelPick", m.modelFilter, m.screen)
+	}
+	m, _ = press(t, m, "esc") // empty filter, so this one leaves (focus stays on default_model)
+	if m.screen != screenForm {
+		t.Fatalf("second esc: screen = %d, want screenForm", m.screen)
+	}
+	// Picking is the one exit that leaves a filter behind, so it is what a reopen must reset.
+	m, _ = press(t, m, "enter") // reopen
+	m, _ = step(t, m, modelsMsg{models: []models.Model{{ID: "deepseek-chat"}}})
+	m, _ = press(t, m, "c")
+	m, _ = press(t, m, "enter") // pick the match, back to the form
+	m, _ = press(t, m, "enter") // reopen
 	if m.modelFilter != "" {
 		t.Fatalf("reopened picker: modelFilter = %q, want reset", m.modelFilter)
 	}
@@ -3192,5 +3204,18 @@ func TestBoardEndedTeamKeySafe(t *testing.T) {
 		if strings.ContainsRune(out, '\x1b') {
 			t.Errorf("%s leaked a raw ESC byte from a record-sourced string:\n%q", name, out)
 		}
+	}
+}
+
+// A bracketed paste reaches the model filter as one key message; its newlines and
+// control bytes are dropped so no rendered line can span rows and break the box.
+func TestModelPickerFilterSanitizesPaste(t *testing.T) {
+	m := pickerWith(t, "glm-4.5", "glm-4.5-air")
+	m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("glm\n-4.5\x1b\x07")})
+	if m.modelFilter != "glm-4.5" {
+		t.Fatalf("modelFilter = %q, want the printable remainder", m.modelFilter)
+	}
+	if out := m.View(); !strings.Contains(out, "glm-4.5") {
+		t.Fatalf("sanitized filter should still narrow:\n%s", out)
 	}
 }

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -3,9 +3,11 @@ package tui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ethanhq/cc-fleet/internal/codexproxy"
@@ -665,5 +667,293 @@ func TestAddPicker_WindowsTallListOnCursor(t *testing.T) {
 	}
 	if !strings.Contains(joined, "Codex") || !strings.Contains(joined, "↑") {
 		t.Fatalf("bottom window should show Codex and a ↑ marker:\n%s", joined)
+	}
+}
+
+// Typing narrows the grouped picker to the matching rows, drops the groups that lose
+// everything, and keeps the seed preview aligned with the highlighted survivor.
+func TestAddPickerFilterNarrowsAndKeepsDetailAligned(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter") // + Add -> grouped picker
+	m.width, m.height = 100, 40
+	for _, r := range "moonshot" {
+		m, _ = press(t, m, string(r))
+	}
+	if got := addItems(m.tmplFilter); len(got) != 1 || got[0].label != "Moonshot Kimi" {
+		t.Fatalf("filter %q → %+v, want just Moonshot Kimi", m.tmplFilter, got)
+	}
+	if m.tmplCursor != 0 {
+		t.Fatalf("tmplCursor = %d, want 0 (reset on filter)", m.tmplCursor)
+	}
+	out := m.View()
+	if !strings.Contains(out, "Moonshot Kimi") || strings.Contains(out, "StepFun") {
+		t.Fatalf("filtered view should show only the match:\n%s", out)
+	}
+	if strings.Contains(out, "OpenAI-protocol API") {
+		t.Fatalf("a group with no surviving row should drop out:\n%s", out)
+	}
+	if !strings.Contains(out, "https://api.moonshot.cn/anthropic") {
+		t.Fatalf("the seed preview must track the highlighted row:\n%s", out)
+	}
+	if want := fmt.Sprintf("(1/%d)", len(addItems(""))); !strings.Contains(out, want) {
+		t.Fatalf("filter line should report %s:\n%s", want, out)
+	}
+	m, _ = press(t, m, "enter")
+	if m.screen != screenForm || m.form.value("name") != "kimi" {
+		t.Fatalf("enter should open the kimi add form; screen = %d, name = %q", m.screen, m.form.value("name"))
+	}
+}
+
+// A query matches more than the visible label: the provider id the row seeds, its
+// endpoint, and the protocol group it sits under.
+func TestAddPickerFilterMatchesIdEndpointAndGroup(t *testing.T) {
+	if got := addItems("zai"); len(got) != 1 || got[0].tIdx < 0 || Templates[got[0].tIdx].Name != "zai" {
+		t.Fatalf("id query zai → %+v, want the zai preset", got)
+	}
+	if got := addItems("bigmodel"); len(got) != 1 || got[0].label != "Zhipu GLM" {
+		t.Fatalf("endpoint query bigmodel → %+v, want Zhipu GLM", got)
+	}
+	got := addItems("openai") // group heading: the whole OpenAI-protocol class
+	if len(got) != len(OAITemplates)+1 {
+		t.Fatalf("group query openai → %d rows, want the whole OpenAI class", len(got))
+	}
+	for _, it := range got {
+		if it.class != addCatOpenAI {
+			t.Fatalf("group query openai returned a %v row: %+v", it.class, it)
+		}
+	}
+}
+
+// Nothing in the catalog matching is exactly what the manual rows are for, so they
+// stand in rather than an empty list — and they are live, not decoration.
+func TestAddPickerFilterNoMatchOffersCustom(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m.width, m.height = 100, 40
+	for _, r := range "mistral" {
+		m, _ = press(t, m, string(r))
+	}
+	items := addItems(m.tmplFilter)
+	if len(items) != 2 || items[0] != customAnthropicItem || items[1] != customOpenAIItem {
+		t.Fatalf("no-match filter → %+v, want the two Custom rows", items)
+	}
+	out := m.View()
+	if !strings.Contains(out, "no preset matches") {
+		t.Fatalf("no-match view should say so:\n%s", out)
+	}
+	if want := fmt.Sprintf("(0/%d)", len(addItems(""))); !strings.Contains(out, want) {
+		t.Fatalf("no-match count should be %s:\n%s", want, out)
+	}
+	m, _ = press(t, m, "enter")
+	if m.screen != screenForm || m.form.value("name") != "" || m.form.value("base_url") != "" {
+		t.Fatalf("enter on the fallback should open the blank custom form; screen = %d", m.screen)
+	}
+}
+
+// Backspace widens the filter and stops at the start.
+func TestAddPickerFilterBackspaceWidens(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	for _, r := range "kimi" {
+		m, _ = press(t, m, string(r))
+	}
+	if got := len(addItems(m.tmplFilter)); got != 2 { // Moonshot Kimi + Kimi Code
+		t.Fatalf("filter kimi → %d rows, want 2", got)
+	}
+	m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlH}) // terminals that report Backspace as Ctrl-H
+	for i := 0; i < 4; i++ {
+		m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	if m.tmplFilter != "" {
+		t.Fatalf("tmplFilter = %q, want empty after backspacing past the start", m.tmplFilter)
+	}
+	if got, want := len(addItems(m.tmplFilter)), len(addItems("")); got != want {
+		t.Fatalf("empty filter → %d rows, want the full %d", got, want)
+	}
+}
+
+// Esc clears a live filter before it cancels, so the picker is never left narrowed.
+func TestAddPickerEscClearsFilterThenCancels(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	for _, r := range "glm" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "esc")
+	if m.tmplFilter != "" || m.screen != screenPickTemplate {
+		t.Fatalf("first esc: filter = %q, screen = %d, want cleared and still on the picker", m.tmplFilter, m.screen)
+	}
+	m, _ = press(t, m, "esc")
+	if m.screen != screenList {
+		t.Fatalf("second esc: screen = %d, want screenList", m.screen)
+	}
+}
+
+// Printable j/k/q extend the filter rather than navigating, which is what makes the
+// presets starting with those letters reachable by typing.
+func TestAddPickerVimKeysTypeIntoFilter(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m, _ = press(t, m, "k")
+	if m.tmplFilter != "k" || m.tmplCursor != 0 {
+		t.Fatalf("k should type, not move: filter = %q, cursor = %d", m.tmplFilter, m.tmplCursor)
+	}
+	m, _ = press(t, m, "esc") // clear and start over
+	for _, r := range "qwen" {
+		m, _ = press(t, m, string(r))
+	}
+	if m.screen != screenPickTemplate {
+		t.Fatalf("q must not quit the picker; screen = %d", m.screen)
+	}
+	if got := addItems(m.tmplFilter); len(got) != 1 || got[0].label != "Qwen (Alibaba DashScope)" {
+		t.Fatalf("typing qwen → %+v, want the Qwen preset", got)
+	}
+}
+
+// The hub's read-only "+ Add provider…" preview always shows the whole catalog — the
+// filter belongs to the picker the user is standing in, and picking a row leaves one
+// behind.
+func TestAddPickerHubPreviewIgnoresFilter(t *testing.T) {
+	m := withProviders(t) // no providers: the cursor starts on the "+ Add" row
+	m, _ = press(t, m, "enter")
+	m.width, m.height = 100, 60
+	for _, r := range "moonshot" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "enter") // pick it: the add form keeps the filter behind
+	m, _ = press(t, m, "esc")   // back to the hub, which reloads
+	m, _ = step(t, m, providersMsg{})
+	if m.screen != screenList {
+		t.Fatalf("screen = %d, want screenList", m.screen)
+	}
+	if m.tmplFilter == "" {
+		t.Fatal("this guards a live filter — it should still be set after picking")
+	}
+	out := m.View()
+	if !strings.Contains(out, "StepFun") || !strings.Contains(out, "Codex") {
+		t.Fatalf("the hub preview must show the whole catalog:\n%s", out)
+	}
+}
+
+// The fallback's explanation rides on the filter block, which sits outside the row
+// window — so a pane too short to hold the rows still says why they are the only ones
+// left. Heights 12-16 are the band where the rows do get windowed.
+func TestAddPickerFilterNoMatchExplainsOnShortPanes(t *testing.T) {
+	for _, h := range []int{12, 14, 16, 24} {
+		m := NewModel()
+		m, _ = press(t, m, "enter")
+		m.width, m.height = 100, h
+		for _, r := range "mistral" {
+			m, _ = press(t, m, string(r))
+		}
+		out := m.View()
+		if !strings.Contains(out, "no preset matches") {
+			t.Fatalf("height %d dropped the fallback explanation:\n%s", h, out)
+		}
+		if !strings.Contains(out, "Custom (fill everything manually)") {
+			t.Fatalf("height %d dropped the fallback rows:\n%s", h, out)
+		}
+	}
+}
+
+// Enter acts on the highlighted row, so it must be on screen even when the pane is too
+// tight for the markers and the seed preview — including the fallback's second row,
+// where the window opens with an ↑ marker that would otherwise take the last line.
+func TestAddPickerTightPaneKeepsHighlightVisible(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m.width, m.height = 100, 12 // boardBodyHeight floors at 5; the 3-line no-match head leaves 2
+	for _, r := range "mistral" {
+		m, _ = press(t, m, string(r))
+	}
+	// Assert on the picker's own rows: the footer hint spells out "↑/↓", so a whole-view
+	// substring check would pass on that alone.
+	rows := strings.Join(m.addPickerLines(m.tmplCursor), "\n")
+	if !strings.Contains(rows, "Custom (fill everything manually)") || !strings.Contains(rows, "↓ 1 more") {
+		t.Fatalf("first row: want the highlight and a ↓ for the row it hides:\n%s", rows)
+	}
+	m, _ = press(t, m, "down") // to the OpenAI-compatible Custom row
+	items := addItems(m.tmplFilter)
+	if m.tmplCursor != 1 || items[1] != customOpenAIItem {
+		t.Fatalf("cursor = %d over %+v, want the second fallback row", m.tmplCursor, items)
+	}
+	rows = strings.Join(m.addPickerLines(m.tmplCursor), "\n")
+	if !strings.Contains(rows, "Custom OpenAI-compatible") {
+		t.Fatalf("the highlighted row must stay visible on a tight pane:\n%s", rows)
+	}
+	if !strings.Contains(rows, "↑ 1 more") {
+		t.Fatalf("second row: want a ↑ for the row it hides:\n%s", rows)
+	}
+}
+
+// The window math has two invariants the picker cannot break at any size: Enter acts on
+// the highlighted row, so that row is always rendered; and a row left off screen is
+// always announced by a ↑/↓ marker. Swept over every pane height and cursor position
+// because the head, the detail block and the markers all draw on one budget.
+func TestAddPickerWindowInvariantsHoldAtEverySize(t *testing.T) {
+	for _, q := range []string{"", "kimi", "mistral", "openai", "glm", "custom", "z"} {
+		items := addItems(q)
+		for h := 5; h <= 60; h++ {
+			for cur := range items {
+				m := NewModel()
+				m.screen, m.loading = screenPickTemplate, false
+				m.width, m.height = 100, h
+				m.tmplFilter, m.tmplCursor = q, cur
+				out := m.addPickerLines(cur)
+				joined := strings.Join(out, "\n")
+				if !strings.Contains(joined, "❯ "+items[cur].label) {
+					t.Fatalf("h=%d q=%q cur=%d: the highlighted %q is off screen:\n%s", h, q, cur, items[cur].label, joined)
+				}
+				shown := 0
+				for _, it := range items {
+					for _, l := range out {
+						if strings.HasSuffix(l, it.label) {
+							shown++
+							break
+						}
+					}
+				}
+				if shown < len(items) && !strings.Contains(joined, "↑ ") && !strings.Contains(joined, "↓ ") {
+					t.Fatalf("h=%d q=%q cur=%d: %d of %d rows shown with no marker:\n%s", h, q, cur, shown, len(items), joined)
+				}
+			}
+		}
+	}
+}
+
+// A label is typed the way it is displayed, spaces included; and a bracketed paste
+// arrives as one key message, so its newlines and control bytes are dropped rather
+// than rendered through the pane border.
+func TestAddPickerFilterAcceptsSpaceAndSanitizesPaste(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	for _, r := range "Kimi" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = step(t, m, tea.KeyMsg{Type: tea.KeySpace})
+	for _, r := range "Code" {
+		m, _ = press(t, m, string(r))
+	}
+	if m.tmplFilter != "Kimi Code" {
+		t.Fatalf("tmplFilter = %q, want the label as typed", m.tmplFilter)
+	}
+	if got := addItems(m.tmplFilter); len(got) != 1 || got[0].label != "Kimi Code" {
+		t.Fatalf("typing the displayed label → %+v, want Kimi Code", got)
+	}
+
+	m2 := NewModel()
+	m2, _ = press(t, m2, "enter")
+	m2.width, m2.height = 100, 40
+	m2, _ = step(t, m2, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ki\nmi\x1b[31m\x07")})
+	if m2.tmplFilter != "kimi[31m" { // the ESC and BEL go, the letters it introduced stay
+		t.Fatalf("tmplFilter = %q, want the printable remainder on one line", m2.tmplFilter)
+	}
+	if strings.ContainsAny(m2.tmplFilter, "\n\r\x1b") {
+		t.Fatalf("tmplFilter kept a control byte: %q", m2.tmplFilter)
+	}
+	for _, l := range m2.addPickerLines(m2.tmplCursor) {
+		if strings.Contains(l, "\n") {
+			t.Fatalf("a rendered line spans rows, which breaks the box: %q", l)
+		}
 	}
 }

--- a/internal/tui/provider_classes_test.go
+++ b/internal/tui/provider_classes_test.go
@@ -887,8 +887,9 @@ func TestAddPickerTightPaneKeepsHighlightVisible(t *testing.T) {
 }
 
 // The window math has two invariants the picker cannot break at any size: Enter acts on
-// the highlighted row, so that row is always rendered; and a row left off screen is
-// always announced by a ↑/↓ marker. Swept over every pane height and cursor position
+// the highlighted row, so that row is always rendered; and each ↑/↓ marker tells the
+// exact truth — its count equals the providers hidden in that direction, and a direction
+// hiding none renders no marker. Swept over every pane height and cursor position
 // because the head, the detail block and the markers all draw on one budget.
 func TestAddPickerWindowInvariantsHoldAtEverySize(t *testing.T) {
 	for _, q := range []string{"", "kimi", "mistral", "openai", "glm", "custom", "z"} {
@@ -904,17 +905,40 @@ func TestAddPickerWindowInvariantsHoldAtEverySize(t *testing.T) {
 				if !strings.Contains(joined, "❯ "+items[cur].label) {
 					t.Fatalf("h=%d q=%q cur=%d: the highlighted %q is off screen:\n%s", h, q, cur, items[cur].label, joined)
 				}
-				shown := 0
-				for _, it := range items {
+				// The visible items are a contiguous idx window; everything before it
+				// is hidden above, everything after it hidden below. Item rows are
+				// matched exactly ("    <label>" / "  ❯ <label>") so a detail or note
+				// line echoing a label cannot count as visible.
+				first, last := -1, -1
+				for i, it := range items {
 					for _, l := range out {
-						if strings.HasSuffix(l, it.label) {
-							shown++
+						if l == "    "+it.label || l == "  ❯ "+it.label {
+							if first < 0 {
+								first = i
+							}
+							last = i
 							break
 						}
 					}
 				}
-				if shown < len(items) && !strings.Contains(joined, "↑ ") && !strings.Contains(joined, "↓ ") {
-					t.Fatalf("h=%d q=%q cur=%d: %d of %d rows shown with no marker:\n%s", h, q, cur, shown, len(items), joined)
+				wantUp, wantDown := first, len(items)-1-last
+				if wantUp > 0 && !strings.Contains(joined, fmt.Sprintf("↑ %d more", wantUp)) {
+					t.Fatalf("h=%d q=%q cur=%d: %d items hidden above, marker disagrees:\n%s", h, q, cur, wantUp, joined)
+				}
+				if wantUp == 0 && strings.Contains(joined, "↑ ") {
+					t.Fatalf("h=%d q=%q cur=%d: nothing hidden above yet ↑ shows:\n%s", h, q, cur, joined)
+				}
+				if wantDown > 0 && !strings.Contains(joined, fmt.Sprintf("↓ %d more", wantDown)) {
+					t.Fatalf("h=%d q=%q cur=%d: %d items hidden below, marker disagrees:\n%s", h, q, cur, wantDown, joined)
+				}
+				if wantDown == 0 && strings.Contains(joined, "↓ ") {
+					t.Fatalf("h=%d q=%q cur=%d: nothing hidden below yet ↓ shows:\n%s", h, q, cur, joined)
+				}
+				// With providers still hidden there is always another row to show,
+				// so the pane must be full — a suppressed marker's reserved row is
+				// given back to the window, never left blank.
+				if wantUp+wantDown > 0 && len(out) != m.boardBodyHeight() {
+					t.Fatalf("h=%d q=%q cur=%d: rows hidden yet the pane is not filled (%d/%d):\n%s", h, q, cur, len(out), m.boardBodyHeight(), joined)
 				}
 			}
 		}
@@ -955,5 +979,26 @@ func TestAddPickerFilterAcceptsSpaceAndSanitizesPaste(t *testing.T) {
 		if strings.Contains(l, "\n") {
 			t.Fatalf("a rendered line spans rows, which breaks the box: %q", l)
 		}
+	}
+}
+
+// A suppressed marker's reserved row joins the window: with nothing hidden above,
+// the pane shows one more provider instead of a blank slot, and the ↓ count shrinks
+// to match.
+func TestAddPickerUnusedMarkerRowJoinsWindow(t *testing.T) {
+	m := NewModel()
+	m, _ = press(t, m, "enter")
+	m.width, m.height = 100, 19
+	for _, r := range "openai" {
+		m, _ = press(t, m, string(r))
+	}
+	m, _ = press(t, m, "down")
+	rows := m.addPickerLines(m.tmplCursor)
+	joined := strings.Join(rows, "\n")
+	if len(rows) != m.boardBodyHeight() {
+		t.Fatalf("pane not filled: %d rows, want %d:\n%s", len(rows), m.boardBodyHeight(), joined)
+	}
+	if strings.Contains(joined, "\u2191 ") || !strings.Contains(joined, "\u2193 1 more") {
+		t.Fatalf("want no \u2191 and a truthful \u2193 1 more:\n%s", joined)
 	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -3015,6 +3015,7 @@ func (m Model) addPickerLines(cursor int) []string {
 		head = m.addFilterLines(matched)
 	}
 	var lines []string
+	var itemLines []int // each selectable row's line number, in flat cursor order
 	cursorLine := 0
 	idx := 0
 	var cursored addItem
@@ -3034,6 +3035,7 @@ func (m Model) addPickerLines(cursor int) []string {
 				cursorLine = len(lines)
 				cursored = it
 			}
+			itemLines = append(itemLines, len(lines))
 			lines = append(lines, "  "+marker+label)
 			idx++
 		}
@@ -3048,21 +3050,57 @@ func (m Model) addPickerLines(cursor int) []string {
 		return append(head, lines...)
 	}
 	// The list overflows the pane: window the rows on the cursored line so the
-	// highlight stays visible, keep its detail pinned below, and flag the hidden
-	// rows with ↑/↓ markers (two rows are reserved for them).
+	// highlight stays visible, and keep its detail pinned below. The ↑/↓ markers
+	// count the PROVIDERS out of view, not the trimmed lines — a hidden group
+	// heading or spacer is not a "1 more" — and a direction hiding nothing
+	// selectable gets no marker. Rows are reserved only for the markers actually
+	// drawn: start from two, then hand a suppressed marker's row back to the
+	// window. Widening only ever reveals rows, so the marker count shrinks
+	// monotonically and the loop settles within two passes.
 	detail := lines[detailStart:]
+	countHidden := func(start, end int) (above, below int) {
+		for _, ln := range itemLines {
+			switch {
+			case ln < start:
+				above++
+			case ln >= end:
+				below++
+			}
+		}
+		return
+	}
 	avail := bodyH - len(detail) - 2
 	if avail < 1 {
 		avail = 1
 	}
 	start, end := windowBounds(cursorLine, detailStart, avail)
+	hiddenAbove, hiddenBelow := countHidden(start, end)
+	for i := 0; i < 2; i++ {
+		markers := 0
+		if hiddenAbove > 0 {
+			markers++
+		}
+		if hiddenBelow > 0 {
+			markers++
+		}
+		next := bodyH - len(detail) - markers
+		if next < 1 {
+			next = 1
+		}
+		if next == avail {
+			break
+		}
+		avail = next
+		start, end = windowBounds(cursorLine, detailStart, avail)
+		hiddenAbove, hiddenBelow = countHidden(start, end)
+	}
 	var out []string
-	if start > 0 {
-		out = append(out, faintStyle.Render(fmt.Sprintf("  ↑ %d more", start)))
+	if hiddenAbove > 0 {
+		out = append(out, faintStyle.Render(fmt.Sprintf("  ↑ %d more", hiddenAbove)))
 	}
 	out = append(out, lines[start:end]...)
-	if end < detailStart {
-		out = append(out, faintStyle.Render(fmt.Sprintf("  ↓ %d more", detailStart-end)))
+	if hiddenBelow > 0 {
+		out = append(out, faintStyle.Render(fmt.Sprintf("  ↓ %d more", hiddenBelow)))
 	}
 	out = append(out, detail...)
 	if len(out) > bodyH {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2990,26 +2990,41 @@ func shortJobID(id string) string {
 // with its seeds under one header (indented), one cursor over the flat selectable
 // rows, and a seed preview for the highlighted row.
 func (m Model) viewPickTemplate() string {
+	hint := "type to filter · ↑/↓ move · enter/→ choose · esc cancel"
+	if m.tmplFilter != "" {
+		hint = "↑/↓ move · enter/→ choose · esc clear filter"
+	}
 	return m.providerFlowView("Add provider", "", "+", "pick a provider",
-		"↑/↓ move · enter/→ choose · esc cancel", func(rightW int) []string {
+		hint, func(rightW int) []string {
 			return m.addPickerLines(m.tmplCursor)
 		})
 }
 
-// addPickerLines renders the grouped provider list. cursor >= 0 highlights that
-// flat item index and appends its seed preview; cursor < 0 is a read-only preview
-// (used as the home list's "+ Add provider…" hover detail). When the highlighted
-// list is taller than the pane it windows on the cursored row — keeping the
-// highlighted row visible — the way viewModelPick does.
+// addPickerLines renders the grouped provider list. cursor >= 0 is the live picker:
+// it narrows to tmplFilter under a filter line, highlights that flat item index among
+// the survivors, and appends its seed preview. cursor < 0 is the home list's
+// "+ Add provider…" hover detail — read-only and always the whole catalog, since the
+// filter belongs to the picker the user is standing in. When the highlighted list is
+// taller than the pane it windows on the cursored row — keeping the highlighted row
+// visible — the way viewModelPick does.
 func (m Model) addPickerLines(cursor int) []string {
+	groups, head := addGroups(), []string(nil)
+	if cursor >= 0 {
+		var matched int
+		groups, matched = filteredAddGroups(m.tmplFilter)
+		head = m.addFilterLines(matched)
+	}
 	var lines []string
 	cursorLine := 0
 	idx := 0
-	for gi, g := range addGroups() {
+	var cursored addItem
+	for gi, g := range groups {
 		if gi > 0 {
 			lines = append(lines, "")
 		}
-		lines = append(lines, faintStyle.Render(g.header))
+		if g.header != "" { // the zero-match fallback carries none
+			lines = append(lines, faintStyle.Render(g.header))
+		}
 		for _, it := range g.items {
 			marker := "  "
 			label := contentStyle.Render(it.label)
@@ -3017,25 +3032,24 @@ func (m Model) addPickerLines(cursor int) []string {
 				marker = cursorStyle.Render("❯ ")
 				label = selectedStyle.Render(it.label)
 				cursorLine = len(lines)
+				cursored = it
 			}
 			lines = append(lines, "  "+marker+label)
 			idx++
 		}
 	}
 	detailStart := len(lines)
-	if cursor >= 0 {
+	if cursor >= 0 && cursor < idx {
 		lines = append(lines, "")
-		lines = append(lines, m.addItemDetail()...)
+		lines = append(lines, m.addItemDetail(cursored)...)
 	}
-	bodyH := m.boardBodyHeight()
+	bodyH := m.boardBodyHeight() - len(head)
 	if cursor < 0 || len(lines) <= bodyH {
-		return lines
+		return append(head, lines...)
 	}
 	// The list overflows the pane: window the rows on the cursored line so the
 	// highlight stays visible, keep its detail pinned below, and flag the hidden
-	// rows with ↑/↓ markers (two rows are reserved for them). On a tiny pane the
-	// detail alone can outrun the budget, so the result is clamped to bodyH — the
-	// cursored row sits near the top of the window and survives the clamp.
+	// rows with ↑/↓ markers (two rows are reserved for them).
 	detail := lines[detailStart:]
 	avail := bodyH - len(detail) - 2
 	if avail < 1 {
@@ -3054,16 +3068,31 @@ func (m Model) addPickerLines(cursor int) []string {
 	if len(out) > bodyH {
 		out = out[:bodyH]
 	}
-	return out
+	return append(head, out...)
+}
+
+// addFilterLines is the picker's filter block: the affordance while nothing is typed,
+// then the query and how much of the catalog survives it. It sits outside the row
+// window, so the line explaining a zero-match fallback is always on screen — however
+// short the pane, and however far the rows below it are windowed.
+func (m Model) addFilterLines(matched int) []string {
+	total := len(addItems(""))
+	if m.tmplFilter == "" {
+		return []string{contentStyle.Render(fmt.Sprintf("Filter: type to narrow %d providers", total)), ""}
+	}
+	head := []string{contentStyle.Render("Filter: "+m.tmplFilter) +
+		faintStyle.Render(fmt.Sprintf("  (%d/%d)", matched, total)), ""}
+	if matched == 0 {
+		// No trailing spacer: the line reads as the heading for the two rows right
+		// below it, and on the shortest panes that row is the whole row budget.
+		head = append(head, faintStyle.Render("no preset matches — pick a Custom entry to fill it in by hand"))
+	}
+	return head
 }
 
 // addItemDetail is the seed/source preview for the highlighted picker row.
-func (m Model) addItemDetail() []string {
-	items := addItems()
-	if m.tmplCursor < 0 || m.tmplCursor >= len(items) {
-		return nil
-	}
-	switch it := items[m.tmplCursor]; it.class {
+func (m Model) addItemDetail(it addItem) []string {
+	switch it.class {
 	case addCatCLI:
 		if st := codexproxy.StatusReport(codexproxy.SecretRef); st.Active != "none" {
 			return []string{faintStyle.Render("  reuses the codex login (" + st.Active + ", account " + st.Account + ") — no key needed")}
@@ -3239,8 +3268,12 @@ func (m Model) viewModelPick() string {
 	if m.formMode == modeEdit {
 		active = m.editName
 	}
+	hint := "type to filter · ↑/↓ move · enter pick · esc manual entry"
+	if m.modelFilter != "" {
+		hint = "↑/↓ move · enter pick · esc clear filter"
+	}
 	return m.providerFlowView("Select default model", "", active, "models",
-		"type to filter · ↑/↓ move · enter pick · esc manual entry", func(rightW int) []string {
+		hint, func(rightW int) []string {
 			switch {
 			case m.loading:
 				return []string{faintStyle.Render("fetching models…")}
@@ -3261,7 +3294,7 @@ func (m Model) viewModelPick() string {
 					faintStyle.Render(fmt.Sprintf("  (%d/%d)", len(filtered), total)), "")
 			}
 			if len(filtered) == 0 {
-				return append(lines, faintStyle.Render("no model matches — backspace to widen, esc to type manually"))
+				return append(lines, faintStyle.Render("no model matches — backspace or esc to widen"))
 			}
 			// The window fills the pane: the filter line + spacer and the two
 			// ↑/↓ markers cost 4 rows; an owner sub-line doubles a model's cost.


### PR DESCRIPTION
The add-provider picker now filters as you type, the way the model picker and the session browser already do. Printable keys narrow the grouped list live over a case-insensitive substring of the display label, the provider id, the endpoint host, and the protocol class, so `zai`, `moonshot`, and `openai` all find what they mean; protocol groups that lose every entry drop out, and a query matching no preset falls back to the two Custom entries under an explanatory line, since an unlisted provider is exactly what they are for. Space is accepted (labels like `Kimi Code` carry one) and bracketed pastes are stripped of newlines and control bytes before they reach the filter, so a stray paste cannot tear the pane border. Esc is now two-stage on both this picker and the model picker: the first press clears a live filter, and only an empty-filter press leaves the screen. The vi aliases j/k/q give way to filter input — arrow keys and Esc navigate, matching the model picker's long-standing bindings.

The window overflow markers also tell the truth now: ↑/↓ count the providers out of view rather than trimmed render lines (a hidden group heading is no longer "1 more"), a direction hiding nothing selectable shows no marker, and a suppressed marker's reserved row is handed back to the window so the pane stays full. An exhaustive sweep pins both invariants — the highlighted row is always on screen and every marker count is exact — across every pane height and cursor position.

Closes #104.
