### PR TITLE
chore(release): set version to v0.3.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-fleet",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API (e.g. DeepSeek, GLM, Kimi, Qwen, MiniMax) — even your Codex subscription — as real Claude Code workflows, agent-team teammates, or one-shot subagents, driven exactly like native ones. Your main session's own auth is untouched (OAuth subscription or API key, either works); API-key providers bill the provider key via apiKeyHelper, while a Codex subscription bills through a local OAuth daemon — each worker receives its credential on demand, never through its env or argv. Requires the `cc-fleet` binary on PATH, installed separately.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "Ethan Guo",
     "email": "ethanguo.dev@gmail.com"

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-fleet",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Fan out provider LLM subagents and multi-phase JS workflows from Codex via the cc-fleet CLI — DeepSeek / GLM / Kimi / Qwen / MiniMax, or your Codex/Claude subscription. Each worker receives its credential on demand, never through its env or argv. Requires the cc-fleet and claude binaries on PATH (installed separately).",
   "author": {
     "name": "Ethan Guo",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethanhq/cc-fleet",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Run any model with an Anthropic- or OpenAI-compatible API — even your Codex subscription — as Claude Code workflows, agent-team teammates, or one-shot subagents. Your main session's own auth (OAuth or API key) is untouched.",
   "bin": {
     "cc-fleet": "bin/launcher.js",


### PR DESCRIPTION
Version manifests for the v0.3.3 release: the type-to-filter add-provider picker and truthful overflow markers land in this patch. Three manifests move together per the release guard.